### PR TITLE
CI: drop the Linux-old continue-on-error mask now that old-toolchain builds are fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,6 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
-    continue-on-error: ${{ (!endsWith(matrix.os, '-arm') && matrix.container == 'ubuntu:16.04') || (endsWith(matrix.os, '-arm') && (matrix.container == 'ubuntu:16.04' || matrix.container == 'ubuntu:18.04') && matrix.cc == 'clang') || (matrix.container == 'alpine:3.8' && (!endsWith(matrix.os, '-arm') || matrix.cc == 'clang')) }}
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]


### PR DESCRIPTION
The `Mlucas Linux old` job marks several ancient-toolchain matrix cells `continue-on-error` (allowed-to-fail). Those failures are addressed across three PRs, so this PR removes the mask and lets those jobs gate real regressions. The masked cells, and what fixes each:

- **arm clang** (alpine:3.8 / ubuntu:16.04 / ubuntu:18.04): `-mcpu=native` → `-march=native` → no-arch-flag probe fallback — #67
- **x86 gcc** (ubuntu:16.04 / alpine:3.8): `-flto` `'asm' operand has impossible constraints` fix — #71
- **x86 clang** (ubuntu:16.04 extended-register names; alpine:3.8 AVX-512 ER `vrcp28pd`): AVX-512 capability probe + skip — #73

With all three merged, no `Linux old` cell is expected to fail, so the `continue-on-error` line is removed entirely.

> [!IMPORTANT]
> #67 merged on 2026-07-23; **#71 and #73 are still open, and this must merge after both.** Until they land, this PR's CI will be red — their cells still fail on current `main`. Once merged, if any cell still fails, a minimal mask can be restored here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
