### PR TITLE
Bound the preferred-FFT cfg scan to <= 2x default FFT length (fixes #36)

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -1328,7 +1328,7 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 				a "not found" (dum == 0) result above, i.e. request a fresh timing self-test
 				for the requested length rather than trusting the out-of-range entry.
 				*/
-				snprintf(cbuf,STR_MAX_LEN*2,"WARN: get_preferred_fft_radix returned out-of-range FFT length: asked for %u, returned %u, packed value= %#8X -- ignoring and treating as 'not found' in '%s'; please rerun the self-test for this length.\n", kblocks, i, dum, CONFIGFILE);
+				snprintf(cbuf,sizeof(cbuf),"WARN: get_preferred_fft_radix returned out-of-range FFT length: asked for %u, returned %u, packed value= %#8X -- ignoring and treating as 'not found' in '%s'; please rerun the self-test for this length.\n", kblocks, i, dum, CONFIGFILE);
 				fprintf(stderr, "%s", cbuf);
 				if (!fft_length || MODULUS_TYPE == MODULUS_TYPE_MERSENNE) return ERR_RUN_SELFTEST_FORLENGTH + (kblocks << 8);
 			}

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -1328,7 +1328,7 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 				a "not found" (dum == 0) result above, i.e. request a fresh timing self-test
 				for the requested length rather than trusting the out-of-range entry.
 				*/
-				sprintf(cbuf,"WARN: get_preferred_fft_radix returned out-of-range FFT length: asked for %u, returned %u, packed value= %#8X -- ignoring and treating as 'not found' in '%s'; please rerun the self-test for this length.\n", kblocks, i, dum, CONFIGFILE);
+				snprintf(cbuf,STR_MAX_LEN*2,"WARN: get_preferred_fft_radix returned out-of-range FFT length: asked for %u, returned %u, packed value= %#8X -- ignoring and treating as 'not found' in '%s'; please rerun the self-test for this length.\n", kblocks, i, dum, CONFIGFILE);
 				fprintf(stderr, "%s", cbuf);
 				if (!fft_length || MODULUS_TYPE == MODULUS_TYPE_MERSENNE) return ERR_RUN_SELFTEST_FORLENGTH + (kblocks << 8);
 			}

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -1322,8 +1322,15 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 			/* Only allow lengths that are <= 2x default */
 			if( !(i >= kblocks && i <= (kblocks<<1) ) )
 			{
-				sprintf(cbuf,"Call to get_preferred_fft_radix returns out-of-range FFT length: asked for %u, returned %u, packed value= %#8X\n", kblocks, i, dum);
-				ASSERT(0, cbuf);
+				/* Should be unreachable now that get_preferred_fft_radix() itself bounds its
+				cfg-file scan to i <= 2*kblocks, but guard defensively rather than asserting/
+				crashing on a stale or hand-edited cfg file: warn and treat this the same as
+				a "not found" (dum == 0) result above, i.e. request a fresh timing self-test
+				for the requested length rather than trusting the out-of-range entry.
+				*/
+				sprintf(cbuf,"WARN: get_preferred_fft_radix returned out-of-range FFT length: asked for %u, returned %u, packed value= %#8X -- ignoring and treating as 'not found' in '%s'; please rerun the self-test for this length.\n", kblocks, i, dum, CONFIGFILE);
+				fprintf(stderr, "%s", cbuf);
+				if (!fft_length || MODULUS_TYPE == MODULUS_TYPE_MERSENNE) return ERR_RUN_SELFTEST_FORLENGTH + (kblocks << 8);
 			}
 			else	/* If length acceptable, extract the FFT-radix data encoded and populate the NRADICES and RADIX_VEC[] globals */
 			{

--- a/src/get_preferred_fft_radix.c
+++ b/src/get_preferred_fft_radix.c
@@ -111,9 +111,13 @@ uint32	get_preferred_fft_radix(uint32 kblocks)
 			any line not of that form is ignored, thus allowing pretty much any common comment-format: */
 			if(sscanf(g_in_line, "%d", &i) == 1) {
 				/* Consider any entry with an FFT length >= target, which further contains
-				a per-iteration timing datum in the form 'msec/iter = [float arg]' in non-exponential form:
+				a per-iteration timing datum in the form 'msec/iter = [float arg]' in non-exponential form.
+				Cap the upper end at 2x the target length: the caller (Mlucas.c) refuses to accept any
+				returned length beyond that, so scanning past it can only waste time chasing a cfg entry
+				we'd have to reject anyway - or worse, cause us to skip a usable smaller "better" entry
+				within range in favor of an out-of-range one that later trips the caller's ASSERT:
 				*/
-				if((i >= kblocks) && (char_addr = strstr(g_in_line, "msec/iter =")) != 0) {
+				if((i >= kblocks) && (i <= (kblocks<<1)) && (char_addr = strstr(g_in_line, "msec/iter =")) != 0) {
 					/* Stores whether we found an entry for the requested FFT length
 					(whether that proves to have the best timing for lengths >= kblocks or not): */
 					if(i == kblocks) {


### PR DESCRIPTION
Fixes #36.

## Problem (#36)

`get_preferred_fft_radix()` scans `mlucas.cfg` for any entry whose FFT length is `>= kblocks` (the target), with **no upper bound**. The caller in `ernstMain` (`Mlucas.c`) then asserts the returned length is `<= 2*kblocks`. So when the fastest cfg entry for an exponent is more than 2× the default FFT length, the scan returns it and the caller aborts:

```
Assertion `0' failed: Call to get_preferred_fft_radix returns out-of-range FFT length: asked for 16, returned 40
```

## Fix

- **Producer** (`get_preferred_fft_radix.c`): cap the scan at `i <= (kblocks<<1)`, so an out-of-range entry is never selected — and an in-range entry is not passed over in favour of an out-of-range one. The 2× cap itself is unchanged.
- **Caller** (`Mlucas.c`), defense-in-depth: instead of a bare `ASSERT`, warn and fall back to the existing "not found" path (request a fresh timing self-test for the length), so a stale or hand-edited cfg degrades gracefully rather than crashing.

## Verification (AVX2)

Crafted a cfg containing an entry `> 2×` the default length for M341749 (16K default):
- **unpatched**: aborts with the exact #36 assert (`out-of-range FFT length: asked for 16, returned 40`);
- **patched**: skips the oversized entry and runs normally.

`-s tiny` self-test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)