### PR TITLE
Skip too-small FFT lengths on the AVX/AVX-512 wrapper_square path (fixes #7)

### DIFF
--- a/src/mers_mod_square.c
+++ b/src/mers_mod_square.c
@@ -338,6 +338,26 @@ The scratch array (2nd input argument) is only needed for data table initializat
 			}
 		}
 
+	#ifdef USE_AVX
+		/* The AVX/AVX-512 radix16|32_wrapper_square routines read RE_IM_STRIDE (=4|8)
+		sincos-index sets per SIMD pass from the length-(N2/radix_final) index[] array. For FFT
+		lengths so small that the final-block schedule leaves a partial chunk with fewer than
+		RE_IM_STRIDE sets, those wide-SIMD code paths read past the end of index[] (garbage
+		twiddles, or SIGSEGV under ASan / when the slack falls on an unmapped page). This is
+		independent of the DAT_BITS/array-padding logic above (which is disabled - DAT_BITS=31 -
+		for the runlengths <= 32K where this bites). Such lengths are sub-1-Mdigit toy sizes with
+		no production use; they compute correctly in scalar/SSE2 builds but not the wide-SIMD ones,
+		so soft-skip here (self-test moves on to the next radix set instead of crashing). The
+		bound is empirical: the overrun occurs only for N2/radix_final <= 32 in AVX (stride 4)
+		builds; require >= 16*RE_IM_STRIDE for margin (and 2x that for the stride-8 AVX-512 path). */
+		if((N2 / (uint32)RADIX_VEC[NRADICES-1]) < (uint32)(16*RE_IM_STRIDE))
+		{
+			snprintf(cbuf,STR_MAX_LEN*2,"FFT length %u K too small for the AVX/AVX-512 wrapper_square SIMD width (need complex-length/radix_final = %u >= %u); skipping this radix set.\n",
+				(uint32)(n>>10), N2/(uint32)RADIX_VEC[NRADICES-1], (uint32)(16*RE_IM_STRIDE));
+			WARN(HERE, cbuf, "", 1); return(ERR_ASSERT);
+		}
+	#endif
+
 		sprintf(cbuf,"Using complex FFT radices*");
 		char_addr = strstr(cbuf,"*");
 		for(i = 0; i < NRADICES; i++)

--- a/src/mers_mod_square.c
+++ b/src/mers_mod_square.c
@@ -352,7 +352,7 @@ The scratch array (2nd input argument) is only needed for data table initializat
 		builds; require >= 16*RE_IM_STRIDE for margin (and 2x that for the stride-8 AVX-512 path). */
 		if((N2 / (uint32)RADIX_VEC[NRADICES-1]) < (uint32)(16*RE_IM_STRIDE))
 		{
-			snprintf(cbuf,STR_MAX_LEN*2,"FFT length %u K too small for the AVX/AVX-512 wrapper_square SIMD width (need complex-length/radix_final = %u >= %u); skipping this radix set.\n",
+			snprintf(cbuf,sizeof(cbuf),"FFT length %u K too small for the AVX/AVX-512 wrapper_square SIMD width (need complex-length/radix_final = %u >= %u); skipping this radix set.\n",
 				(uint32)(n>>10), N2/(uint32)RADIX_VEC[NRADICES-1], (uint32)(16*RE_IM_STRIDE));
 			WARN(HERE, cbuf, "", 1); return(ERR_ASSERT);
 		}

--- a/src/radix16_wrapper_square.c
+++ b/src/radix16_wrapper_square.c
@@ -1639,6 +1639,7 @@ jump_in:	/* Entry point for all blocks but the first. */
 	  #elif !defined(USE_AVX512)	// AVX/AVX2:
 
 	  // In AVX mode need 4 sets of sincos:
+		ASSERT(k + (j1 > 64 ? 4 : 2) <= (int)(N2>>4), "radix16_wrapper_square: AVX sincos index[] overrun - FFT length too small for SIMD width");
 		// Need to explicitly 0 these for the first-few-blocks-done-via-scalar-code case in AVX mode to make sure the
 		// unused-in-those-cases 3rd/4th-set indices stay nice and non-segfault-y:
 		if(j1 <= 160) {
@@ -1712,6 +1713,7 @@ jump_in:	/* Entry point for all blocks but the first. */
 	  #elif defined(USE_AVX512)	// AVX512:
 
 	  // In AVX-512 mode need 8 sets of sincos:
+		ASSERT(k + 2 + (j1 > 64 ? 2 : 0) + (j1 > 160 ? 4 : 0) <= (int)(N2>>4), "radix16_wrapper_square: AVX-512 sincos index[] overrun - FFT length too small for SIMD width");
 		// Need to explicitly 0 these for the first-few-blocks-done-via-scalar-code case in AVX mode to make sure the
 		// unused-in-those-cases 3rd/4th-set indices stay nice and non-segfault-y:
 		if(j1 <= 160) {

--- a/src/radix32_wrapper_square.c
+++ b/src/radix32_wrapper_square.c
@@ -1174,6 +1174,7 @@ jump_in:	/* Entry point for all blocks but the first. */
 	  #elif !defined(USE_AVX512)	// AVX/AVX2:
 
 	  // In AVX mode need 4 sets of sincos:
+		ASSERT(k + (j1 > 128 ? 4 : 2) <= (int)(N2>>5), "radix32_wrapper_square: AVX sincos index[] overrun - FFT length too small for SIMD width");
 		// Need to explicitly 0 these for the first-blocks case in AVX mode to make sure the
 		// unused-in-those-cases 3rd/4th-set indices stay nice and non-segfault-y:
 		if(j1 <= 320) {
@@ -1265,6 +1266,7 @@ jump_in:	/* Entry point for all blocks but the first. */
 	  #elif defined(USE_AVX512)	// AVX512:
 
 	  // In AVX-512 mode need 8 sets of sincos:
+		ASSERT(k + 2 + (j1 > 128 ? 2 : 0) + (j1 > 320 ? 4 : 0) <= (int)(N2>>5), "radix32_wrapper_square: AVX-512 sincos index[] overrun - FFT length too small for SIMD width");
 		// Need to explicitly 0 these for the first-few-blocks-done-via-scalar-code case in AVX mode to make sure the
 		// unused-in-those-cases 3rd/4th-set indices stay nice and non-segfault-y:
 		if(j1 <= 320) {


### PR DESCRIPTION
## Summary

Fixes the teensy self-test segfault at `radix16_wrapper_square.c` (and the same latent bug in `radix32_wrapper_square.c`).

The AVX/AVX-512 `radix16|32_wrapper_square` routines read `RE_IM_STRIDE` (4 or 8) sincos-index sets per SIMD pass from the length-`N2/radix_final` `index[]` array. For the smallest FFT lengths, the final-block schedule leaves a partial chunk with **fewer** sets than that, so the wide-SIMD code paths read **past the end of `index[]`**:

- On non-ASan glibc the realloc slack is usually zero → garbage/identity twiddles → the length fails its self-test via excessive roundoff (silent).
- Under ASan, or when the slack lands on an unmapped page, it **segfaults** at the final `SSE2_RADIX16_CALC_TWIDDLES_LOACC` call.

Verified overruns on an AVX2 build (instrumented probe):
```
radix16-final, n=1K: index size N2/16 = 32, final pass k=30 reads index[32],[33]  (OOB)
radix32-final, n=1K: index size N2/32 = 16, overrun
radix32-final, n=2K: index size N2/32 = 32, overrun
```

This is **independent of** the `DAT_BITS` array-padding minimum-length check in `mers_mod_square`, which is disabled (`DAT_BITS = 31`) for exactly the ≤ 32K runlengths where this bites.

## Fix

These affected lengths are sub-1-Mdigit toy sizes with no production use. They compute correctly in **scalar/SSE2** builds (whose 2-set-per-pass consumption matches the schedule exactly) but not the wide-SIMD ones.

1. **Soft-skip** such lengths for AVX/AVX-512 builds — `return ERR_ASSERT` with a `WARN`, exactly matching the existing `DAT_BITS` soft-skip a few lines above. Gated on `USE_AVX`, so the exact SSE2/scalar paths are untouched and still handle 1K. Threshold is the empirical overrun boundary (`N2/radix_final ≤ 32` for AVX) with margin: require `N2/radix_final ≥ 16*RE_IM_STRIDE`.
2. **Exact bounds `ASSERT`s** at the four wide-SIMD consumption sites as a safety net, so any length that slips past the guard aborts cleanly instead of reading OOB.

## Verification

- AVX2 `-s tt`: skips 1K (both radix sets, `N2/radix_final` = 32 and 16) and the radix-32-final 2K set `32 32` (32). The 2K set `8 8 16` sits exactly *at* the AVX threshold — `N2/radix_final` = 1024/16 = 64 = `16*RE_IM_STRIDE`, not below it — so it still runs, as does everything from 3K up. No overrun, no abort anywhere in the tier.
- AVX2 `-s s`: all 24 radix-sets pass, **no assert false-fire**.
- SSE2 `-s tt`: **still computes 1K** (2/2 radix-sets) — confirms the fix doesn't regress the exact narrow-SIMD path.
- AVX-512 tree builds clean with **gcc 16.1.1** and **clang 22**.

⚠️ Build host is AVX2-only, so the AVX-512 threshold (`16*8 = 128`) is conservative and its runtime behavior is confirmable via CI / AVX-512 hardware; the safety-net asserts turn any residual miss into a clean abort rather than a segfault.

Fixes #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

