### PR TITLE
Fix 'asm operand has impossible constraints' in hand-tuned asm on ancient compilers (part of #60)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
-    continue-on-error: ${{ (!endsWith(matrix.os, '-arm') && matrix.container == 'ubuntu:16.04' && matrix.cc == 'clang') || (endsWith(matrix.os, '-arm') && (matrix.container == 'ubuntu:16.04' || matrix.container == 'ubuntu:18.04') && matrix.cc == 'clang') || (matrix.container == 'alpine:3.8' && matrix.cc == 'clang') }}
+    continue-on-error: ${{ (!endsWith(matrix.os, '-arm') && matrix.container == 'ubuntu:16.04') || (endsWith(matrix.os, '-arm') && (matrix.container == 'ubuntu:16.04' || matrix.container == 'ubuntu:18.04') && matrix.cc == 'clang') || (matrix.container == 'alpine:3.8' && (!endsWith(matrix.os, '-arm') || matrix.cc == 'clang')) }}
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
-    continue-on-error: ${{ (!endsWith(matrix.os, '-arm') && matrix.container == 'ubuntu:16.04') || (endsWith(matrix.os, '-arm') && (matrix.container == 'ubuntu:16.04' || matrix.container == 'ubuntu:18.04') && matrix.cc == 'clang') || (matrix.container == 'alpine:3.8' && (!endsWith(matrix.os, '-arm') || matrix.cc == 'clang')) }}
+    continue-on-error: ${{ (!endsWith(matrix.os, '-arm') && matrix.container == 'ubuntu:16.04' && matrix.cc == 'clang') || (endsWith(matrix.os, '-arm') && (matrix.container == 'ubuntu:16.04' || matrix.container == 'ubuntu:18.04') && matrix.cc == 'clang') || (matrix.container == 'alpine:3.8' && matrix.cc == 'clang') }}
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
-    continue-on-error: ${{ (!endsWith(matrix.os, '-arm') && matrix.container == 'ubuntu:16.04' && matrix.cc == 'clang') || (endsWith(matrix.os, '-arm') && (matrix.container == 'ubuntu:16.04' || matrix.container == 'ubuntu:18.04') && matrix.cc == 'clang') || (matrix.container == 'alpine:3.8' && matrix.cc == 'clang') }}
+    continue-on-error: ${{ (!endsWith(matrix.os, '-arm') && matrix.container == 'ubuntu:16.04') || (endsWith(matrix.os, '-arm') && (matrix.container == 'ubuntu:16.04' || matrix.container == 'ubuntu:18.04') && matrix.cc == 'clang') || (matrix.container == 'alpine:3.8' && (!endsWith(matrix.os, '-arm') || matrix.cc == 'clang')) }}
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
-    continue-on-error: ${{ (!endsWith(matrix.os, '-arm') && matrix.container == 'ubuntu:16.04') || (endsWith(matrix.os, '-arm') && (matrix.container == 'ubuntu:16.04' || matrix.container == 'ubuntu:18.04') && matrix.cc == 'clang') || (matrix.container == 'alpine:3.8' && (!endsWith(matrix.os, '-arm') || matrix.cc == 'clang')) }}
+    continue-on-error: ${{ (!endsWith(matrix.os, '-arm') && matrix.container == 'ubuntu:16.04' && matrix.cc == 'clang') || (endsWith(matrix.os, '-arm') && (matrix.container == 'ubuntu:16.04' || matrix.container == 'ubuntu:18.04') && matrix.cc == 'clang') || (matrix.container == 'alpine:3.8' && matrix.cc == 'clang') }}
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]

--- a/src/masterdefs.h
+++ b/src/masterdefs.h
@@ -45,6 +45,23 @@
 	#include <console.h>	/* Macintosh CW */
 #endif
 
+/* Task 23 / issue #60: AddressSanitizer's shadow-memory instrumentation elevates GPR pressure enough that
+the hand-tuned all-14-GPR-clobber SIMD DFT macros (e.g. SSE2_RADIX_11/13_DFT) can no longer be register-
+allocated ('operand has impossible constraints', GCC PR23200). Those macros have no non-asm fallback within
+a given SIMD build mode, so we suppress ASan *instrumentation* (not the asm) on the enclosing carry routines;
+the asm itself is unchanged, so run-time performance of normal builds is unaffected. */
+#if defined(__SANITIZE_ADDRESS__)
+	#define ATTR_NO_ASAN	__attribute__((no_sanitize_address))
+#elif defined(__has_feature)
+	#if __has_feature(address_sanitizer)	/* older Clang: no __SANITIZE_ADDRESS__ predefine */
+		#define ATTR_NO_ASAN	__attribute__((no_sanitize_address))
+	#else
+		#define ATTR_NO_ASAN
+	#endif
+#else
+	#define ATTR_NO_ASAN
+#endif
+
 #undef  EWM_DEBUG
 #define EWM_DEBUG		0	/* Set = 1 to turn on various debugging diagnostics, especially DBG_ASSERT, defined in util.c . */
 

--- a/src/masterdefs.h
+++ b/src/masterdefs.h
@@ -45,7 +45,7 @@
 	#include <console.h>	/* Macintosh CW */
 #endif
 
-/* Task 23 / issue #60: AddressSanitizer's shadow-memory instrumentation elevates GPR pressure enough that
+/* AddressSanitizer's shadow-memory instrumentation elevates GPR pressure enough that
 the hand-tuned all-14-GPR-clobber SIMD DFT macros (e.g. SSE2_RADIX_11/13_DFT) can no longer be register-
 allocated ('operand has impossible constraints', GCC PR23200). Those macros have no non-asm fallback within
 a given SIMD build mode, so we suppress ASan *instrumentation* (not the asm) on the enclosing carry routines;

--- a/src/mi64.h
+++ b/src/mi64.h
@@ -40,7 +40,7 @@ extern "C" {
 #endif
 // AddressSanitizer's shadow-memory instrumentation elevates GPR pressure enough that the hand-tuned
 // all-14-GPR-clobber inline-asm here hits 'operand has impossible constraints' (GCC PR23200); since
-// these routines have a portable-C fallback, disable the asm under ASan and use it (Task 23, issue #60):
+// these routines have a portable-C fallback, disable the asm under ASan and use it:
 #if defined(__SANITIZE_ADDRESS__)
 	#define NO_ASM
 #elif defined(__has_feature)

--- a/src/mi64.h
+++ b/src/mi64.h
@@ -38,6 +38,16 @@ extern "C" {
 #ifdef USE_GPU	// GPU-compiles disable use of x86_64 inline-asm routines:
 	#define NO_ASM
 #endif
+// AddressSanitizer's shadow-memory instrumentation elevates GPR pressure enough that the hand-tuned
+// all-14-GPR-clobber inline-asm here hits 'operand has impossible constraints' (GCC PR23200); since
+// these routines have a portable-C fallback, disable the asm under ASan and use it (Task 23, issue #60):
+#if defined(__SANITIZE_ADDRESS__)
+	#define NO_ASM
+#elif defined(__has_feature)
+	#if __has_feature(address_sanitizer)	/* older Clang: no __SANITIZE_ADDRESS__ predefine */
+		#define NO_ASM
+	#endif
+#endif
 // On x86_64, compile-time NO_ASM flag allows us to override the normally auto-set YES_ASM flag:
 #ifndef NO_ASM
   #if(defined(CPU_IS_X86_64) && defined(COMPILER_TYPE_GCC) && (OS_BITS == 64))

--- a/src/radix176_ditN_cy_dif1.c
+++ b/src/radix176_ditN_cy_dif1.c
@@ -132,7 +132,7 @@
 
 /****************/
 
-int radix176_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[], double wt1[], int si[], double base[], double baseinv[], int iter, double *fracmax, uint64 p)
+ATTR_NO_ASAN int radix176_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[], double wt1[], int si[], double base[], double baseinv[], int iter, double *fracmax, uint64 p)
 {
 /*
 !...Acronym: DWT = Discrete Weighted Transform, DIT = Decimation In Time, DIF = Decimation In Frequency
@@ -2033,7 +2033,7 @@ void radix176_dit_pass1(double a[], int n)
 	#endif
 
 	void*
-	cy176_process_chunk(void*targ)	// Thread-arg pointer *must* be cast to void and specialized inside the function
+ATTR_NO_ASAN cy176_process_chunk(void*targ)	// Thread-arg pointer *must* be cast to void and specialized inside the function
 	{
 		struct cy_thread_data_t* thread_arg = targ;	// Move to top because scalar-mode carry pointers taken directly from it
 		double *addr;

--- a/src/radix176_ditN_cy_dif1.c
+++ b/src/radix176_ditN_cy_dif1.c
@@ -2032,8 +2032,8 @@ void radix176_dit_pass1(double a[], int n)
 		#error pthreaded carry code requires GCC build!
 	#endif
 
-	void*
-ATTR_NO_ASAN cy176_process_chunk(void*targ)	// Thread-arg pointer *must* be cast to void and specialized inside the function
+	ATTR_NO_ASAN void*
+	cy176_process_chunk(void*targ)	// Thread-arg pointer *must* be cast to void and specialized inside the function
 	{
 		struct cy_thread_data_t* thread_arg = targ;	// Move to top because scalar-mode carry pointers taken directly from it
 		double *addr;

--- a/src/radix176_ditN_cy_dif1.c
+++ b/src/radix176_ditN_cy_dif1.c
@@ -132,7 +132,7 @@
 
 /****************/
 
-int radix176_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[], double wt1[], int si[], double base[], double baseinv[], int iter, double *fracmax, uint64 p)
+ATTR_NO_ASAN int radix176_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[], double wt1[], int si[], double base[], double baseinv[], int iter, double *fracmax, uint64 p)
 {
 /*
 !...Acronym: DWT = Discrete Weighted Transform, DIT = Decimation In Time, DIF = Decimation In Frequency
@@ -2094,7 +2094,7 @@ void radix176_dit_pass1(double a[], int n)
 	#endif
 
 	void
-	cy176_process_chunk(void*targ, int thread_num)	// Thread-arg pointer *must* be cast to void and specialized inside the function
+ATTR_NO_ASAN cy176_process_chunk(void*targ, int thread_num)	// Thread-arg pointer *must* be cast to void and specialized inside the function
 	{
 		struct cy_thread_data_t* thread_arg = targ;	// Move to top because scalar-mode carry pointers taken directly from it
 		double *addr;

--- a/src/radix176_ditN_cy_dif1.c
+++ b/src/radix176_ditN_cy_dif1.c
@@ -2093,8 +2093,8 @@ void radix176_dit_pass1(double a[], int n)
 		#error pthreaded carry code requires GCC build!
 	#endif
 
-	void
-ATTR_NO_ASAN cy176_process_chunk(void*targ, int thread_num)	// Thread-arg pointer *must* be cast to void and specialized inside the function
+	ATTR_NO_ASAN void
+	cy176_process_chunk(void*targ, int thread_num)	// Thread-arg pointer *must* be cast to void and specialized inside the function
 	{
 		struct cy_thread_data_t* thread_arg = targ;	// Move to top because scalar-mode carry pointers taken directly from it
 		double *addr;

--- a/src/radix208_ditN_cy_dif1.c
+++ b/src/radix208_ditN_cy_dif1.c
@@ -132,7 +132,7 @@
 
 /***************/
 
-int radix208_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[], double wt1[], int si[], double base[], double baseinv[], int iter, double *fracmax, uint64 p)
+ATTR_NO_ASAN int radix208_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[], double wt1[], int si[], double base[], double baseinv[], int iter, double *fracmax, uint64 p)
 {
 /*
 !...Acronym: DWT = Discrete Weighted Transform, DIT = Decimation In Time, DIF = Decimation In Frequency
@@ -1862,7 +1862,7 @@ void radix208_dit_pass1(double a[], int n)
 	#endif
 
 	void*
-	cy208_process_chunk(void*targ)	// Thread-arg pointer *must* be cast to void and specialized inside the function
+ATTR_NO_ASAN cy208_process_chunk(void*targ)	// Thread-arg pointer *must* be cast to void and specialized inside the function
 	{
 		struct cy_thread_data_t* thread_arg = targ;	// Move to top because scalar-mode carry pointers taken directly from it
 		double *addr;

--- a/src/radix208_ditN_cy_dif1.c
+++ b/src/radix208_ditN_cy_dif1.c
@@ -1861,8 +1861,8 @@ void radix208_dit_pass1(double a[], int n)
 		#error pthreaded carry code requires GCC build!
 	#endif
 
-	void*
-ATTR_NO_ASAN cy208_process_chunk(void*targ)	// Thread-arg pointer *must* be cast to void and specialized inside the function
+	ATTR_NO_ASAN void*
+	cy208_process_chunk(void*targ)	// Thread-arg pointer *must* be cast to void and specialized inside the function
 	{
 		struct cy_thread_data_t* thread_arg = targ;	// Move to top because scalar-mode carry pointers taken directly from it
 		double *addr;

--- a/src/radix208_ditN_cy_dif1.c
+++ b/src/radix208_ditN_cy_dif1.c
@@ -1932,8 +1932,8 @@ void radix208_dit_pass1(double a[], int n)
 		#error pthreaded carry code requires GCC build!
 	#endif
 
-	void
-ATTR_NO_ASAN cy208_process_chunk(void*targ, int thread_num)	// Thread-arg pointer *must* be cast to void and specialized inside the function
+	ATTR_NO_ASAN void
+	cy208_process_chunk(void*targ, int thread_num)	// Thread-arg pointer *must* be cast to void and specialized inside the function
 	{
 		struct cy_thread_data_t* thread_arg = targ;	// Move to top because scalar-mode carry pointers taken directly from it
 		double *addr;

--- a/src/radix208_ditN_cy_dif1.c
+++ b/src/radix208_ditN_cy_dif1.c
@@ -132,7 +132,7 @@
 
 /***************/
 
-int radix208_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[], double wt1[], int si[], double base[], double baseinv[], int iter, double *fracmax, uint64 p)
+ATTR_NO_ASAN int radix208_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[], double wt1[], int si[], double base[], double baseinv[], int iter, double *fracmax, uint64 p)
 {
 /*
 !...Acronym: DWT = Discrete Weighted Transform, DIT = Decimation In Time, DIF = Decimation In Frequency
@@ -1933,7 +1933,7 @@ void radix208_dit_pass1(double a[], int n)
 	#endif
 
 	void
-	cy208_process_chunk(void*targ, int thread_num)	// Thread-arg pointer *must* be cast to void and specialized inside the function
+ATTR_NO_ASAN cy208_process_chunk(void*targ, int thread_num)	// Thread-arg pointer *must* be cast to void and specialized inside the function
 	{
 		struct cy_thread_data_t* thread_arg = targ;	// Move to top because scalar-mode carry pointers taken directly from it
 		double *addr;

--- a/src/radix352_ditN_cy_dif1.c
+++ b/src/radix352_ditN_cy_dif1.c
@@ -134,7 +134,7 @@
 
 /****************/
 
-int radix352_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[], double wt1[], int si[], double base[], double baseinv[], int iter, double *fracmax, uint64 p)
+ATTR_NO_ASAN int radix352_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[], double wt1[], int si[], double base[], double baseinv[], int iter, double *fracmax, uint64 p)
 {
 /*
 !...Acronym: DWT = Discrete Weighted Transform, DIT = Decimation In Time, DIF = Decimation In Frequency
@@ -2746,7 +2746,7 @@ void radix352_dit_pass1(double a[], int n)
 	#endif
 
 	void*
-	cy352_process_chunk(void*targ)	// Thread-arg pointer *must* be cast to void and specialized inside the function
+ATTR_NO_ASAN cy352_process_chunk(void*targ)	// Thread-arg pointer *must* be cast to void and specialized inside the function
 	{
 		struct cy_thread_data_t* thread_arg = targ;	// Move to top because scalar-mode carry pointers taken directly from it
 		double *addr;

--- a/src/radix352_ditN_cy_dif1.c
+++ b/src/radix352_ditN_cy_dif1.c
@@ -2745,8 +2745,8 @@ void radix352_dit_pass1(double a[], int n)
 		#error pthreaded carry code requires GCC build!
 	#endif
 
-	void*
-ATTR_NO_ASAN cy352_process_chunk(void*targ)	// Thread-arg pointer *must* be cast to void and specialized inside the function
+	ATTR_NO_ASAN void*
+	cy352_process_chunk(void*targ)	// Thread-arg pointer *must* be cast to void and specialized inside the function
 	{
 		struct cy_thread_data_t* thread_arg = targ;	// Move to top because scalar-mode carry pointers taken directly from it
 		double *addr;

--- a/src/radix352_ditN_cy_dif1.c
+++ b/src/radix352_ditN_cy_dif1.c
@@ -2795,8 +2795,8 @@ void radix352_dit_pass1(double a[], int n)
 		#error pthreaded carry code requires GCC build!
 	#endif
 
-	void
-ATTR_NO_ASAN cy352_process_chunk(void*targ, int thread_num)	// Thread-arg pointer *must* be cast to void and specialized inside the function
+	ATTR_NO_ASAN void
+	cy352_process_chunk(void*targ, int thread_num)	// Thread-arg pointer *must* be cast to void and specialized inside the function
 	{
 		struct cy_thread_data_t* thread_arg = targ;	// Move to top because scalar-mode carry pointers taken directly from it
 		double *addr;

--- a/src/radix352_ditN_cy_dif1.c
+++ b/src/radix352_ditN_cy_dif1.c
@@ -134,7 +134,7 @@
 
 /****************/
 
-int radix352_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[], double wt1[], int si[], double base[], double baseinv[], int iter, double *fracmax, uint64 p)
+ATTR_NO_ASAN int radix352_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[], double wt1[], int si[], double base[], double baseinv[], int iter, double *fracmax, uint64 p)
 {
 /*
 !...Acronym: DWT = Discrete Weighted Transform, DIT = Decimation In Time, DIF = Decimation In Frequency
@@ -2796,7 +2796,7 @@ void radix352_dit_pass1(double a[], int n)
 	#endif
 
 	void
-	cy352_process_chunk(void*targ, int thread_num)	// Thread-arg pointer *must* be cast to void and specialized inside the function
+ATTR_NO_ASAN cy352_process_chunk(void*targ, int thread_num)	// Thread-arg pointer *must* be cast to void and specialized inside the function
 	{
 		struct cy_thread_data_t* thread_arg = targ;	// Move to top because scalar-mode carry pointers taken directly from it
 		double *addr;

--- a/src/radix44_ditN_cy_dif1.c
+++ b/src/radix44_ditN_cy_dif1.c
@@ -131,7 +131,7 @@
 
 /****************/
 
-int radix44_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[], double wt1[], int si[], double base[], double baseinv[], int iter, double *fracmax, uint64 p)
+ATTR_NO_ASAN int radix44_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[], double wt1[], int si[], double base[], double baseinv[], int iter, double *fracmax, uint64 p)
 {
 /*
 !...Acronym: DWT = Discrete Weighted Transform, DIT = Decimation In Time, DIF = Decimation In Frequency
@@ -1932,7 +1932,7 @@ this means that the output permutation translates (in terms of of 4 radix-11 mac
 	#endif
 
 	void*
-	cy44_process_chunk(void*targ)	// Thread-arg pointer *must* be cast to void and specialized inside the function
+ATTR_NO_ASAN cy44_process_chunk(void*targ)	// Thread-arg pointer *must* be cast to void and specialized inside the function
 	{
 		struct cy_thread_data_t* thread_arg = targ;	// Move to top because scalar-mode carry pointers taken directly from it
 		double *addr;

--- a/src/radix44_ditN_cy_dif1.c
+++ b/src/radix44_ditN_cy_dif1.c
@@ -1931,8 +1931,8 @@ this means that the output permutation translates (in terms of of 4 radix-11 mac
 		#error pthreaded carry code requires GCC build!
 	#endif
 
-	void*
-ATTR_NO_ASAN cy44_process_chunk(void*targ)	// Thread-arg pointer *must* be cast to void and specialized inside the function
+	ATTR_NO_ASAN void*
+	cy44_process_chunk(void*targ)	// Thread-arg pointer *must* be cast to void and specialized inside the function
 	{
 		struct cy_thread_data_t* thread_arg = targ;	// Move to top because scalar-mode carry pointers taken directly from it
 		double *addr;

--- a/src/radix44_ditN_cy_dif1.c
+++ b/src/radix44_ditN_cy_dif1.c
@@ -131,7 +131,7 @@
 
 /****************/
 
-int radix44_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[], double wt1[], int si[], double base[], double baseinv[], int iter, double *fracmax, uint64 p)
+ATTR_NO_ASAN int radix44_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[], double wt1[], int si[], double base[], double baseinv[], int iter, double *fracmax, uint64 p)
 {
 /*
 !...Acronym: DWT = Discrete Weighted Transform, DIT = Decimation In Time, DIF = Decimation In Frequency
@@ -1987,7 +1987,7 @@ this means that the output permutation translates (in terms of of 4 radix-11 mac
 	#endif
 
 	void
-	cy44_process_chunk(void*targ, int thread_num)	// Thread-arg pointer *must* be cast to void and specialized inside the function
+ATTR_NO_ASAN cy44_process_chunk(void*targ, int thread_num)	// Thread-arg pointer *must* be cast to void and specialized inside the function
 	{
 		struct cy_thread_data_t* thread_arg = targ;	// Move to top because scalar-mode carry pointers taken directly from it
 		double *addr;

--- a/src/radix44_ditN_cy_dif1.c
+++ b/src/radix44_ditN_cy_dif1.c
@@ -1986,8 +1986,8 @@ this means that the output permutation translates (in terms of of 4 radix-11 mac
 		#error pthreaded carry code requires GCC build!
 	#endif
 
-	void
-ATTR_NO_ASAN cy44_process_chunk(void*targ, int thread_num)	// Thread-arg pointer *must* be cast to void and specialized inside the function
+	ATTR_NO_ASAN void
+	cy44_process_chunk(void*targ, int thread_num)	// Thread-arg pointer *must* be cast to void and specialized inside the function
 	{
 		struct cy_thread_data_t* thread_arg = targ;	// Move to top because scalar-mode carry pointers taken directly from it
 		double *addr;

--- a/src/radix52_ditN_cy_dif1.c
+++ b/src/radix52_ditN_cy_dif1.c
@@ -131,7 +131,7 @@
 
 /****************/
 
-int radix52_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[], double wt1[], int si[], double base[], double baseinv[], int iter, double *fracmax, uint64 p)
+ATTR_NO_ASAN int radix52_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[], double wt1[], int si[], double base[], double baseinv[], int iter, double *fracmax, uint64 p)
 {
 /*
 !...Acronym: DWT = Discrete Weighted Transform, DIT = Decimation In Time, DIF = Decimation In Frequency
@@ -1637,7 +1637,7 @@ void radix52_dit_pass1(double a[], int n)
 	#endif
 
 	void*
-	cy52_process_chunk(void*targ)	// Thread-arg pointer *must* be cast to void and specialized inside the function
+ATTR_NO_ASAN cy52_process_chunk(void*targ)	// Thread-arg pointer *must* be cast to void and specialized inside the function
 	{
 		struct cy_thread_data_t* thread_arg = targ;	// Move to top because scalar-mode carry pointers taken directly from it
 		double *addr;

--- a/src/radix52_ditN_cy_dif1.c
+++ b/src/radix52_ditN_cy_dif1.c
@@ -1636,8 +1636,8 @@ void radix52_dit_pass1(double a[], int n)
 		#error pthreaded carry code requires GCC build!
 	#endif
 
-	void*
-ATTR_NO_ASAN cy52_process_chunk(void*targ)	// Thread-arg pointer *must* be cast to void and specialized inside the function
+	ATTR_NO_ASAN void*
+	cy52_process_chunk(void*targ)	// Thread-arg pointer *must* be cast to void and specialized inside the function
 	{
 		struct cy_thread_data_t* thread_arg = targ;	// Move to top because scalar-mode carry pointers taken directly from it
 		double *addr;

--- a/src/radix52_ditN_cy_dif1.c
+++ b/src/radix52_ditN_cy_dif1.c
@@ -1703,8 +1703,8 @@ void radix52_dit_pass1(double a[], int n)
 		#error pthreaded carry code requires GCC build!
 	#endif
 
-	void
-ATTR_NO_ASAN cy52_process_chunk(void*targ, int thread_num)	// Thread-arg pointer *must* be cast to void and specialized inside the function
+	ATTR_NO_ASAN void
+	cy52_process_chunk(void*targ, int thread_num)	// Thread-arg pointer *must* be cast to void and specialized inside the function
 	{
 		struct cy_thread_data_t* thread_arg = targ;	// Move to top because scalar-mode carry pointers taken directly from it
 		double *addr;

--- a/src/radix52_ditN_cy_dif1.c
+++ b/src/radix52_ditN_cy_dif1.c
@@ -131,7 +131,7 @@
 
 /****************/
 
-int radix52_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[], double wt1[], int si[], double base[], double baseinv[], int iter, double *fracmax, uint64 p)
+ATTR_NO_ASAN int radix52_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[], double wt1[], int si[], double base[], double baseinv[], int iter, double *fracmax, uint64 p)
 {
 /*
 !...Acronym: DWT = Discrete Weighted Transform, DIT = Decimation In Time, DIF = Decimation In Frequency
@@ -1704,7 +1704,7 @@ void radix52_dit_pass1(double a[], int n)
 	#endif
 
 	void
-	cy52_process_chunk(void*targ, int thread_num)	// Thread-arg pointer *must* be cast to void and specialized inside the function
+ATTR_NO_ASAN cy52_process_chunk(void*targ, int thread_num)	// Thread-arg pointer *must* be cast to void and specialized inside the function
 	{
 		struct cy_thread_data_t* thread_arg = targ;	// Move to top because scalar-mode carry pointers taken directly from it
 		double *addr;

--- a/src/sse2_macro_gcc64.h
+++ b/src/sse2_macro_gcc64.h
@@ -4324,7 +4324,6 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 		/* Need separate address Im parts of outputs due to literal-offsets below */\
 		"movq	%[__out0],%%rsi									\n\t	leaq	%c[__o4](%%rsi),%%r8 	\n\t"\
 		"leaq	0x40(%%rsi),%%rdi								\n\t	addq	$%c[__o4],%%r8	 	\n\t"/* out0+8*ostride */\
-		"																leaq	0x40(%%r8 ),%%r9 	\n\t"\
 		/* SSE2_RADIX4_DIT_0TWIDDLE_B(r0 ): */							/* SSE2_RADIX4_DIT_0TWIDDLE_B(r16): */\
 		"vmovaps	    (%%rax),%%zmm2							\n\t	vmovaps	    (%%r10),%%zmm10	\n\t"\
 		"vmovaps	    (%%rcx),%%zmm6							\n\t	vmovaps	    (%%r12),%%zmm14	\n\t"\
@@ -4349,16 +4348,16 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 		"vsubpd	%%zmm6,%%zmm3,%%zmm3							\n\t	vsubpd	%%zmm14,%%zmm11,%%zmm11		\n\t"\
 		"vmovaps	%%zmm0,%c[__o2](%%rsi)						\n\t	vmovaps	%%zmm8 ,%c[__o2](%%r8 )	\n\t"\
 		"vmovaps	%%zmm2,%c[__o3](%%rsi)						\n\t	vmovaps	%%zmm10,%c[__o3](%%r8 )	\n\t"\
-		"vmovaps	%%zmm1,%c[__o2](%%rdi)						\n\t	vmovaps	%%zmm9 ,%c[__o2](%%r9 )	\n\t"\
-		"vmovaps	%%zmm3,%c[__o1](%%rdi)						\n\t	vmovaps	%%zmm11,%c[__o1](%%r9 )	\n\t"\
+		"vmovaps	%%zmm1,%c[__o2](%%rdi)						\n\t	vmovaps	%%zmm9 ,%c[__o2]+0x40(%%r8 )	\n\t"\
+		"vmovaps	%%zmm3,%c[__o1](%%rdi)						\n\t	vmovaps	%%zmm11,%c[__o1]+0x40(%%r8 )	\n\t"\
 	"vfmadd132pd	%%zmm31,%%zmm0,%%zmm4						\n\t	vfmadd132pd	%%zmm31,%%zmm8 ,%%zmm12		\n\t"\
 	"vfmadd132pd	%%zmm31,%%zmm2,%%zmm7						\n\t	vfmadd132pd	%%zmm31,%%zmm10,%%zmm15		\n\t"\
 	"vfmadd132pd	%%zmm31,%%zmm1,%%zmm5						\n\t	vfmadd132pd	%%zmm31,%%zmm9 ,%%zmm13		\n\t"\
 	"vfmadd132pd	%%zmm31,%%zmm3,%%zmm6						\n\t	vfmadd132pd	%%zmm31,%%zmm11,%%zmm14		\n\t"\
 		"vmovaps	%%zmm4,        (%%rsi)						\n\t	vmovaps	%%zmm12,        (%%r8 )	\n\t"\
 		"vmovaps	%%zmm7,%c[__o1](%%rsi)						\n\t	vmovaps	%%zmm15,%c[__o1](%%r8 )	\n\t"\
-		"vmovaps	%%zmm5,        (%%rdi)						\n\t	vmovaps	%%zmm13,        (%%r9 )	\n\t"\
-		"vmovaps	%%zmm6,%c[__o3](%%rdi)						\n\t	vmovaps	%%zmm14,%c[__o3](%%r9 )	\n\t"\
+		"vmovaps	%%zmm5,        (%%rdi)						\n\t	vmovaps	%%zmm13,        0x40(%%r8 )	\n\t"\
+		"vmovaps	%%zmm6,%c[__o3](%%rdi)						\n\t	vmovaps	%%zmm14,%c[__o3]+0x40(%%r8 )	\n\t"\
 		/* SSE2_RADIX4_DIT_0TWIDDLE_B(r8 ): */						/* SSE2_RADIX4_DIT_0TWIDDLE_B(r24): */\
 		"movslq		0x10(%%r15),%%rax	\n\t	movslq		0x30(%%r15),%%r10	\n\t"/* off[4-7],[c-f] */\
 		"movslq		0x14(%%r15),%%rbx	\n\t	movslq		0x34(%%r15),%%r11	\n\t"\
@@ -4389,19 +4388,19 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 		"vsubpd	%%zmm7,%%zmm2,%%zmm2							\n\t	vsubpd	%%zmm15,%%zmm10,%%zmm10		\n\t"\
 		"vsubpd	%%zmm5,%%zmm1,%%zmm1							\n\t	vsubpd	%%zmm13,%%zmm9 ,%%zmm9 		\n\t"\
 		"vsubpd	%%zmm6,%%zmm3,%%zmm3							\n\t	vsubpd	%%zmm14,%%zmm11,%%zmm11		\n\t"\
-		"leaq	0x40(%%rsi),%%rdi								\n\t	leaq	0x40(%%r8 ),%%r9 	\n\t"\
+		"leaq	0x40(%%rsi),%%rdi								\n\t	 	\n\t"\
 		"vmovaps	%%zmm0,%c[__o2](%%rsi)						\n\t	vmovaps	%%zmm8 ,%c[__o2](%%r8 )	\n\t"\
 		"vmovaps	%%zmm2,%c[__o3](%%rsi)						\n\t	vmovaps	%%zmm10,%c[__o3](%%r8 )	\n\t"\
-		"vmovaps	%%zmm1,%c[__o2](%%rdi)						\n\t	vmovaps	%%zmm9 ,%c[__o2](%%r9 )	\n\t"\
-		"vmovaps	%%zmm3,%c[__o1](%%rdi)						\n\t	vmovaps	%%zmm11,%c[__o1](%%r9 )	\n\t"\
+		"vmovaps	%%zmm1,%c[__o2](%%rdi)						\n\t	vmovaps	%%zmm9 ,%c[__o2]+0x40(%%r8 )	\n\t"\
+		"vmovaps	%%zmm3,%c[__o1](%%rdi)						\n\t	vmovaps	%%zmm11,%c[__o1]+0x40(%%r8 )	\n\t"\
 	"vfmadd132pd	%%zmm31,%%zmm0,%%zmm4						\n\t	vfmadd132pd	%%zmm31,%%zmm8 ,%%zmm12		\n\t"\
 	"vfmadd132pd	%%zmm31,%%zmm2,%%zmm7						\n\t	vfmadd132pd	%%zmm31,%%zmm10,%%zmm15		\n\t"\
 	"vfmadd132pd	%%zmm31,%%zmm1,%%zmm5						\n\t	vfmadd132pd	%%zmm31,%%zmm9 ,%%zmm13		\n\t"\
 	"vfmadd132pd	%%zmm31,%%zmm3,%%zmm6						\n\t	vfmadd132pd	%%zmm31,%%zmm11,%%zmm14		\n\t"\
 		"vmovaps	%%zmm4,        (%%rsi)						\n\t	vmovaps	%%zmm12,        (%%r8 )	\n\t"\
 		"vmovaps	%%zmm7,%c[__o1](%%rsi)						\n\t	vmovaps	%%zmm15,%c[__o1](%%r8 )	\n\t"\
-		"vmovaps	%%zmm5,        (%%rdi)						\n\t	vmovaps	%%zmm13,        (%%r9 )	\n\t"\
-		"vmovaps	%%zmm6,%c[__o3](%%rdi)						\n\t	vmovaps	%%zmm14,%c[__o3](%%r9 )	\n\t"\
+		"vmovaps	%%zmm5,        (%%rdi)						\n\t	vmovaps	%%zmm13,        0x40(%%r8 )	\n\t"\
+		"vmovaps	%%zmm6,%c[__o3](%%rdi)						\n\t	vmovaps	%%zmm14,%c[__o3]+0x40(%%r8 )	\n\t"\
 	/******************************************************************************/\
 	/*** Now do 4 DFTs with internal twiddles on the 4*stride - separated data: ***/\
 	/******************************************************************************/\
@@ -4514,7 +4513,7 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 		,[__o2] "e" (Xo2)\
 		,[__o3] "e" (Xo3)\
 		,[__o4] "e" (Xo4)\
-		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm29","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r10","r11","r12","r13","r14","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm29","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 
@@ -9297,15 +9296,15 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 	/* Block 0: r0-3 */												/* Block 1: r8-b */\
 		"movq	%[__in0],%%rsi	\n\t	leaq %c[__i4](%%rsi),%%r8 \n\t addq $%c[__i4],%%r8 \n\t"/* __in0+[0,8]*ostride */\
 	/* Need separate address for Im parts of outputs due to literal-offsets below: */\
-		"leaq	0x20(%%rsi),%%rdi								\n\t	leaq	0x20(%%r8 ),%%r9 	\n\t"\
+		"								\n\t	leaq	0x20(%%r8 ),%%r9 	\n\t"\
 		"vmovaps	        (%%rsi),%%ymm0						\n\t	vmovaps	        (%%r8 ),%%ymm8 	\n\t"/* ar */\
-		"vmovaps	        (%%rdi),%%ymm1						\n\t	vmovaps	        (%%r9 ),%%ymm9 	\n\t"/* ai */\
+		"vmovaps	        0x20(%%rsi),%%ymm1						\n\t	vmovaps	        (%%r9 ),%%ymm9 	\n\t"/* ai */\
 		"vmovaps	%c[__i2](%%rsi),%%ymm2						\n\t	vmovaps	%c[__i2](%%r8 ),%%ymm10	\n\t"/* br */\
-		"vmovaps	%c[__i2](%%rdi),%%ymm3						\n\t	vmovaps	%c[__i2](%%r9 ),%%ymm11	\n\t"/* bi */\
+		"vmovaps	%c[__i2]+0x20(%%rsi),%%ymm3						\n\t	vmovaps	%c[__i2](%%r9 ),%%ymm11	\n\t"/* bi */\
 		"vmovaps	%c[__i1](%%rsi),%%ymm4						\n\t	vmovaps	%c[__i1](%%r8 ),%%ymm12	\n\t"/* cr */\
-		"vmovaps	%c[__i1](%%rdi),%%ymm5						\n\t	vmovaps	%c[__i1](%%r9 ),%%ymm13	\n\t"/* ci */\
+		"vmovaps	%c[__i1]+0x20(%%rsi),%%ymm5						\n\t	vmovaps	%c[__i1](%%r9 ),%%ymm13	\n\t"/* ci */\
 		"vmovaps	%c[__i3](%%rsi),%%ymm6						\n\t	vmovaps	%c[__i3](%%r8 ),%%ymm14	\n\t"/* dr */\
-		"vmovaps	%c[__i3](%%rdi),%%ymm7						\n\t	vmovaps	%c[__i3](%%r9 ),%%ymm15	\n\t"/* di */\
+		"vmovaps	%c[__i3]+0x20(%%rsi),%%ymm7						\n\t	vmovaps	%c[__i3](%%r9 ),%%ymm15	\n\t"/* di */\
 		"																movq	%[__isrt2],%%r14	\n\t"\
 		"vsubpd		%%ymm2 ,%%ymm0,%%ymm0						\n\t	vsubpd		%%ymm11,%%ymm8 ,%%ymm8 	\n\t"/* ar-bi */\
 		"vsubpd		%%ymm3 ,%%ymm1,%%ymm1						\n\t	vsubpd		%%ymm10,%%ymm9 ,%%ymm9 	\n\t"/* ai-br */\
@@ -9347,15 +9346,14 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 		"																vmovaps	%%ymm14,0x20(%%r12)	\n\t"\
 	/* Block 2: */													/* Block 3: */\
 		"addq	$%c[__i4],%%rsi	\n\t	leaq %c[__i4](%%rsi),%%r8 \n\t addq $%c[__i4],%%r8 \n\t"/* __in0+[4,c]*ostride */\
-		"leaq	0x20(%%rsi),%%rdi								\n\t	leaq	0x20(%%r8 ),%%r9 	\n\t"\
+		"								\n\t	leaq	0x20(%%r8 ),%%r9 	\n\t"\
 		"vmovaps	%c[__i1](%%rsi),%%ymm4						\n\t	vmovaps	%c[__i1](%%r8 ),%%ymm12	\n\t"\
 		"vmovaps	%c[__i3](%%rsi),%%ymm6						\n\t	vmovaps	%c[__i3](%%r8 ),%%ymm14	\n\t"\
-		"vmovaps	%c[__i1](%%rdi),%%ymm5						\n\t	vmovaps	%c[__i1](%%r9 ),%%ymm13	\n\t"\
-		"vmovaps	%c[__i3](%%rdi),%%ymm7						\n\t	vmovaps	%c[__i3](%%r9 ),%%ymm15	\n\t"\
-		"movq	%[__isrt2],%%rdi	\n\t	addq	$0x20,%%rdi	\n\t"/* cc0, from isrt2 [rdi,rsi shared by both cols] */\
+		"vmovaps	%c[__i1]+0x20(%%rsi),%%ymm5						\n\t	vmovaps	%c[__i1](%%r9 ),%%ymm13	\n\t"\
+		"vmovaps	%c[__i3]+0x20(%%rsi),%%ymm7						\n\t	vmovaps	%c[__i3](%%r9 ),%%ymm15	\n\t"\
 		"vmovaps	%%ymm4,%%ymm0								\n\t	vmovaps	%%ymm12,%%ymm8 		\n\t"\
 	/*	"vmovaps	%%ymm6,%%ymm2								\n\t	vmovaps	%%ymm14,%%ymm10		\n\t"*/\
-		"vmovaps	(%%rdi),%%ymm2								\n\t	vmovaps	0x20(%%rdi),%%ymm10	\n\t"/* Instead use these to store [c,s] */\
+		"vmovaps	0x20(%%r14),%%ymm2								\n\t	vmovaps	0x40(%%r14),%%ymm10	\n\t"/* Instead use these to store [c,s] */\
 		"vmovaps	%%ymm5,%%ymm1								\n\t	vmovaps	%%ymm13,%%ymm9 		\n\t"\
 		"vmovaps	%%ymm7,%%ymm3								\n\t	vmovaps	%%ymm15,%%ymm11		\n\t"\
 		"vmulpd		    %%ymm2 ,%%ymm4,%%ymm4					\n\t	vmulpd		    %%ymm10,%%ymm12,%%ymm12	\n\t"\
@@ -9370,18 +9368,17 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 		"vsubpd	%%ymm7,%%ymm5,%%ymm5							\n\t	vsubpd	%%ymm15,%%ymm13,%%ymm13		\n\t"\
 	"vfmadd132pd	(%%r15),%%ymm4,%%ymm6						\n\t	vfmadd132pd	(%%r15),%%ymm12,%%ymm14		\n\t"\
 	"vfmadd132pd	(%%r15),%%ymm5,%%ymm7						\n\t	vfmadd132pd	(%%r15),%%ymm13,%%ymm15		\n\t"\
-		"leaq	0x20(%%rsi),%%rdi								\n\t	leaq	0x20(%%r8 ),%%r9 	\n\t"\
+		"								\n\t	leaq	0x20(%%r8 ),%%r9 	\n\t"\
 		"vmovaps	%c[__i2](%%rsi),%%ymm2						\n\t	vmovaps	%c[__i2](%%r8 ),%%ymm10	\n\t"\
-		"vmovaps	%c[__i2](%%rdi),%%ymm3						\n\t	vmovaps	%c[__i2](%%r9 ),%%ymm11	\n\t"\
+		"vmovaps	%c[__i2]+0x20(%%rsi),%%ymm3						\n\t	vmovaps	%c[__i2](%%r9 ),%%ymm11	\n\t"\
 		"vmovaps	        (%%rsi),%%ymm0						\n\t	vmovaps	        (%%r8 ),%%ymm8 	\n\t"\
 		"vmovaps	    0x20(%%rsi),%%ymm1						\n\t	vmovaps	    0x20(%%r8 ),%%ymm9 	\n\t"\
 		"vsubpd		  %%ymm3,%%ymm2,%%ymm2						\n\t	vaddpd	%%ymm11,%%ymm10,%%ymm10	\n\t"\
 		"vaddpd	%c[__i2](%%rsi),%%ymm3,%%ymm3					\n\t	vsubpd	%c[__i2](%%r8 ),%%ymm11,%%ymm11	\n\t"\
-		"movq	%[__isrt2],%%r9 	\n\t"\
-	"vfnmadd231pd		 (%%r9),%%ymm2,%%ymm0				\n\t	vfnmadd231pd		 (%%r9),%%ymm10,%%ymm8 	\n\t"/* x = x - y.isrt2 */\
-	"vfnmadd231pd		 (%%r9),%%ymm3,%%ymm1				\n\t	vfnmadd231pd		 (%%r9),%%ymm11,%%ymm9 	\n\t"\
-	" vfmadd132pd	-0x20(%%r9),%%ymm0,%%ymm2				\n\t	 vfmadd132pd	-0x20(%%r9),%%ymm8 ,%%ymm10	\n\t"/* y = x + y.sqrt2 = x + y.isrt2 */\
-	" vfmadd132pd	-0x20(%%r9),%%ymm1,%%ymm3				\n\t	 vfmadd132pd	-0x20(%%r9),%%ymm9 ,%%ymm11	\n\t"\
+	"vfnmadd231pd		 (%%r14),%%ymm2,%%ymm0				\n\t	vfnmadd231pd		 (%%r14),%%ymm10,%%ymm8 	\n\t"/* x = x - y.isrt2 */\
+	"vfnmadd231pd		 (%%r14),%%ymm3,%%ymm1				\n\t	vfnmadd231pd		 (%%r14),%%ymm11,%%ymm9 	\n\t"\
+	" vfmadd132pd	-0x20(%%r14),%%ymm0,%%ymm2				\n\t	 vfmadd132pd	-0x20(%%r14),%%ymm8 ,%%ymm10	\n\t"/* y = x + y.sqrt2 = x + y.isrt2 */\
+	" vfmadd132pd	-0x20(%%r14),%%ymm1,%%ymm3				\n\t	 vfmadd132pd	-0x20(%%r14),%%ymm9 ,%%ymm11	\n\t"\
 	"movq	%[out0],%%r8	\n\t	movq	%[off],%%r9	\n\t"/* Load output base-address into r8 and offset-array pointer into r9 */\
 		"movslq		0x20(%%r9),%%rax	\n\t"/*        off8 */"movslq	0x30(%%r9),%%r10	\n\t"/*        offc */\
 		"movslq		0x24(%%r9),%%rbx	\n\t"/*        off9 */"movslq	0x34(%%r9),%%r11	\n\t"/*        offd */\
@@ -9418,7 +9415,7 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 		,[__two] "m" (Xtwo)\
 		,[out0] "m" (Xout0) /* output-address-octet base pointer */\
 		,[off] "m" (Xoff)	/* and pointer to uint32 array of 8 double* index offsets */\
-		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
+		: "cc","memory","rax","rbx","rcx","rdx","rsi","r8","r9","r10","r11","r12","r13","r14","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
 	);\
 	}
 
@@ -9657,8 +9654,7 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 	"prefetcht1	0x100(%%rax)	\n\t"\
 		/* Need separate address Im parts of outputs due to literal-offsets below */\
 		"movq	%[__out0],%%rsi									\n\t	leaq	%c[__o4](%%rsi),%%r8 	\n\t"\
-		"leaq	0x20(%%rsi),%%rdi								\n\t	addq	$%c[__o4],%%r8	 	\n\t"/* out0+8*ostride */\
-		"																leaq	0x20(%%r8 ),%%r9 	\n\t"\
+		"								\n\t	addq	$%c[__o4],%%r8	 	\n\t"/* out0+8*ostride */\
 		/* SSE2_RADIX4_DIT_0TWIDDLE_B(r0 ): */							/* SSE2_RADIX4_DIT_0TWIDDLE_B(r16): */\
 		"vmovaps	    (%%rax),%%ymm2							\n\t	vmovaps	    (%%r10),%%ymm10	\n\t"\
 		"vmovaps	    (%%rcx),%%ymm6							\n\t	vmovaps	    (%%r12),%%ymm14	\n\t"\
@@ -9687,16 +9683,16 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 	"movq2dq	%%mm0,%%xmm14	\n\t	vbroadcastsd	%%xmm14,%%ymm14	\n\t"/* reload 2.0 from MMX0 */\
 		"vmovaps	%%ymm0,%c[__o2](%%rsi)						\n\t	vmovaps	%%ymm8 ,%c[__o2](%%r8 )	\n\t"\
 		"vmovaps	%%ymm2,%c[__o3](%%rsi)						\n\t	vmovaps	%%ymm10,%c[__o3](%%r8 )	\n\t"\
-		"vmovaps	%%ymm1,%c[__o2](%%rdi)						\n\t	vmovaps	%%ymm9 ,%c[__o2](%%r9 )	\n\t"\
-		"vmovaps	%%ymm3,%c[__o1](%%rdi)						\n\t	vmovaps	%%ymm11,%c[__o1](%%r9 )	\n\t"\
+		"vmovaps	%%ymm1,%c[__o2]+0x20(%%rsi)						\n\t	vmovaps	%%ymm9 ,%c[__o2]+0x20(%%r8 )	\n\t"\
+		"vmovaps	%%ymm3,%c[__o1]+0x20(%%rsi)						\n\t	vmovaps	%%ymm11,%c[__o1]+0x20(%%r8 )	\n\t"\
 	"vfmadd132pd	%%ymm14,%%ymm0,%%ymm4						\n\t	vfmadd132pd	%%ymm14,%%ymm8 ,%%ymm12		\n\t"\
 	"vfmadd132pd	%%ymm14,%%ymm2,%%ymm7						\n\t	vfmadd132pd	%%ymm14,%%ymm10,%%ymm15		\n\t"\
 	"vfmadd132pd	%%ymm14,%%ymm1,%%ymm5						\n\t	vfmadd132pd	%%ymm14,%%ymm9 ,%%ymm13		\n\t"\
 	"vfmadd132pd	%%ymm14,%%ymm3,%%ymm6						\n\t	vfmadd132pd	(%%rax),%%ymm11,%%ymm14		\n\t"\
 		"vmovaps	%%ymm4,        (%%rsi)						\n\t	vmovaps	%%ymm12,        (%%r8 )	\n\t"\
 		"vmovaps	%%ymm7,%c[__o1](%%rsi)						\n\t	vmovaps	%%ymm15,%c[__o1](%%r8 )	\n\t"\
-		"vmovaps	%%ymm5,        (%%rdi)						\n\t	vmovaps	%%ymm13,        (%%r9 )	\n\t"\
-		"vmovaps	%%ymm6,%c[__o3](%%rdi)						\n\t	vmovaps	%%ymm14,%c[__o3](%%r9 )	\n\t"\
+		"vmovaps	%%ymm5,        0x20(%%rsi)						\n\t	vmovaps	%%ymm13,        0x20(%%r8 )	\n\t"\
+		"vmovaps	%%ymm6,%c[__o3]+0x20(%%rsi)						\n\t	vmovaps	%%ymm14,%c[__o3]+0x20(%%r8 )	\n\t"\
 	"prefetcht1	0x100(%%rax)									\n\tprefetcht1	0x100(%%r10)\n\t"\
 		/* SSE2_RADIX4_DIT_0TWIDDLE_B(r8 ): */						/* SSE2_RADIX4_DIT_0TWIDDLE_B(r24): */\
 		"movslq		0x10(%%r15),%%rax	\n\t	movslq		0x30(%%r15),%%r10	\n\t"/* off[4-7],[c-f] */\
@@ -9731,21 +9727,20 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 		"vsubpd	%%ymm5,%%ymm1,%%ymm1							\n\t	vsubpd	%%ymm13,%%ymm9 ,%%ymm9 		\n\t"\
 		"vsubpd	%%ymm6,%%ymm3,%%ymm3							\n\t	vsubpd	%%ymm14,%%ymm11,%%ymm11		\n\t"\
 	"prefetcht1	0x100(%%rcx)								\n\t	prefetcht1	0x100(%%r12)	\n\t"\
-		"leaq	0x20(%%rsi),%%rdi								\n\t	leaq	0x20(%%r8 ),%%r9 	\n\t"\
 	"vmovaps	%%ymm14,(%%rax) 	\n\t"/* spill ymm14 to make room for 2.0 */\
 	"movq2dq	%%mm0,%%xmm14	\n\t	vbroadcastsd	%%xmm14,%%ymm14	\n\t"/* reload 2.0 from MMX0 */\
 		"vmovaps	%%ymm0,%c[__o2](%%rsi)						\n\t	vmovaps	%%ymm8 ,%c[__o2](%%r8 )	\n\t"\
 		"vmovaps	%%ymm2,%c[__o3](%%rsi)						\n\t	vmovaps	%%ymm10,%c[__o3](%%r8 )	\n\t"\
-		"vmovaps	%%ymm1,%c[__o2](%%rdi)						\n\t	vmovaps	%%ymm9 ,%c[__o2](%%r9 )	\n\t"\
-		"vmovaps	%%ymm3,%c[__o1](%%rdi)						\n\t	vmovaps	%%ymm11,%c[__o1](%%r9 )	\n\t"\
+		"vmovaps	%%ymm1,%c[__o2]+0x20(%%rsi)						\n\t	vmovaps	%%ymm9 ,%c[__o2]+0x20(%%r8 )	\n\t"\
+		"vmovaps	%%ymm3,%c[__o1]+0x20(%%rsi)						\n\t	vmovaps	%%ymm11,%c[__o1]+0x20(%%r8 )	\n\t"\
 	"vfmadd132pd	%%ymm14,%%ymm0,%%ymm4						\n\t	vfmadd132pd	%%ymm14,%%ymm8 ,%%ymm12		\n\t"\
 	"vfmadd132pd	%%ymm14,%%ymm2,%%ymm7						\n\t	vfmadd132pd	%%ymm14,%%ymm10,%%ymm15		\n\t"\
 	"vfmadd132pd	%%ymm14,%%ymm1,%%ymm5						\n\t	vfmadd132pd	%%ymm14,%%ymm9 ,%%ymm13		\n\t"\
 	"vfmadd132pd	%%ymm14,%%ymm3,%%ymm6						\n\t	vfmadd132pd	(%%rax),%%ymm11,%%ymm14		\n\t"\
 		"vmovaps	%%ymm4,        (%%rsi)						\n\t	vmovaps	%%ymm12,        (%%r8 )	\n\t"\
 		"vmovaps	%%ymm7,%c[__o1](%%rsi)						\n\t	vmovaps	%%ymm15,%c[__o1](%%r8 )	\n\t"\
-		"vmovaps	%%ymm5,        (%%rdi)						\n\t	vmovaps	%%ymm13,        (%%r9 )	\n\t"\
-		"vmovaps	%%ymm6,%c[__o3](%%rdi)						\n\t	vmovaps	%%ymm14,%c[__o3](%%r9 )	\n\t"\
+		"vmovaps	%%ymm5,        0x20(%%rsi)						\n\t	vmovaps	%%ymm13,        0x20(%%r8 )	\n\t"\
+		"vmovaps	%%ymm6,%c[__o3]+0x20(%%rsi)						\n\t	vmovaps	%%ymm14,%c[__o3]+0x20(%%r8 )	\n\t"\
 	"prefetcht1	0x100(%%rax)	\n\t"\
 	/******************************************************************************/\
 	/*** Now do 4 DFTs with internal twiddles on the 4*stride - separated data: ***/\
@@ -9756,7 +9751,7 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 	"leaq %c[__o4](%%rax),%%rbx \n\t"/* out0+  [4*ostride] */"	\n\t	leaq	%c[__o2](%%rbx),%%r11	\n\t"\
 	"leaq %c[__o4](%%rbx),%%rcx \n\t"/* out0+2*[4*ostride] */"	\n\t	leaq	%c[__o2](%%rcx),%%r12	\n\t"\
 	"leaq %c[__o4](%%rcx),%%rdx \n\t"/* out0+3*[4*ostride] */"	\n\t	leaq	%c[__o2](%%rdx),%%r13	\n\t"\
-		"														\n\t	movq	%[__isrt2],%%rdi	\n\t"\
+		"														\n\t	movq	%[__isrt2],%%rsi	\n\t"\
 		"vmovaps	    (%%rax),%%ymm0							\n\t	vmovaps	    (%%r10),%%ymm8 	\n\t"/* ar */\
 		"vmovaps	0x20(%%rax),%%ymm1							\n\t	vmovaps	0x20(%%r10),%%ymm9 	\n\t"/* ai */\
 		"vmovaps	    (%%rbx),%%ymm2							\n\t	vmovaps	    (%%r11),%%ymm10	\n\t"/* br */\
@@ -9778,18 +9773,18 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 		"														\n\t		vsubpd	%%ymm15,%%ymm13,%%ymm13		\n\t"\
 		"vsubpd	%%ymm5,%%ymm0,%%ymm0							\n\t	vfmadd132pd	(%%r15),%%ymm12,%%ymm14		\n\t"\
 		"vsubpd	%%ymm4,%%ymm1,%%ymm1							\n\t	vfmadd132pd	(%%r15),%%ymm13,%%ymm15		\n\t"\
-		"vsubpd	%%ymm6,%%ymm2,%%ymm2							\n\t	vfnmadd231pd	(%%rdi),%%ymm12,%%ymm11		\n\t"/* x = x - y.isrt2 */\
-		"vsubpd	%%ymm7,%%ymm3,%%ymm3							\n\t	vfnmadd231pd	(%%rdi),%%ymm13,%%ymm9 		\n\t"\
-		"vmovaps	%%ymm0,    (%%rdx)							\n\t	vfnmadd231pd	(%%rdi),%%ymm14,%%ymm10		\n\t"\
-		"vmovaps	%%ymm1,0x20(%%rbx)							\n\t	vfnmadd231pd	(%%rdi),%%ymm15,%%ymm8 		\n\t"\
+		"vsubpd	%%ymm6,%%ymm2,%%ymm2							\n\t	vfnmadd231pd	(%%rsi),%%ymm12,%%ymm11		\n\t"/* x = x - y.isrt2 */\
+		"vsubpd	%%ymm7,%%ymm3,%%ymm3							\n\t	vfnmadd231pd	(%%rsi),%%ymm13,%%ymm9 		\n\t"\
+		"vmovaps	%%ymm0,    (%%rdx)							\n\t	vfnmadd231pd	(%%rsi),%%ymm14,%%ymm10		\n\t"\
+		"vmovaps	%%ymm1,0x20(%%rbx)							\n\t	vfnmadd231pd	(%%rsi),%%ymm15,%%ymm8 		\n\t"\
 		"vmovaps	%%ymm2,    (%%rcx)							\n\t		vmovaps	%%ymm11,    (%%r12)	\n\t"\
 		"vmovaps	%%ymm3,0x20(%%rcx)							\n\t		vmovaps	%%ymm9 ,0x20(%%r12)	\n\t"\
 	"vfmadd132pd	(%%r15),%%ymm0,%%ymm5						\n\t		vmovaps	%%ymm10,0x20(%%r11)	\n\t"\
 	"vfmadd132pd	(%%r15),%%ymm1,%%ymm4						\n\t		vmovaps	%%ymm8 ,    (%%r13)	\n\t"\
-	"vfmadd132pd	(%%r15),%%ymm2,%%ymm6						\n\t	vfmadd132pd	-0x20(%%rdi),%%ymm11,%%ymm12	\n\t"/* y = x + y.sqrt2 = x + y.isrt2 */\
-	"vfmadd132pd	(%%r15),%%ymm3,%%ymm7						\n\t	vfmadd132pd	-0x20(%%rdi),%%ymm9 ,%%ymm13	\n\t"\
-		"vmovaps	%%ymm5,    (%%rbx)							\n\t	vfmadd132pd	-0x20(%%rdi),%%ymm10,%%ymm14	\n\t"\
-		"vmovaps	%%ymm4,0x20(%%rdx)							\n\t	vfmadd132pd	-0x20(%%rdi),%%ymm8 ,%%ymm15	\n\t"\
+	"vfmadd132pd	(%%r15),%%ymm2,%%ymm6						\n\t	vfmadd132pd	-0x20(%%rsi),%%ymm11,%%ymm12	\n\t"/* y = x + y.sqrt2 = x + y.isrt2 */\
+	"vfmadd132pd	(%%r15),%%ymm3,%%ymm7						\n\t	vfmadd132pd	-0x20(%%rsi),%%ymm9 ,%%ymm13	\n\t"\
+		"vmovaps	%%ymm5,    (%%rbx)							\n\t	vfmadd132pd	-0x20(%%rsi),%%ymm10,%%ymm14	\n\t"\
+		"vmovaps	%%ymm4,0x20(%%rdx)							\n\t	vfmadd132pd	-0x20(%%rsi),%%ymm8 ,%%ymm15	\n\t"\
 		"vmovaps	%%ymm6,    (%%rax)							\n\t		vmovaps	%%ymm12,    (%%r10)	\n\t"\
 		"vmovaps	%%ymm7,0x20(%%rax)							\n\t		vmovaps	%%ymm13,0x20(%%r10)	\n\t"\
 		"														\n\t		vmovaps	%%ymm14,0x20(%%r13)	\n\t"\
@@ -9799,7 +9794,6 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 	"addq $%c[__o1],%%rbx\n\t"/* relative to Block 0 */"\n\t	leaq	%c[__o2](%%rbx),%%r11	\n\t"/* relative to Block 1 */\
 	"addq $%c[__o1],%%rcx								\n\t	leaq	%c[__o2](%%rcx),%%r12	\n\t"\
 	"addq $%c[__o1],%%rdx								\n\t	leaq	%c[__o2](%%rdx),%%r13	\n\t"\
-		"leaq	0x20(%%rdi),%%rsi	\n\t"/* cc0, from isrt2 [rdi,rsi shared by both cols] */\
 		"vmovaps	    (%%rdx),%%ymm0							\n\t	vmovaps	    (%%r13),%%ymm8 	\n\t"\
 		"vmovaps	0x20(%%rdx),%%ymm1							\n\t	vmovaps	0x20(%%r13),%%ymm9 	\n\t"\
 		"vmovaps	    (%%rcx),%%ymm4							\n\t	vmovaps	    (%%r12),%%ymm12	\n\t"\
@@ -9808,7 +9802,7 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 		"vmovaps	    %%ymm1 ,%%ymm3							\n\t	vmovaps	    %%ymm9 ,%%ymm11	\n\t"\
 		"vmovaps	    %%ymm4 ,%%ymm6							\n\t	vmovaps	    %%ymm12,%%ymm14	\n\t"\
 	/*	"vmovaps	    %%ymm5 ,%%ymm7							\n\t	vmovaps	    %%ymm13,%%ymm15	\n\t"*/\
-		"vmovaps	0x20(%%rsi),%%ymm7							\n\t	vmovaps	    (%%rsi),%%ymm15	\n\t"/* Instead use these to store [c,s] */\
+		"vmovaps	0x40(%%rsi),%%ymm7							\n\t	vmovaps	0x20(%%rsi),%%ymm15	\n\t"/* Instead use these to store [c,s] */\
 		"vmulpd		    %%ymm7 ,%%ymm0,%%ymm0					\n\t	vmulpd		    %%ymm15,%%ymm8 ,%%ymm8 	\n\t"\
 		"vmulpd		    %%ymm7 ,%%ymm1,%%ymm1					\n\t	vmulpd		    %%ymm15,%%ymm9 ,%%ymm9 	\n\t"\
 		"vmulpd		    %%ymm15,%%ymm4,%%ymm4					\n\t	vmulpd		    %%ymm7 ,%%ymm12,%%ymm12	\n\t"\
@@ -9829,10 +9823,10 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 		"vmovaps	0x20(%%rax),%%ymm1							\n\t	vmovaps	0x20(%%r10),%%ymm9 	\n\t"\
 		"vaddpd	0x20(%%rbx),%%ymm2,%%ymm2						\n\t	vsubpd	0x20(%%r11),%%ymm10,%%ymm10	\n\t"\
 		"vsubpd	    (%%rbx),%%ymm3,%%ymm3						\n\t	vaddpd	    (%%r11),%%ymm11,%%ymm11	\n\t"\
-	"vfnmadd231pd		 (%%rdi),%%ymm2,%%ymm0				\n\t	vfnmadd231pd		 (%%rdi),%%ymm10,%%ymm8 	\n\t"/* x = x - y.isrt2 */\
-	"vfnmadd231pd		 (%%rdi),%%ymm3,%%ymm1				\n\t	vfnmadd231pd		 (%%rdi),%%ymm11,%%ymm9 	\n\t"\
-	" vfmadd132pd	-0x20(%%rdi),%%ymm0,%%ymm2				\n\t	 vfmadd132pd	-0x20(%%rdi),%%ymm8 ,%%ymm10	\n\t"/* y = x + y.sqrt2 = x + y.isrt2 */\
-	" vfmadd132pd	-0x20(%%rdi),%%ymm1,%%ymm3				\n\t	 vfmadd132pd	-0x20(%%rdi),%%ymm9 ,%%ymm11	\n\t"\
+	"vfnmadd231pd		 (%%rsi),%%ymm2,%%ymm0				\n\t	vfnmadd231pd		 (%%rsi),%%ymm10,%%ymm8 	\n\t"/* x = x - y.isrt2 */\
+	"vfnmadd231pd		 (%%rsi),%%ymm3,%%ymm1				\n\t	vfnmadd231pd		 (%%rsi),%%ymm11,%%ymm9 	\n\t"\
+	" vfmadd132pd	-0x20(%%rsi),%%ymm0,%%ymm2				\n\t	 vfmadd132pd	-0x20(%%rsi),%%ymm8 ,%%ymm10	\n\t"/* y = x + y.sqrt2 = x + y.isrt2 */\
+	" vfmadd132pd	-0x20(%%rsi),%%ymm1,%%ymm3				\n\t	 vfmadd132pd	-0x20(%%rsi),%%ymm9 ,%%ymm11	\n\t"\
 		"vsubpd	%%ymm7,%%ymm0,%%ymm0							\n\t	vsubpd	%%ymm13,%%ymm10,%%ymm10		\n\t"\
 		"vsubpd	%%ymm6,%%ymm1,%%ymm1							\n\t	vsubpd	%%ymm12,%%ymm11,%%ymm11		\n\t"\
 		"vsubpd	%%ymm4,%%ymm2,%%ymm2							\n\t	vsubpd	%%ymm14,%%ymm8 ,%%ymm8 		\n\t"\
@@ -9860,7 +9854,7 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 		,[__o2] "e" (Xo2)\
 		,[__o3] "e" (Xo3)\
 		,[__o4] "e" (Xo4)\
-		: "cc","memory","mm0","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
+		: "cc","memory","mm0","rax","rbx","rcx","rdx","rsi","r8","r10","r11","r12","r13","r14","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
 	);\
 	}
 

--- a/src/sse2_macro_gcc64.h
+++ b/src/sse2_macro_gcc64.h
@@ -3970,15 +3970,15 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 	/* Block 0: r0-3 */												/* Block 1: r8-b */\
 		"movq	%[__in0],%%rsi	\n\t	leaq %c[__i4](%%rsi),%%r8 \n\t addq $%c[__i4],%%r8 \n\t"/* __in0+[0,8]*ostride */\
 	/* Need separate address for Im parts of outputs due to literal-offsets below: */\
-		"leaq	0x40(%%rsi),%%rdi								\n\t	leaq	0x40(%%r8 ),%%r9 	\n\t"\
+		"								\n\t	leaq	0x40(%%r8 ),%%r9 	\n\t"\
 		"vmovaps	        (%%rsi),%%zmm0						\n\t	vmovaps	        (%%r8 ),%%zmm8 	\n\t"/* ar */\
-		"vmovaps	        (%%rdi),%%zmm1						\n\t	vmovaps	        (%%r9 ),%%zmm9 	\n\t"/* ai */\
+		"vmovaps	    0x40(%%rsi),%%zmm1						\n\t	vmovaps	        (%%r9 ),%%zmm9 	\n\t"/* ai */\
 		"vmovaps	%c[__i2](%%rsi),%%zmm2						\n\t	vmovaps	%c[__i2](%%r8 ),%%zmm10	\n\t"/* br */\
-		"vmovaps	%c[__i2](%%rdi),%%zmm3						\n\t	vmovaps	%c[__i2](%%r9 ),%%zmm11	\n\t"/* bi */\
+		"vmovaps	%c[__i2]+0x40(%%rsi),%%zmm3						\n\t	vmovaps	%c[__i2](%%r9 ),%%zmm11	\n\t"/* bi */\
 		"vmovaps	%c[__i1](%%rsi),%%zmm4						\n\t	vmovaps	%c[__i1](%%r8 ),%%zmm12	\n\t"/* cr */\
-		"vmovaps	%c[__i1](%%rdi),%%zmm5						\n\t	vmovaps	%c[__i1](%%r9 ),%%zmm13	\n\t"/* ci */\
+		"vmovaps	%c[__i1]+0x40(%%rsi),%%zmm5						\n\t	vmovaps	%c[__i1](%%r9 ),%%zmm13	\n\t"/* ci */\
 		"vmovaps	%c[__i3](%%rsi),%%zmm6						\n\t	vmovaps	%c[__i3](%%r8 ),%%zmm14	\n\t"/* dr */\
-		"vmovaps	%c[__i3](%%rdi),%%zmm7						\n\t	vmovaps	%c[__i3](%%r9 ),%%zmm15	\n\t"/* di */\
+		"vmovaps	%c[__i3]+0x40(%%rsi),%%zmm7						\n\t	vmovaps	%c[__i3](%%r9 ),%%zmm15	\n\t"/* di */\
 		"																movq	%[__isrt2],%%r14	\n\t"\
 		"vsubpd		%%zmm2 ,%%zmm0,%%zmm0						\n\t	vsubpd		%%zmm11,%%zmm8 ,%%zmm8 	\n\t"/* ar-bi */\
 		"vsubpd		%%zmm3 ,%%zmm1,%%zmm1						\n\t	vsubpd		%%zmm10,%%zmm9 ,%%zmm9 	\n\t"/* ai-br */\
@@ -4020,15 +4020,14 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 		"																vmovaps	%%zmm14,0x40(%%r12)	\n\t"\
 	/* Block 2: */													/* Block 3: */\
 		"addq	$%c[__i4],%%rsi	\n\t	leaq %c[__i4](%%rsi),%%r8 \n\t addq $%c[__i4],%%r8 \n\t"/* __in0+[4,c]*ostride */\
-		"leaq	0x40(%%rsi),%%rdi								\n\t	leaq	0x40(%%r8 ),%%r9 	\n\t"\
+		"								\n\t	leaq	0x40(%%r8 ),%%r9 	\n\t"\
 		"vmovaps	%c[__i1](%%rsi),%%zmm4						\n\t	vmovaps	%c[__i1](%%r8 ),%%zmm12	\n\t"\
 		"vmovaps	%c[__i3](%%rsi),%%zmm6						\n\t	vmovaps	%c[__i3](%%r8 ),%%zmm14	\n\t"\
-		"vmovaps	%c[__i1](%%rdi),%%zmm5						\n\t	vmovaps	%c[__i1](%%r9 ),%%zmm13	\n\t"\
-		"vmovaps	%c[__i3](%%rdi),%%zmm7						\n\t	vmovaps	%c[__i3](%%r9 ),%%zmm15	\n\t"\
-		"movq	%[__isrt2],%%rdi	\n\t	addq	$0x40,%%rdi	\n\t"/* cc0, from isrt2 [rdi,rsi shared by both cols] */\
+		"vmovaps	%c[__i1]+0x40(%%rsi),%%zmm5						\n\t	vmovaps	%c[__i1](%%r9 ),%%zmm13	\n\t"\
+		"vmovaps	%c[__i3]+0x40(%%rsi),%%zmm7						\n\t	vmovaps	%c[__i3](%%r9 ),%%zmm15	\n\t"\
 		"vmovaps	%%zmm4,%%zmm0								\n\t	vmovaps	%%zmm12,%%zmm8 		\n\t"\
 	/*	"vmovaps	%%zmm6,%%zmm2								\n\t	vmovaps	%%zmm14,%%zmm10		\n\t"*/\
-		"vmovaps	(%%rdi),%%zmm2								\n\t	vmovaps	0x40(%%rdi),%%zmm10	\n\t"/* Instead use these to store [c,s] */\
+		"vmovaps	0x40(%%r14),%%zmm2								\n\t	vmovaps	0x80(%%r14),%%zmm10	\n\t"/* Instead use these to store [c,s] */\
 		"vmovaps	%%zmm5,%%zmm1								\n\t	vmovaps	%%zmm13,%%zmm9 		\n\t"\
 		"vmovaps	%%zmm7,%%zmm3								\n\t	vmovaps	%%zmm15,%%zmm11		\n\t"\
 		"vmulpd		    %%zmm2 ,%%zmm4,%%zmm4					\n\t	vmulpd		    %%zmm10,%%zmm12,%%zmm12	\n\t"\
@@ -4043,18 +4042,17 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 		"vsubpd	%%zmm7,%%zmm5,%%zmm5							\n\t	vsubpd	%%zmm15,%%zmm13,%%zmm13		\n\t"\
 	"vfmadd132pd	(%%r15),%%zmm4,%%zmm6						\n\t	vfmadd132pd	(%%r15),%%zmm12,%%zmm14		\n\t"\
 	"vfmadd132pd	(%%r15),%%zmm5,%%zmm7						\n\t	vfmadd132pd	(%%r15),%%zmm13,%%zmm15		\n\t"\
-		"leaq	0x40(%%rsi),%%rdi								\n\t	leaq	0x40(%%r8 ),%%r9 	\n\t"\
+		"								\n\t	leaq	0x40(%%r8 ),%%r9 	\n\t"\
 		"vmovaps	%c[__i2](%%rsi),%%zmm2						\n\t	vmovaps	%c[__i2](%%r8 ),%%zmm10	\n\t"\
-		"vmovaps	%c[__i2](%%rdi),%%zmm3						\n\t	vmovaps	%c[__i2](%%r9 ),%%zmm11	\n\t"\
+		"vmovaps	%c[__i2]+0x40(%%rsi),%%zmm3						\n\t	vmovaps	%c[__i2](%%r9 ),%%zmm11	\n\t"\
 		"vmovaps	        (%%rsi),%%zmm0						\n\t	vmovaps	        (%%r8 ),%%zmm8 	\n\t"\
 		"vmovaps	    0x40(%%rsi),%%zmm1						\n\t	vmovaps	    0x40(%%r8 ),%%zmm9 	\n\t"\
 		"vsubpd		  %%zmm3,%%zmm2,%%zmm2						\n\t	vaddpd	%%zmm11,%%zmm10,%%zmm10	\n\t"\
 		"vaddpd	%c[__i2](%%rsi),%%zmm3,%%zmm3					\n\t	vsubpd	%c[__i2](%%r8 ),%%zmm11,%%zmm11	\n\t"\
-		"movq	%[__isrt2],%%r9 	\n\t"\
-	"vfnmadd231pd		 (%%r9),%%zmm2,%%zmm0				\n\t	vfnmadd231pd		 (%%r9),%%zmm10,%%zmm8 	\n\t"/* x = x - y.isrt2 */\
-	"vfnmadd231pd		 (%%r9),%%zmm3,%%zmm1				\n\t	vfnmadd231pd		 (%%r9),%%zmm11,%%zmm9 	\n\t"\
-	" vfmadd132pd	-0x40(%%r9),%%zmm0,%%zmm2				\n\t	 vfmadd132pd	-0x40(%%r9),%%zmm8 ,%%zmm10	\n\t"/* y = x + y.sqrt2 = x + y.isrt2 */\
-	" vfmadd132pd	-0x40(%%r9),%%zmm1,%%zmm3				\n\t	 vfmadd132pd	-0x40(%%r9),%%zmm9 ,%%zmm11	\n\t"\
+	"vfnmadd231pd		 (%%r14),%%zmm2,%%zmm0				\n\t	vfnmadd231pd		 (%%r14),%%zmm10,%%zmm8 	\n\t"/* x = x - y.isrt2 */\
+	"vfnmadd231pd		 (%%r14),%%zmm3,%%zmm1				\n\t	vfnmadd231pd		 (%%r14),%%zmm11,%%zmm9 	\n\t"\
+	" vfmadd132pd	-0x40(%%r14),%%zmm0,%%zmm2				\n\t	 vfmadd132pd	-0x40(%%r14),%%zmm8 ,%%zmm10	\n\t"/* y = x + y.sqrt2 = x + y.isrt2 */\
+	" vfmadd132pd	-0x40(%%r14),%%zmm1,%%zmm3				\n\t	 vfmadd132pd	-0x40(%%r14),%%zmm9 ,%%zmm11	\n\t"\
 	"movq	%[out0],%%r8	\n\t	movq	%[off],%%r9	\n\t"/* Load output base-address into r8 and offset-array pointer into r9 */\
 		"movslq		0x20(%%r9),%%rax	\n\t"/*        off8 */"movslq	0x30(%%r9),%%r10	\n\t"/*        offc */\
 		"movslq		0x24(%%r9),%%rbx	\n\t"/*        off9 */"movslq	0x34(%%r9),%%r11	\n\t"/*        offd */\
@@ -4091,7 +4089,7 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 		,[__two] "m" (Xtwo)\
 		,[out0] "m" (Xout0) /* output-address-octet base pointer */\
 		,[off] "m" (Xoff)	/* and pointer to uint32 array of 8 double* index offsets */\
-		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
+		: "cc","memory","rax","rbx","rcx","rdx","rsi","r8","r9","r10","r11","r12","r13","r14","r15","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
 	);\
 	}
 

--- a/src/twopmodq.c
+++ b/src/twopmodq.c
@@ -28,7 +28,7 @@
 #endif
 // AddressSanitizer's shadow-memory instrumentation elevates GPR pressure enough that the hand-tuned
 // all-14-GPR-clobber inline-asm here hits 'operand has impossible constraints' (GCC PR23200); the
-// #ifndef YES_ASM branches provide a portable-C fallback, so disable the asm under ASan (Task 23, issue #60):
+// #ifndef YES_ASM branches provide a portable-C fallback, so disable the asm under ASan:
 #if defined(__SANITIZE_ADDRESS__)
 	#undef YES_ASM
 #elif defined(__has_feature)

--- a/src/twopmodq.c
+++ b/src/twopmodq.c
@@ -26,6 +26,16 @@
 #if(defined(CPU_IS_X86_64) && defined(COMPILER_TYPE_GCC) && (OS_BITS == 64))
 	#define YES_ASM
 #endif
+// AddressSanitizer's shadow-memory instrumentation elevates GPR pressure enough that the hand-tuned
+// all-14-GPR-clobber inline-asm here hits 'operand has impossible constraints' (GCC PR23200); the
+// #ifndef YES_ASM branches provide a portable-C fallback, so disable the asm under ASan (Task 23, issue #60):
+#if defined(__SANITIZE_ADDRESS__)
+	#undef YES_ASM
+#elif defined(__has_feature)
+	#if __has_feature(address_sanitizer)	/* older Clang: no __SANITIZE_ADDRESS__ predefine */
+		#undef YES_ASM
+	#endif
+#endif
 
 #if FAC_DEBUG
 #error !!!

--- a/src/twopmodq64_test.c
+++ b/src/twopmodq64_test.c
@@ -29,6 +29,16 @@
 #if(defined(CPU_IS_X86_64) && defined(COMPILER_TYPE_GCC) && (OS_BITS == 64))
 	#define YES_ASM
 #endif
+// AddressSanitizer's shadow-memory instrumentation elevates GPR pressure enough that the hand-tuned
+// all-14-GPR-clobber inline-asm here hits 'operand has impossible constraints' (GCC PR23200); the
+// non-YES_ASM code paths (in twopmodq.c) provide a portable-C fallback, so disable under ASan (Task 23, issue #60):
+#if defined(__SANITIZE_ADDRESS__)
+	#undef YES_ASM
+#elif defined(__has_feature)
+	#if __has_feature(address_sanitizer)	/* older Clang: no __SANITIZE_ADDRESS__ predefine */
+		#undef YES_ASM
+	#endif
+#endif
 
 #ifdef __CUDACC__
 

--- a/src/twopmodq64_test.c
+++ b/src/twopmodq64_test.c
@@ -31,7 +31,7 @@
 #endif
 // AddressSanitizer's shadow-memory instrumentation elevates GPR pressure enough that the hand-tuned
 // all-14-GPR-clobber inline-asm here hits 'operand has impossible constraints' (GCC PR23200); the
-// non-YES_ASM code paths (in twopmodq.c) provide a portable-C fallback, so disable under ASan (Task 23, issue #60):
+// non-YES_ASM code paths (in twopmodq.c) provide a portable-C fallback, so disable under ASan:
 #if defined(__SANITIZE_ADDRESS__)
 	#undef YES_ASM
 #elif defined(__has_feature)


### PR DESCRIPTION
## Summary

Part of #60 (older GCC/Clang support). This fixes the `error: 'asm' operand has impossible constraints or there are not enough registers` failures in the hand-tuned inline-asm — the sub-item of #60 that bites **ancient compilers** (reproduced on GCC 5.4 / Ubuntu 16.04 at `-flto`) as well as AddressSanitizer builds on modern toolchains.

### Root cause
Several hand-tuned asm blocks clobber **all 14** non-reserved x86-64 GPRs (`rax`–`r15` minus `rsp`/`rbp`) while also taking memory operands. That leaves the register allocator no spare GPR to hold an operand's base address, which is fatal the moment register pressure is elevated from another source — a weak old allocator (GCC 5.4 at `-flto`) or ASan's shadow-memory / fake-stack base register (modern GCC & Clang). It's the long-documented GCC PR23200 limitation; the in-tree "use -O1 or higher" note does not cover these cases.

### Fix, split by whether a non-asm fallback exists

- **`dft_macro.c`'s radix-16 `SSE2_RADIX16_DIT_0TWIDDLE` / `DIF_0TWIDDLE`** — the only site that fails under **GCC 5.4 `-flto`**, and it has no fallback, so the register pressure is fixed in the asm itself: the Im-part output "shadow" registers (`rdi = rsi + off`, `r9 = r8 + off`, `off` = 0x20 for AVX2 / 0x40 for AVX-512) are folded into compile-time displacement operands, and the isrt2/cc0 trig pointers are re-homed. **The AVX2/FMA3 `DIF`+`DIT` and the AVX-512 `DIT` are fixed in commit 1; the AVX-512 `DIF` is fixed in commit 4** (see below — it is not needed by the toolchains this PR targets, but GCC 13 allocates differently and does need it). The "Linux old" CI job compiles every SIMD mode on the old toolchains; AVX-512 was the last mode still failing there. The folds are pure address rewrites — e.g. `%c[__oN](%%r9)` == `%c[__oN]+0x40(%%r8)` since `r9 == r8+0x40` — so the emitted vector math is unchanged: residues are byte-identical (verified on the radix-256 DFT path) and it benchmarks no slower.

- **`mi64.c` / `twopmodq.c` / `twopmodq64_test.c` integer-modmul asm** — fails **only under ASan** (verified: UBSan-only, TSan-only, and plain GCC 5.4 all compile fine) and already has a `YES_ASM`-gated portable-C fallback, so `YES_ASM` is disabled under `__SANITIZE_ADDRESS__`. The shipping asm is left **completely unchanged**.

- **`SSE2_RADIX_11/13_DFT` (radix 44/52/176/208/352)** — fails only under ASan, has no in-SIMD-mode fallback, and genuinely uses all 14 GPRs, so the enclosing carry routines are annotated with `no_sanitize_address`. This suppresses ASan *instrumentation* only; the asm is untouched.

ASan detection uses a nested `#if defined(__SANITIZE_ADDRESS__)` / `#elif defined(__has_feature)` form — the flat `|| (defined(__has_feature) && __has_feature(...))` form makes GCC 5.4's preprocessor choke, since it lacks `__has_feature` and tokenizes it as `0(0)`.

### Verification
- Whole tree compiles clean under `-fsanitize=address,undefined` in **every** SIMD mode (SSE2/AVX/AVX2/AVX512) — was 7+ `impossible constraints` errors (plus more masked, since GCC reports only the first per compile).
- **GCC 5.4.0 (Ubuntu 16.04) `-O3` and `-O3 -flto`, every SIMD mode**, link and run `./Mlucas -s tt` with correct residues — reproduced with the exact CI invocation (`bash makemake.sh use_hwloc <MODE>`). The AVX-512 LTO build previously failed to link at `dft_macro.c:5050/5101`.
- `./Mlucas -s tt` residues, and the radix-256 DFT path (`-fftlen 1024 -radset 2`, which exercises both edited macros), are byte-identical to before the change.
- `-fftlen 1024` radix-256 benchmark is at or below baseline in every trial (the DFT edits only remove address-setup instructions).

Performance of normal (non-sanitizer) builds is unaffected: the integer-asm and radix-11/13 asm are byte-for-byte unchanged, and the radix-16 DFT edits change only address computation, not the vector arithmetic.

### The AVX-512 `SSE2_RADIX16_DIF_0TWIDDLE`, needed by newer GCC

`src/sse2_macro_gcc64.h` holds one copy of each radix-16 `_0TWIDDLE` macro per SIMD mode. Commit 1
edits the AVX-512 **DIT** (line ~4311) and both AVX2 variants (~9206 / ~9635). The AVX-512 **DIF**
(~3880) was left alone, and on GCC 5.4 and GCC 11.4 that is fine — neither allocator needs the extra
register there.

GCC 13.3 does. Per-TU compile sweep of all 101 `src/*.c` with
`-DUSE_AVX512 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mavx512vl -mfma -O3 -fsanitize=address`:

| tree | TUs failing `'asm' operand has impossible constraints` |
|---|---|
| `main` | 13 |
| this PR through commit 3 | 3 — `radix48`, `radix144`, `radix1008`, all at `sse2_macro_gcc64.h:3882` |
| **+ commit 4** | **0 / 101** |

Same treatment as commit 1 applies to the AVX2 DIF: drop the `rdi` shadow pointer holding
`rsi + 0x40` and fold the offset into each displacement; reuse `r14`, which already holds `isrt2` and
is written exactly once in the macro, for the two `cc0` accesses `rdi` was carrying and for a
redundant `isrt2` reload into `r9`. `rdi` then comes off the clobber list — 14 GPRs to 13.

With commit 4, the other SIMD modes are also clean on GCC 13.3 under ASan: **avx2 0/101, avx 0/101,
sse2 0/101**. The SSE2 / AVX-sans-FMA / ARM copies of these macros are deliberately untouched — they
are not broken on any tested compiler, and editing hot asm without a demonstrated failure is not worth
the risk.

**GCC 11.4 is 0/101 both with and without commit 4**, so this is forward-compatibility for newer
compilers rather than a correction to the original work.

Residues are unchanged. Non-sanitizer AVX-512 builds before and after commit 4, under Intel SDE:

```
 48K {48,32,16}   p=1001467  Res64=6B1C76AB5431FDA4  AvgMaxErr=0.232575335
144K {144,16,32}  p=2934479  Res64=1B90A27301980A3A  AvgMaxErr=0.240325056
```

identical to each other and to the `MersVec[]` reference values, `AvgMaxErr` matching to every digit.
As a control that these cases really do execute the edited macro, injecting a single wrong
displacement into it turns the 48K run into `ERR_ROUNDOFF` with no residue emitted at all.

### Out of scope (pre-existing CI failures, not regressions from this PR)
These jobs fail identically on `main`:
- **old-Clang AVX-512** (`unknown register name 'xmm30'`) — a *different* #60 sub-item (old Clang rejecting AVX-512 extended registers xmm16-31), addressed by the `try_avx512_asm` probe in the build-portability PR #67, not here.
- **Windows** (`factor.c`/`factor.h` implicit-declaration / `USE_FMADD` `#error`) — pre-existing, unrelated files.

