### PR TITLE
Declare AVX-512 opmask/high-vector clobbers; harden carry-loop index arithmetic

### DIFF
--- a/src/carry_gcc64.h
+++ b/src/carry_gcc64.h
@@ -10637,7 +10637,7 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		,	[__p4]   "m" (Xp4)\
 		/* Mar 2018: Needed to support PRP testing: */\
 		,	[__prp_mult]   "m" (Xprp_mult)\
-		: "cc","memory","k1","k2","k3","k4","k5","xmm18","rax","rbx","rcx","rdx","rdi","rsi","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","k3","k4","k5","rax","rbx","rcx","rdx","rdi","rsi","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25"	/* Clobbered registers */\
 	);\
 	}
 
@@ -12318,7 +12318,7 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		,	[__p4]   "m" (Xp4)\
 		/* Mar 2018: Needed to support PRP testing: */\
 		,	[__prp_mult]   "m" (Xprp_mult)\
-		: "cc","memory","k1","k2","k3","k4","xmm18","xmm19","rax","rbx","rcx","rdx","rdi","rsi","r14","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","k3","k4","rax","rbx","rcx","rdx","rdi","rsi","r14","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 

--- a/src/carry_gcc64.h
+++ b/src/carry_gcc64.h
@@ -5126,7 +5126,7 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		, [__sinwtm1]	"m" (Xsinwtm1)		\
 		, [__sse_bw]	"m" (Xsse_bw)		\
 		, [__sse_nm1]	"m" (Xsse_nm1)		\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm17","xmm18","xmm20","xmm21","xmm24","xmm25","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","k3","k4","rax","rbx","rcx","rdx","rdi","rsi","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm17","xmm18","xmm20","xmm21","xmm24","xmm25","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 
@@ -5567,7 +5567,7 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		, [__sinwtm1]	"m" (Xsinwtm1)		\
 		, [__sse_bw]	"m" (Xsse_bw)		\
 		, [__sse_nm1]	"m" (Xsse_nm1)		\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 
@@ -6084,7 +6084,7 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		, [__sinwtm1]	"m" (Xsinwtm1)		\
 		, [__sse_bw]	"m" (Xsse_bw)		\
 		, [__sse_n]		"m" (Xsse_n)		\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm17","xmm18","xmm20","xmm21","xmm24","xmm25","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","k3","k4","rax","rbx","rcx","rdx","rdi","rsi","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm17","xmm18","xmm20","xmm21","xmm24","xmm25","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 
@@ -6558,7 +6558,7 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		, [__sinwtm1]	"m" (Xsinwtm1)		\
 		, [__sse_bw]	"m" (Xsse_bw)		\
 		, [__sse_n]		"m" (Xsse_n)		\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 
@@ -7025,7 +7025,7 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		, [__sinwtm1]	"m" (Xsinwtm1)		\
 		, [__sse_bw]	"m" (Xsse_bw)		\
 		, [__sse_nm1]	"m" (Xsse_nm1)		\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm17","xmm18","xmm20","xmm21","xmm24","xmm25","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","k3","k4","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm17","xmm18","xmm20","xmm21","xmm24","xmm25","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 
@@ -7461,7 +7461,7 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		, [__sinwtm1]	"m" (Xsinwtm1)		\
 		, [__sse_bw]	"m" (Xsse_bw)		\
 		, [__sse_nm1]	"m" (Xsse_nm1)		\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 
@@ -7941,7 +7941,7 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		, [__sinwtm1]	"m" (Xsinwtm1)		\
 		, [__sse_bw]	"m" (Xsse_bw)		\
 		, [__sse_n]		"m" (Xsse_n)		\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm17","xmm18","xmm20","xmm21","xmm24","xmm25","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","k3","k4","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm17","xmm18","xmm20","xmm21","xmm24","xmm25","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 
@@ -8405,7 +8405,7 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		, [__sinwtm1]	"m" (Xsinwtm1)		\
 		, [__sse_bw]	"m" (Xsse_bw)		\
 		, [__sse_n]		"m" (Xsse_n)		\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 
@@ -10637,7 +10637,7 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		,	[__p4]   "m" (Xp4)\
 		/* Mar 2018: Needed to support PRP testing: */\
 		,	[__prp_mult]   "m" (Xprp_mult)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","k3","k4","k5","xmm18","rax","rbx","rcx","rdx","rdi","rsi","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25"	/* Clobbered registers */\
 	);\
 	}
 
@@ -11379,7 +11379,7 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		,	[__p4]   "m" (Xp4)\
 		/* Mar 2018: Needed to support PRP testing: */\
 		,	[__prp_mult]   "m" (Xprp_mult)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","k3","k4","k5","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23"	/* Clobbered registers */\
 	);\
 	}
 
@@ -12318,7 +12318,7 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		,	[__p4]   "m" (Xp4)\
 		/* Mar 2018: Needed to support PRP testing: */\
 		,	[__prp_mult]   "m" (Xprp_mult)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","r14","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","k3","k4","xmm18","xmm19","rax","rbx","rcx","rdx","rdi","rsi","r14","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 
@@ -13062,7 +13062,7 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		,	[__p4]   "m" (Xp4)\
 		/* Mar 2018: Needed to support PRP testing: */\
 		,	[__prp_mult]   "m" (Xprp_mult)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","r14","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","rax","rbx","rcx","rdx","rdi","rsi","r14","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 
@@ -17299,7 +17299,7 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		,	[__p4]   "m" (Xp4)\
 		/* Mar 2018: Needed to support PRP testing: */\
 		,	[__prp_mult]   "m" (Xprp_mult)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","k3","k4","k5","rax","rbx","rcx","rdx","rdi","rsi","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27"	/* Clobbered registers */\
 	);\
 	}
 
@@ -18076,7 +18076,7 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		,	[__p4]   "m" (Xp4)\
 		/* Mar 2018: Needed to support PRP testing: */\
 		,	[__prp_mult]   "m" (Xprp_mult)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm20"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","k3","k4","k5","k6","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm20"	/* Clobbered registers */\
 	);\
 	}
 
@@ -19091,7 +19091,7 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		,	[__p4]   "m" (Xp4)\
 		/* Mar 2018: Needed to support PRP testing: */\
 		,	[__prp_mult]   "m" (Xprp_mult)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","r14","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","k3","k4","rax","rbx","rcx","rdx","rdi","rsi","r14","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 
@@ -19899,7 +19899,7 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		,	[__p4]   "m" (Xp4)\
 		/* Mar 2018: Needed to support PRP testing: */\
 		,	[__prp_mult]   "m" (Xprp_mult)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","r14","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","rax","rbx","rcx","rdx","rdi","rsi","r14","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 
@@ -20247,7 +20247,7 @@ If so, why does the weights-multiplier stuff work w/o extra shuffling here?
 		,	[__p3]   "m" (Xp3)\
 		/* Mar 2018: Needed to support PRP testing: */\
 		,	[__prp_mult]   "m" (Xprp_mult)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","r14","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm15","xmm20"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","rax","rbx","rcx","rdx","rdi","rsi","r14","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm15","xmm20"	/* Clobbered registers */\
 	);\
 	}
 
@@ -20668,7 +20668,7 @@ If so, why does the weights-multiplier stuff work w/o extra shuffling here?
 		,	[__p3]   "m" (Xp3)\
 		/* Mar 2018: Needed to support PRP testing: */\
 		,	[__prp_mult]   "m" (Xprp_mult)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","r14","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","k3","k4","k5","rax","rbx","rcx","rdx","rdi","rsi","r14","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 

--- a/src/factor.c
+++ b/src/factor.c
@@ -3189,7 +3189,7 @@ MFACTOR_HELP:
 				 ,[__bit_len] "m" (bit_len)	\
 				 ,[__m] "m" (m)	\
 				 ,[__nprime] "nprime" (nprime-m)	\
-				: "cc","memory","cl","rax","rbx","rcx","rdx","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm30","xmm31"	/* Clobbered registers */\
+				: "cc","memory","k1","k2","k3","k4","cl","rax","rbx","rcx","rdx","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm30","xmm31"	/* Clobbered registers */\
 			);
 		/*	}	*/
 

--- a/src/mi64.c
+++ b/src/mi64.c
@@ -4203,7 +4203,7 @@ void mi64_vcvtuqq2pd(const uint64 a[], double b[])
 		:					/* outputs: none */\
 		: [__a] "m" (a)	/* All inputs from memory addresses here */\
 		 ,[__b] "m" (b)\
-		: "cc","memory","rax","rbx","rcx","xmm0","xmm1","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","xmm30","rax","rbx","rcx","xmm0","xmm1","xmm31"	/* Clobbered registers */\
 	);
 	for(i = 0; i < 8; i++) {
 		ASSERT(b[i] == (double)a[i], "uint64->double conversion result differs from reference!");

--- a/src/mi64.c
+++ b/src/mi64.c
@@ -4203,7 +4203,7 @@ void mi64_vcvtuqq2pd(const uint64 a[], double b[])
 		:					/* outputs: none */\
 		: [__a] "m" (a)	/* All inputs from memory addresses here */\
 		 ,[__b] "m" (b)\
-		: "cc","memory","k1","xmm30","rax","rbx","rcx","xmm0","xmm1","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","rax","rbx","rcx","xmm0","xmm1","xmm30","xmm31"	/* Clobbered registers */\
 	);
 	for(i = 0; i < 8; i++) {
 		ASSERT(b[i] == (double)a[i], "uint64->double conversion result differs from reference!");

--- a/src/radix1008_main_carry_loop.h
+++ b/src/radix1008_main_carry_loop.h
@@ -220,9 +220,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		{
 			co2 = co2save;	// Need this for all wts-inits beynd the initial set, due to the co2 = co3 preceding the (j+2) data
 			ii = loop << 3;	// Reflects 8 independent carry chains being done in each AVX_cmplx_carry_fast_pow2_errcheck_X8 call
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done
@@ -313,9 +314,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix1024_main_carry_loop.h
+++ b/src/radix1024_main_carry_loop.h
@@ -263,9 +263,10 @@ normally be getting dispatched to [radix] separate blocks of the A-array, we nee
 		  #else
 			ii = loop << 3;	// Reflects  8 independent carry chains being done in each AVX_cmplx_carry_fast_errcheck_X8 call
 		  #endif
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done
@@ -366,9 +367,10 @@ normally be getting dispatched to [radix] separate blocks of the A-array, we nee
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix11_sse_macro.h
+++ b/src/radix11_sse_macro.h
@@ -483,7 +483,7 @@
 		 ,[__cc] "m" (Xcc)\
 		 ,[out0] "m" (Xout0)\
 		 ,[o_off] "m" (Xo_off)	/* O-address pointer-strides */\
-		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15",\
+		: "cc","memory","k1","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15",\
 			"xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm31"	/* Clobbered registers */\
 		);\
 	}

--- a/src/radix128_main_carry_loop.h
+++ b/src/radix128_main_carry_loop.h
@@ -324,9 +324,10 @@ as are the index offsets of each sets of complex outputs in the A-array: [jt,jp]
 		  #else
 			ii = loop << 3;	// Reflects  8 independent carry chains being done in each AVX_cmplx_carry_fast_errcheck_X8 call
 		  #endif
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done
@@ -427,9 +428,10 @@ as are the index offsets of each sets of complex outputs in the A-array: [jt,jp]
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix144_main_carry_loop.h
+++ b/src/radix144_main_carry_loop.h
@@ -335,9 +335,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		  #else
 			ii = loop << 3;	// Reflects  8 independent carry chains being done in each AVX_cmplx_carry_fast_errcheck_X8 call
 		  #endif
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done
@@ -436,9 +437,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix160_main_carry_loop.h
+++ b/src/radix160_main_carry_loop.h
@@ -200,9 +200,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		  #else
 			ii = loop << 3;	// Reflects  8 independent carry chains being done in each AVX_cmplx_carry_fast_errcheck_X8 call
 		  #endif
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done
@@ -301,9 +302,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix16_dyadic_square.c
+++ b/src/radix16_dyadic_square.c
@@ -940,7 +940,7 @@ void radix16_dyadic_square(
 			 ,[__index1_mod] "m" (index1_mod)	\
 			 ,[__k1_arr] "m" (k1_arr)	\
 			 ,[__k2_arr] "m" (k2_arr)	\
-			: "cc","memory","k1","k2","xmm8","cl","rax","rbx","rcx","rdx","rsi","rdi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5"	/* Clobbered registers */\
+			: "cc","memory","k1","k2","cl","rax","rbx","rcx","rdx","rsi","rdi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm8"	/* Clobbered registers */\
 		);
 	   #if 0	// Set = 1 to enable timing-loop
 		}	tdiff = (double)(clock() - clock1);	printf("Time for %u 8x8 execs of AVX-512 twiddle-index macro =%s\n",l,get_time_str(tdiff));	exit(0);

--- a/src/radix16_dyadic_square.c
+++ b/src/radix16_dyadic_square.c
@@ -940,7 +940,7 @@ void radix16_dyadic_square(
 			 ,[__index1_mod] "m" (index1_mod)	\
 			 ,[__k1_arr] "m" (k1_arr)	\
 			 ,[__k2_arr] "m" (k2_arr)	\
-			: "cc","memory","cl","rax","rbx","rcx","rdx","rsi","rdi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5"	/* Clobbered registers */\
+			: "cc","memory","k1","k2","xmm8","cl","rax","rbx","rcx","rdx","rsi","rdi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5"	/* Clobbered registers */\
 		);
 	   #if 0	// Set = 1 to enable timing-loop
 		}	tdiff = (double)(clock() - clock1);	printf("Time for %u 8x8 execs of AVX-512 twiddle-index macro =%s\n",l,get_time_str(tdiff));	exit(0);

--- a/src/radix16_dyadic_square_gcc64.h
+++ b/src/radix16_dyadic_square_gcc64.h
@@ -783,7 +783,7 @@
 		 ,[__r1] "m" (Xr1)\
 		 ,[__isrt2] "m" (Xisrt2)\
 		 ,[__pfetch_dist] "m" (Xpfetch_dist)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","r10","r13","r14","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17"	/* Clobbered registers */\
+		: "cc","memory","k1","rax","rbx","rcx","rdx","rdi","rsi","r10","r13","r14","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17"	/* Clobbered registers */\
 	);\
 	}
 
@@ -1633,7 +1633,7 @@
 		 ,[__r1] "m" (Xr1)\
 		 ,[__isrt2] "m" (Xisrt2)\
 		 ,[__pfetch_dist] "m" (Xpfetch_dist)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","r10","r13","r14","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","k3","k4","k5","rax","rbx","rcx","rdx","rdi","r10","r13","r14","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 

--- a/src/radix16_utils_asm.h
+++ b/src/radix16_utils_asm.h
@@ -419,7 +419,7 @@
 		 ,[__k1]  "m" (Xk1)\
 		 ,[__rt0] "m" (Xrt0)\
 		 ,[__rt1] "m" (Xrt1)\
-		: "cc","memory","rax","rbx","rcx","rdx","r8","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
+		: "cc","memory","k1","rax","rbx","rcx","rdx","r8","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
 		);\
 	}
 

--- a/src/radix16_wrapper_square_gcc64.h
+++ b/src/radix16_wrapper_square_gcc64.h
@@ -972,7 +972,7 @@
 		 ,[__c14] "m" (Xc14)\
 		 ,[__c15] "m" (Xc15)\
 	 ,[__pfetch_dist] "m" (Xpfetch_dist)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","r10","r11","r12","r13","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23", "xmm29","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","k3","k4","k5","rax","rbx","rcx","rdx","rdi","rsi","r10","r11","r12","r13","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23", "xmm29","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 
@@ -1877,7 +1877,7 @@
 		 ,[__c14] "m" (Xc14)\
 		 ,[__c15] "m" (Xc15)\
 	 ,[__pfetch_dist] "m" (Xpfetch_dist)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","r10","r11","r12","r13","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17", "xmm29","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","k3","k4","k5","rax","rbx","rcx","rdx","rdi","rsi","r10","r11","r12","r13","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17", "xmm29","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 

--- a/src/radix176_main_carry_loop.h
+++ b/src/radix176_main_carry_loop.h
@@ -270,9 +270,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		  #else
 			ii = loop << 3;	// Reflects  8 independent carry chains being done in each AVX_cmplx_carry_fast_errcheck_X8 call
 		  #endif
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done
@@ -370,9 +371,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix192_main_carry_loop.h
+++ b/src/radix192_main_carry_loop.h
@@ -308,9 +308,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		  #else
 			ii = loop << 3;	// Reflects  8 independent carry chains being done in each AVX_cmplx_carry_fast_errcheck_X8 call
 		  #endif
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done
@@ -410,9 +411,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix208_main_carry_loop.h
+++ b/src/radix208_main_carry_loop.h
@@ -259,9 +259,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		  #else
 			ii = loop << 3;	// Reflects  8 independent carry chains being done in each AVX_cmplx_carry_fast_errcheck_X8 call
 		  #endif
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done
@@ -361,9 +362,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix224_main_carry_loop.h
+++ b/src/radix224_main_carry_loop.h
@@ -217,9 +217,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		  #else
 			ii = loop << 3;	// Reflects  8 independent carry chains being done in each AVX_cmplx_carry_fast_errcheck_X8 call
 		  #endif
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done
@@ -319,9 +320,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix240_main_carry_loop.h
+++ b/src/radix240_main_carry_loop.h
@@ -513,9 +513,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		  #else
 			ii = loop << 3;	// Reflects  8 independent carry chains being done in each AVX_cmplx_carry_fast_errcheck_X8 call
 		  #endif
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done
@@ -614,9 +615,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix256_main_carry_loop.h
+++ b/src/radix256_main_carry_loop.h
@@ -460,9 +460,10 @@ normally be getting dispatched to [radix] separate blocks of the A-array, we nee
 		  #else
 			ii = loop << 3;	// Reflects  8 independent carry chains being done in each AVX_cmplx_carry_fast_errcheck_X8 call
 		  #endif
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done
@@ -563,9 +564,10 @@ normally be getting dispatched to [radix] separate blocks of the A-array, we nee
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix288_main_carry_loop.h
+++ b/src/radix288_main_carry_loop.h
@@ -240,9 +240,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		  #else
 			ii = loop << 3;	// Reflects  8 independent carry chains being done in each AVX_cmplx_carry_fast_errcheck_X8 call
 		  #endif
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done
@@ -341,9 +342,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix28_main_carry_loop.h
+++ b/src/radix28_main_carry_loop.h
@@ -240,9 +240,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix320_main_carry_loop.h
+++ b/src/radix320_main_carry_loop.h
@@ -246,9 +246,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		  #else
 			ii = loop << 3;	// Reflects  8 independent carry chains being done in each AVX_cmplx_carry_fast_errcheck_X8 call
 		  #endif
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done
 						// (and only then: for all subsequent blocks it's superfluous), this assignment decrements co2 by radix(1).
@@ -346,9 +347,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix32_dyadic_square.c
+++ b/src/radix32_dyadic_square.c
@@ -1009,7 +1009,7 @@ void radix32_dyadic_square(
 			 ,[__index1_mod] "m" (index1_mod)	\
 			 ,[__k1_arr] "m" (k1_arr)	\
 			 ,[__k2_arr] "m" (k2_arr)	\
-			: "cc","memory","k1","k2","xmm8","cl","rax","rbx","rcx","rdx","rsi","rdi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6"	/* Clobbered registers */\
+			: "cc","memory","k1","k2","cl","rax","rbx","rcx","rdx","rsi","rdi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm8"	/* Clobbered registers */\
 		);
 
 		// Need one more (scalar-mode) update of these in preparation for the next 8-fold chunk:

--- a/src/radix32_dyadic_square.c
+++ b/src/radix32_dyadic_square.c
@@ -1009,7 +1009,7 @@ void radix32_dyadic_square(
 			 ,[__index1_mod] "m" (index1_mod)	\
 			 ,[__k1_arr] "m" (k1_arr)	\
 			 ,[__k2_arr] "m" (k2_arr)	\
-			: "cc","memory","cl","rax","rbx","rcx","rdx","rsi","rdi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6"	/* Clobbered registers */\
+			: "cc","memory","k1","k2","xmm8","cl","rax","rbx","rcx","rdx","rsi","rdi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6"	/* Clobbered registers */\
 		);
 
 		// Need one more (scalar-mode) update of these in preparation for the next 8-fold chunk:

--- a/src/radix32_utils_asm.h
+++ b/src/radix32_utils_asm.h
@@ -722,7 +722,7 @@
 		 ,[__k1]  "m" (Xk1)\
 		 ,[__rt0] "m" (Xrt0)\
 		 ,[__rt1] "m" (Xrt1)\
-		: "cc","memory","rax","rbx","rcx","rdx","r10","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
+		: "cc","memory","k1","rax","rbx","rcx","rdx","r10","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
 		);\
 	}
 

--- a/src/radix32_wrapper_square_gcc64.h
+++ b/src/radix32_wrapper_square_gcc64.h
@@ -1815,7 +1815,7 @@ NOTE: Twiddles here shared between DIF/DIT portions, laid out like DIF, i.e. sli
 		 ,[__c03] "m" (Xc03)\
 		 ,[__c05] "m" (Xc05)\
 		 ,[__c07] "m" (Xc07)\
-		: "cc","memory","k1","xmm16","xmm17","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
+		: "cc","memory","k1","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17"	/* Clobbered registers */\
 	);\
 	}
 
@@ -3800,7 +3800,7 @@ NOTE: Twiddles here shared between DIF/DIT portions, laid out like DIF, i.e. sli
 		 ,[__c10] "m" (Xc10)\
 		 ,[__c12] "m" (Xc12)\
 		 ,[__c1A] "m" (Xc1A)\
-		: "cc","memory","k1","xmm16","xmm17","rax","rbx","rcx","rdx","rdi","rsi","r10","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"		/* Clobbered registers */\
+		: "cc","memory","k1","rax","rbx","rcx","rdx","rdi","rsi","r10","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17"		/* Clobbered registers */\
 	);\
 	}
 

--- a/src/radix32_wrapper_square_gcc64.h
+++ b/src/radix32_wrapper_square_gcc64.h
@@ -1815,7 +1815,7 @@ NOTE: Twiddles here shared between DIF/DIT portions, laid out like DIF, i.e. sli
 		 ,[__c03] "m" (Xc03)\
 		 ,[__c05] "m" (Xc05)\
 		 ,[__c07] "m" (Xc07)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
+		: "cc","memory","k1","xmm16","xmm17","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
 	);\
 	}
 
@@ -2398,7 +2398,7 @@ NOTE: Twiddles here shared between DIF/DIT portions, laid out like DIF, i.e. sli
 		 ,[__c03] "m" (Xc03)\
 		 ,[__c05] "m" (Xc05)\
 		 ,[__c07] "m" (Xc07)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","r10","r11","r12","r13","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","k3","k4","k5","rax","rbx","rcx","rdx","rdi","rsi","r10","r11","r12","r13","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 
@@ -2961,7 +2961,7 @@ NOTE: Twiddles here shared between DIF/DIT portions, laid out like DIF, i.e. sli
 		 ,[__c03] "m" (Xc03)\
 		 ,[__c05] "m" (Xc05)\
 		 ,[__c07] "m" (Xc07)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","r10","r11","r12","r13","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","rax","rbx","rcx","rdx","rdi","rsi","r10","r11","r12","r13","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 
@@ -3800,7 +3800,7 @@ NOTE: Twiddles here shared between DIF/DIT portions, laid out like DIF, i.e. sli
 		 ,[__c10] "m" (Xc10)\
 		 ,[__c12] "m" (Xc12)\
 		 ,[__c1A] "m" (Xc1A)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","r10","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"		/* Clobbered registers */\
+		: "cc","memory","k1","xmm16","xmm17","rax","rbx","rcx","rdx","rdi","rsi","r10","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"		/* Clobbered registers */\
 	);\
 	}
 
@@ -4583,7 +4583,7 @@ NOTE: Twiddles here shared between DIF/DIT portions, laid out like DIF, i.e. sli
 		 ,[__c10] "m" (Xc10)\
 		 ,[__c12] "m" (Xc12)\
 		 ,[__c1A] "m" (Xc1A)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","r10","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","k3","k4","k5","rax","rbx","rcx","rdx","rdi","rsi","r10","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 
@@ -5343,7 +5343,7 @@ NOTE: Twiddles here shared between DIF/DIT portions, laid out like DIF, i.e. sli
 		 ,[__c10] "m" (Xc10)\
 		 ,[__c12] "m" (Xc12)\
 		 ,[__c1A] "m" (Xc1A)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","r10","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","rax","rbx","rcx","rdx","rdi","rsi","r10","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 

--- a/src/radix32_wrapper_square_gcc64.h
+++ b/src/radix32_wrapper_square_gcc64.h
@@ -4583,7 +4583,7 @@ NOTE: Twiddles here shared between DIF/DIT portions, laid out like DIF, i.e. sli
 		 ,[__c10] "m" (Xc10)\
 		 ,[__c12] "m" (Xc12)\
 		 ,[__c1A] "m" (Xc1A)\
-		: "cc","memory","k1","k2","k3","k4","k5","rax","rbx","rcx","rdx","rdi","rsi","r10","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","k3","k4","k5","rax","rbx","rcx","rdx","rdi","rsi","r10","r11","r12","r13","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 
@@ -5343,7 +5343,7 @@ NOTE: Twiddles here shared between DIF/DIT portions, laid out like DIF, i.e. sli
 		 ,[__c10] "m" (Xc10)\
 		 ,[__c12] "m" (Xc12)\
 		 ,[__c1A] "m" (Xc1A)\
-		: "cc","memory","k1","rax","rbx","rcx","rdx","rdi","rsi","r10","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","rax","rbx","rcx","rdx","rdi","rsi","r10","r11","r12","r13","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 

--- a/src/radix352_main_carry_loop.h
+++ b/src/radix352_main_carry_loop.h
@@ -197,9 +197,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		  #else
 			ii = loop << 3;	// Reflects  8 independent carry chains being done in each AVX_cmplx_carry_fast_errcheck_X8 call
 		  #endif
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done
@@ -298,9 +299,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix36_main_carry_loop.h
+++ b/src/radix36_main_carry_loop.h
@@ -462,9 +462,10 @@ vinsertf64x4 1,ymm1,zmm0,zmm0	 3-6/1 for y,z,z, 7/1 for m256,z,z			3/1 for y,z,z
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix384_main_carry_loop.h
+++ b/src/radix384_main_carry_loop.h
@@ -321,9 +321,10 @@ if(tid == 1) {
 		  #else
 			ii = loop << 3;	// Reflects  8 independent carry chains being done in each AVX_cmplx_carry_fast_errcheck_X8 call
 		  #endif
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done
@@ -422,9 +423,10 @@ if(tid == 1) {
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix4032_main_carry_loop.h
+++ b/src/radix4032_main_carry_loop.h
@@ -172,9 +172,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		{
 			co2 = co2save;	// Need this for all wts-inits beynd the initial set, due to the co2 = co3 preceding the (j+2) data
 			ii = loop << 3;	// Reflects 8 independent carry chains being done in each AVX_cmplx_carry_fast_pow2_errcheck_X8 call
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done
@@ -265,9 +266,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix44_main_carry_loop.h
+++ b/src/radix44_main_carry_loop.h
@@ -297,9 +297,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix48_main_carry_loop.h
+++ b/src/radix48_main_carry_loop.h
@@ -418,9 +418,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix52_main_carry_loop.h
+++ b/src/radix52_main_carry_loop.h
@@ -313,9 +313,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix56_main_carry_loop.h
+++ b/src/radix56_main_carry_loop.h
@@ -367,9 +367,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix60_main_carry_loop.h
+++ b/src/radix60_main_carry_loop.h
@@ -386,9 +386,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix64_main_carry_loop.h
+++ b/src/radix64_main_carry_loop.h
@@ -412,9 +412,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix768_main_carry_loop.h
+++ b/src/radix768_main_carry_loop.h
@@ -274,9 +274,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		  #else
 			ii = loop << 3;	// Reflects  8 independent carry chains being done in each AVX_cmplx_carry_fast_errcheck_X8 call
 		  #endif
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done
@@ -375,9 +376,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/radix960_main_carry_loop.h
+++ b/src/radix960_main_carry_loop.h
@@ -363,9 +363,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		  #else
 			ii = loop << 3;	// Reflects  8 independent carry chains being done in each AVX_cmplx_carry_fast_errcheck_X8 call
 		  #endif
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done
@@ -464,9 +465,10 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			ctmp->re = ctmp->im = wtlp1;	ctmp += 2;
 			ctmp->re = ctmp->im = wtnm1;
 
-			add1 = &wt1[col  +ii];	/* Don't use add0 here, to avoid need to reload main-array address */
-			add2 = &wt1[co2-1-ii];
-			add3 = &wt1[co3-1-ii];
+			add1 = &wt1[col  +(int)ii];	/* Don't use add0 here, to avoid need to reload main-array address */
+			add2 = &wt1[co2-1-(int)ii];
+			add3 = &wt1[co3-1-(int)ii];
+			ASSERT(col+(int)ii >= 0 && co2-1-(int)ii >= 0 && co3-1-(int)ii >= 0, "wt1[] carry-weight index underflow - carry-chain state corrupted");
 
 			// Since use wt1-array in the wtsinit macro, need to fiddle this here:
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done

--- a/src/twopmodq100.c
+++ b/src/twopmodq100.c
@@ -411,7 +411,7 @@
 			 ,[__base0]  "m" (dptr2), [__binv0]  "m" (dptr3)	/* double-ptrs */\
 			 ,[__base1]  "m" (dptr4), [__binv1]  "m" (dptr5)	/* double-ptrs */\
 			 ,[__two32f] "m" (dptr6), [__two32i] "m" (dptr7)	/* double-ptrs */\
-			: "cc","memory","rax","rbx","rcx","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27", "xmm30","xmm31"	/* Clobbered registers */\
+			: "cc","memory","k1","k2","k3","k4","rax","rbx","rcx","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27", "xmm30","xmm31"	/* Clobbered registers */\
 		);
 
 	#endif
@@ -567,7 +567,7 @@ opcount - umulh adds 5 mul, 3 fma, 5 add, 1 round:
 			:					/* outputs: none */\
 			: [__fq0] "m" (dptr)	/* All inputs from memory addresses here */\
 			 ,[__result] "m" (r)	\
-			: "cc","memory","cl","rax","rbx","rcx","rdx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
+			: "cc","memory","k0","k1","k2","k3","k4","k5","k6","k7","xmm30","xmm31","cl","rax","rbx","rcx","rdx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
 		);
 
 		return r;

--- a/src/twopmodq100.c
+++ b/src/twopmodq100.c
@@ -567,7 +567,7 @@ opcount - umulh adds 5 mul, 3 fma, 5 add, 1 round:
 			:					/* outputs: none */\
 			: [__fq0] "m" (dptr)	/* All inputs from memory addresses here */\
 			 ,[__result] "m" (r)	\
-			: "cc","memory","k0","k1","k2","k3","k4","k5","k6","k7","xmm30","xmm31","cl","rax","rbx","rcx","rdx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
+			: "cc","memory","k0","k1","k2","k3","k4","k5","k6","k7","cl","rax","rbx","rcx","rdx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm30","xmm31"	/* Clobbered registers */\
 		);
 
 		return r;

--- a/src/twopmodq100.h
+++ b/src/twopmodq100.h
@@ -217,7 +217,7 @@ extern "C" {
 		 ,[__crnd] "m" (Xcrnd)\
 		 ,[__pshift] "m" (Xpshift)	\
 		 ,[__j]		 "m" (Xj)		\
-		: "cc","memory","cl","rax","rbx","rcx","rdx","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15", "xmm29","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","k3","k4","cl","rax","rbx","rcx","rdx","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15", "xmm29","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 
@@ -404,7 +404,7 @@ extern "C" {
 		 ,[__crnd] "m" (Xcrnd)\
 		 ,[__pshift] "m" (Xpshift)	\
 		 ,[__j]		 "m" (Xj)		\
-		: "cc","memory","cl","rax","rbx","rcx","rdx","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15", "xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","k1","k2","k3","k4","cl","rax","rbx","rcx","rdx","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15", "xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 

--- a/src/twopmodq80.c
+++ b/src/twopmodq80.c
@@ -5957,7 +5957,7 @@ if(~pshift != p+78) {
 				 ,[__kvec] "m" (tm1)	/* vec-of-doubles copy of input kvec */\
 				 ,[__minv8]   "m" (minv8_ptr)	/* Ptr to Table of precomputed byte-inverses def'd in mi64.h */\
 				 ,[__two26f] "m" (two26f)\
-				: "cc","memory","rax","rbx","rcx","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
+				: "cc","memory","k1","k2","k3","k4","rax","rbx","rcx","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
 			);
 
 		#endif
@@ -6119,7 +6119,7 @@ if(~pshift != p+78) {
 				: [__fq0] "m" (dptr)	/* All inputs from memory addresses here */\
 				 ,[__two26f] "m" (two26f)	\
 				 ,[__result] "m" (r)	\
-				: "cc","memory","cl","rax","rbx","rcx","rdx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
+				: "cc","memory","k0","k1","k2","k3","k4","k5","k6","k7","cl","rax","rbx","rcx","rdx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
 			);
 
 			return r;
@@ -6741,7 +6741,7 @@ if(~pshift != p+78) {
 				 ,[__kvec] "m" (tm1)	/* vec-of-doubles copy of input kvec */\
 				 ,[__minv8]   "m" (minv8_ptr)	/* Ptr to Table of precomputed byte-inverses def'd in mi64.h */\
 				 ,[__two26f] "m" (two26f)\
-				: "cc","memory","rax","rbx","rcx","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
+				: "cc","memory","k1","k2","k3","k4","rax","rbx","rcx","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
 			);
 
 		#endif
@@ -6865,7 +6865,7 @@ if(~pshift != p+78) {
 				: [__fq0] "m" (dptr)	/* All inputs from memory addresses here */\
 				 ,[__two26f] "m" (two26f)	\
 				 ,[__result] "m" (r)	\
-				: "cc","memory","cl","rax","rbx","rcx","rdx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10", "xmm12","xmm13","xmm14", "xmm16","xmm17","xmm18", "xmm20","xmm21","xmm22", "xmm24","xmm25","xmm26", "xmm28","xmm29","xmm30"	/* Clobbered registers */\
+				: "cc","memory","k0","k1","k2","k3","k4","k5","k6","k7","cl","rax","rbx","rcx","rdx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10", "xmm12","xmm13","xmm14", "xmm16","xmm17","xmm18", "xmm20","xmm21","xmm22", "xmm24","xmm25","xmm26", "xmm28","xmm29","xmm30"	/* Clobbered registers */\
 			);
 			return r;
 		}

--- a/src/twopmodq80.h
+++ b/src/twopmodq80.h
@@ -209,7 +209,7 @@ extern "C" {
 			 ,[__two26i] "m" (Xtwo26i)	\
 			 ,[__pshift] "m" (Xpshift)	\
 			 ,[__j]		 "m" (Xj)		\
-			: "cc","memory","cl","rax","rbx","rcx","rdx","rsi","rdi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
+			: "cc","memory","k0","k1","k2","k3","k4","k5","k6","k7","cl","rax","rbx","rcx","rdx","rsi","rdi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
 		);\
 		}
 
@@ -390,7 +390,7 @@ extern "C" {
 			 ,[__two26i] "m" (Xtwo26i)	\
 			 ,[__pshift] "m" (Xpshift)	\
 			 ,[__j]		 "m" (Xj)		\
-			: "cc","memory","cl","rax","rbx","rcx","rdx","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
+			: "cc","memory","k1","k2","k3","k4","cl","rax","rbx","rcx","rdx","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
 		);\
 		}
 

--- a/src/util.c
+++ b/src/util.c
@@ -5963,7 +5963,7 @@ ftmp0 = ftmp;
 		__asm__ volatile (\
 			"movl	$0xaaaa,%%eax	\n\t	kmov	%%eax,%%k1	\n\t"/* k1 = 0b1010101010101010 */\
 			: :
-			: "cc","memory","rax"
+			: "cc","memory","k1","rax"
 		);
 		for(i = 0; i < imax; i++) {
 			__asm__ volatile (\
@@ -5984,7 +5984,7 @@ ftmp0 = ftmp;
 				:	// outputs: none
 				: [__dhalf] "m" (*i64ptr)
 				 ,[__data] "m" (data)	// All inputs from memory addresses here
-				: "cc","memory","rax","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7"
+				: "cc","memory","k1","rax","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7"
 			);
 		}
 		clock2 = getRealTime();
@@ -6017,7 +6017,7 @@ ftmp0 = ftmp;
 			/* No write-back-to-memory - just want to be able to examine contents of zmm2,4,0,3 in debugger. */\
 				:						// outputs: none
 				: [__data] "m" (data)	// All inputs from memory addresses here
-				: "cc","memory","rax","rbx","rcx","xmm0","xmm1","xmm2","xmm3","xmm4", "xmm30","xmm31"
+				: "cc","memory","k1","k2","k3","k4","rax","rbx","rcx","xmm0","xmm1","xmm2","xmm3","xmm4", "xmm30","xmm31"
 			);
 		}
 		clock2 = getRealTime();
@@ -6095,7 +6095,7 @@ ftmp0 = ftmp;
 				"vmovaps	%%zmm7,0x1c0(%%rax)	\n\t"\
 				:				// outputs: none
 				: [__data] "m" (data)	// All inputs from memory addresses here
-				: "cc","memory","rax","rbx","rcx","rdx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8"
+				: "cc","memory","k1","k2","k3","k4","k5","rax","rbx","rcx","rdx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8"
 			);
 		}
 		clock2 = getRealTime();
@@ -6329,7 +6329,7 @@ ftmp0 = ftmp;
 				"vmovaps	%%zmm3,0x1c0(%%rax)	\n\t"\
 				:				// outputs: none
 				: [__data] "m" (data)	// All inputs from memory addresses here
-				: "cc","memory","rax","rbx","rcx","rdx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8"
+				: "cc","memory","k1","k2","k3","k4","k5","rax","rbx","rcx","rdx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8"
 			);
 		}
 		clock2 = getRealTime();
@@ -6497,7 +6497,7 @@ ftmp0 = ftmp;
 				"vmovaps		%%zmm7,0x1c0(%%rax)		\n\t"\
 				:						// outputs: none
 				: [__data] "m" (data)	// All inputs from memory addresses here
-				: "cc","memory","rax","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8"	// Clobbered registers - use xmm form for compatibility with older versions of clang/gcc
+				: "cc","memory","k1","k2","rax","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8"	// Clobbered registers - use xmm form for compatibility with older versions of clang/gcc
 			);
 		}
 		clock2 = getRealTime();
@@ -6570,7 +6570,7 @@ ftmp0 = ftmp;
 				"vmovaps		%%zmm4, 0x1c0(%%rax)		\n\t"\
 				:						// outputs: none
 				: [__data] "m" (data)	// All inputs from memory addresses here
-				: "cc","memory","rax","rbx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11", "xmm30","xmm31"	// Clobbered registers - use xmm form for compatibility with older versions of clang/gcc
+				: "cc","memory","k1","rax","rbx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11", "xmm30","xmm31"	// Clobbered registers - use xmm form for compatibility with older versions of clang/gcc
 			);
 		}
 		clock2 = getRealTime();
@@ -6699,7 +6699,7 @@ ftmp0 = ftmp;
 				:						// outputs: none
 				: [__data] "m" (data)	/* All inputs from memory addresses here */\
 				 ,[__gatherindex] "m" (gatherindex)
-				: "cc","memory","rax","rbx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8"	// Clobbered registers - use xmm form for compatibility with older versions of clang/gcc
+				: "cc","memory","k1","rax","rbx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8"	// Clobbered registers - use xmm form for compatibility with older versions of clang/gcc
 			);
 		}
 		clock2 = getRealTime();
@@ -6758,7 +6758,7 @@ ftmp0 = ftmp;
 				"vmovaps	%%zmm7,0x1c0(%%rax)	\n\t"\
 				:						// outputs: none
 				: [__data] "m" (data)	// All inputs from memory addresses here
-				: "cc","memory","rax","rbx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8"	// Clobbered registers - use xmm form for compatibility with older versions of clang/gcc
+				: "cc","memory","k1","rax","rbx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8"	// Clobbered registers - use xmm form for compatibility with older versions of clang/gcc
 			);
 		}
 		clock2 = getRealTime();
@@ -6842,7 +6842,7 @@ ftmp0 = ftmp;
 				:						// outputs: none
 				: [__data] "m" (data)	/* All inputs from memory addresses here */\
 				 ,[__gatherindex] "m" (gatherindex)
-				: "cc","memory","rax","rbx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8"	// Clobbered registers - use xmm form for compatibility with older versions of clang/gcc
+				: "cc","memory","k1","k2","rax","rbx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8"	// Clobbered registers - use xmm form for compatibility with older versions of clang/gcc
 			);
 		}
 		clock2 = getRealTime();
@@ -6934,7 +6934,7 @@ ftmp0 = ftmp;
 																"vmovaps	%%zmm17,0x1c0(%%rax)	\n\t"\
 				:						// outputs: none
 				: [__data] "m" (data)	// All inputs from memory addresses here
-				: "cc","memory","rax","rbx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17"	// Clobbered registers - use xmm form for compatibility with older versions of clang/gcc
+				: "cc","memory","k1","rax","rbx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17"	// Clobbered registers - use xmm form for compatibility with older versions of clang/gcc
 			);
 		}
 		clock2 = getRealTime();
@@ -7028,7 +7028,7 @@ ftmp0 = ftmp;
 				"vmovaps		%%zmm4, 0x1c0(%%rax)				\n\t	vmovaps		%%zmm16,0x3c0(%%rax)		\n\t"\
 				:						// outputs: none
 				: [__data] "m" (data)	// All inputs from memory addresses here
-				: "cc","memory","rax","rbx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23", "xmm30","xmm31"	// Clobbered registers - use xmm form for compatibility with older versions of clang/gcc
+				: "cc","memory","k1","rax","rbx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23", "xmm30","xmm31"	// Clobbered registers - use xmm form for compatibility with older versions of clang/gcc
 			);
 		}
 		clock2 = getRealTime();


### PR DESCRIPTION
## Summary

Two related fixes for the AVX-512-only segfault family (#65, #52, #16, #12). The first is the root cause; the second is defense-in-depth for the same corruption.

### 1. Declare AVX-512 opmask (`k`) and high-vector clobbers in inline asm

No inline-asm block in the codebase declared the AVX-512 opmask registers `k0`–`k7` as clobbered (`grep '"k[0-7]"' src/` → 0 matches), yet **51 blocks across 16 files write them** via `vpcmpd`/`vcmppd`/`kshiftrw`/`kandw`/`kmov` etc. (`carry_gcc64.h` alone uses `%%k1`–`%%k7` ~2200 times). Under `-O3 -flto -march=native`, modern GCC/Clang auto-vectorize the surrounding C using opmask and `zmm16`–`zmm31` registers and keep those values live across the `asm volatile` blocks, which then silently destroy them.

This is a clean explanation for the observed pattern: the crash is **AVX-512-only** (AVX2 builds allocate no `k` registers), it **moves with compiler version and CPU vendor** (register-allocation dependent), and building with `-fno-tree-vectorize -fno-slp-vectorize` is expected to make it disappear.

This PR adds exactly the `k` registers each block writes (including `k0`, which `twopmodq80/100` write via `vcmppd`/`kandw`). While auditing the same blocks it also fills in undeclared high-vector clobbers:
- `xmm8` at the two `radix16/32_dyadic_square.c` sites (blocks use `xmm8`/`ymm8` but the clobber list stopped short),
- `zmm16`–`zmm31` omissions in `carry_gcc64.h` (zmm18/19), `mi64.c` (zmm30), `radix32_wrapper_square_gcc64.h` (zmm16/17) and `twopmodq100.c` (zmm30/31).

All additions are to blocks compiled only under `USE_AVX512`. Every operand in these blocks is memory/GPR/immediate (`"m"`/`"g"`/`"e"`), so no clobber can collide with an operand constraint. Over-declaring a clobber costs a little performance, never correctness.

### 2. Cast the carry-chain offset to `int` in `wt1[]` indexing

In the LOACC chained-weights carry loops, the per-chain offset `ii` is `uint32` while `col`/`co2`/`co3` are `int`, so `&wt1[co2-1-ii]` and `&wt1[co3-1-ii]` are evaluated in **unsigned 32-bit** arithmetic. If upstream corruption drives `co2`/`co3` negative, the index wraps to ~2³² and produces a wild pointer ~34 GB past `wt1` — matching the fault address decoded in the #16 7950X reports.

Casting `ii` to `int` at the three `wt1[]` index sites keeps the arithmetic signed: a corrupted index now lands near `wt1` (debuggable / promptly faulting) instead of at a random high address, and cannot silently read valid-but-wrong weights from mapped memory. An `ASSERT` on the three indices aborts cleanly on underflow; it runs only in the per-`j`-block weights-init path (a few int compares per 8–16 carries), so the cost is negligible. This also covers the SSE2/scalar/ARM branches.

## Verification

- `"k0"`–`"k7"` accepted as clobbers by **gcc 16.1.1** and **clang 22**.
- AVX-512 tree builds clean (0 errors) with both compilers.
- AVX2 `-s s` self-test passes all 24 radix-sets (256K–1920K) with no assert false-fire.

⚠️ The build host is AVX2-only (Comet Lake), so I could **only compile-check** AVX-512. Runtime confirmation of the segfault fix is expected from the CI self-test matrix and AVX-512 (Zen 4) hardware — the `-fno-tree-vectorize`/`-fno-slp-vectorize` falsification check is the cleanest way to confirm the mechanism.

**Update (2026-07-11):** the runtime segfault was subsequently reproduced on GitHub's AVX-512 runners, where this PR's AVX-512 self-test passes — runtime confirmation of the fix, upgrading the issue links below.

Fixes #65. Fixes #16. Likely fixes #52 (same clobber family; F33-scale verification impractical locally). Helps #12 (shares the index-wrap hardening; the ARM-side clobber audit remains open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

