### PR TITLE
Add support for ARM Windows

### DIFF
--- a/src/getRealTime.c
+++ b/src/getRealTime.c
@@ -11,7 +11,7 @@
 
 #if defined(_WIN32)
 
-	#include <Windows.h>
+	#include <windows.h>
 
 #elif defined(__unix__) || defined(__unix) || defined(unix) || (defined(__APPLE__) && defined(__MACH__))
 

--- a/src/platform.h
+++ b/src/platform.h
@@ -896,7 +896,7 @@ states that the compiler defines __64BIT__ if compiling in 64-bit mode.
 
 	   The symbol __ARM_EABI__ is not defined if compiles under the old EABI.
 	*/
-	#if !(defined(__ARMEL__) && defined(__ARM_EABI__))
+	#if !defined (__MINGW32__) && !(defined(__ARMEL__) && defined(__ARM_EABI__))
 		#error __ARM_ARCH predefine seqeunce expects both __ARMEL__ and __ARM_EABI__ to be defined! Please check your platforms predefine list using 'gcc -dM -E - < /dev/null' and forward the results to the program author/maintainer(s) listed on the README page.
 	#endif
 

--- a/src/util.c
+++ b/src/util.c
@@ -1982,14 +1982,15 @@ uint32 get_system_ram(void) {
 
 // Apr 2018: Due to portability issues, replace the system-headers-based version of the "has advanced SIMD?"
 // check with one based on what amounts to "is the result of 'grep asimd /proc/cpuinfo' empty or not?".
-// Dec 2020: Apple M1 needs special handling, use the Clang/GCC-shared __ARM_NEON__ predefine to detect SIMD support:
+// Dec 2020: Apple M1 needs special handling, use the Clang/GCC-shared __ARM_NEON__ predefine to detect SIMD support.
+// Nov 2024: Ditto for MinGW Windows, but only on 64-bit, otherwise we get false positives on ARMv7.
 #ifdef CPU_IS_ARM_EABI
 
-  #ifdef OS_TYPE_MACOSX
+  #if defined(OS_TYPE_MACOSX) || defined(__MINGW32__)
 
 	int has_asimd(void)
 	{
-	#ifdef __ARM_NEON
+	#if defined(__ARM_NEON) && OS_BITS == 64
 		return (int)__ARM_NEON;
 	#else
 		return 0;


### PR DESCRIPTION
Some simple fixes to allow Mlucas to be compiled with MinGW for armv7 and aarch64.

I've run `-s m` for both architectures with LTO enabled, both work fine.

My 2012 Surface RT may take a few years to run [a PRP-DC](https://www.mersenne.org/M85809707), but modern ARM Windows laptops are genuinely useful.

You may remember my earlier foibles from April, which resulted in the "Cygwin" branch, which I can only describe as an artifact of the follies of my youth. This is the same thing, but done properly.