### PR TITLE
Accept the valid MSW==0 carryout boundary in convert_res_bytewise_FP (fixes #19)

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -5738,7 +5738,7 @@ int 	convert_res_bytewise_FP(const uint8 ui64_arr_in[], double a[], int n, const
 	fold below handles that correctly, same as the MS word < 0 case.): */
 	if(cy && (a[j1] > 0 || cy != +1))
 	{
-		snprintf(cbuf, STR_MAX_LEN*2, "convert_res_bytewise_FP: Illegal combination of nonzero carry = %" PRId64 ", most sig. word = %20.4f\n", cy, a[j1]);
+		snprintf(cbuf, sizeof(cbuf), "convert_res_bytewise_FP: Illegal combination of nonzero carry = %" PRId64 ", most sig. word = %20.4f\n", cy, a[j1]);
 		ASSERT(0, cbuf);
 	}
 

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -5732,10 +5732,13 @@ int 	convert_res_bytewise_FP(const uint8 ui64_arr_in[], double a[], int n, const
 	into the LS word of the residue (e.g. if cy = 1, this amounts to subtracting
 	the modulus from the positive-digit form to get the balanced-digit form):
 	*/
-	/* Should have carryout of +1 Iff MS word < 0; otherwise expect 0 carry: */
-	if(cy && (a[j1] >= 0 || cy != +1))
+	/* Should have carryout of +1 Iff MS word <= 0; otherwise expect 0 carry.
+	(MS word == 0 with cy = 1 is a legal boundary case: an all-1-bits top digit
+	plus an incoming carry of 1 normalizes to 0 with carryout 1 - the a[0] += cy
+	fold below handles that correctly, same as the MS word < 0 case.): */
+	if(cy && (a[j1] > 0 || cy != +1))
 	{
-		sprintf(cbuf, "convert_res_bytewise_FP: Illegal combination of nonzero carry = %" PRId64 ", most sig. word = %20.4f\n", cy, a[j]);
+		snprintf(cbuf, STR_MAX_LEN*2, "convert_res_bytewise_FP: Illegal combination of nonzero carry = %" PRId64 ", most sig. word = %20.4f\n", cy, a[j1]);
 		ASSERT(0, cbuf);
 	}
 


### PR DESCRIPTION
Fixes #19.

### Problem (#19)

`convert_res_bytewise_FP()` rejected a **legal** balanced-representation carry-propagation state with an assert, killing an otherwise-healthy run.

After the per-digit normalize step:

```c
itmp += cy;                       // add carry-in from previous digit
if(itmp > 0) {
    cy   = itmp >> bits[ii];
    itmp -= (cy << bits[ii]);
    if(itmp > (base[ii]>>1)) { itmp -= base[ii]; cy += 1; }
} else cy = 0;
a[j1] = (double)itmp;
```

an all-ones top digit (`base[ii]-1`) plus an incoming carry of 1 gives `itmp = base[ii]` → `cy = 1`, `itmp` reduced to exactly **0**, no rebalance. That is an ordinary carry ripple — not corruption — with probability ≈ `2^-bits_per_word` per conversion, which is why only oversized-FFT runs ever tripped it. But the guard

```c
if(cy && (a[j1] >= 0 || cy != +1)) ASSERT(0, ...);
```

treated `MSW == 0 && cy == 1` as illegal and aborted.

Compounding it, the diagnostic printed `a[j]` — where `j` has run past the last data word (an unused pad element) rather than indexing the top digit that was actually tested. That produced the spurious "most sig. word = -21.0000" and "= 16448.0000" readings reported in #19, which misdirected the entire diagnosis thread.

### Fix

- Relax the comparison `a[j1] >= 0` → `a[j1] > 0`, admitting exactly the legal `cy == +1 && a[j1] == 0` state while keeping `cy == +1 && a[j1] > 0` (top digit failed to reduce → `cy` genuinely bogus) illegal. `cy == +1 && a[j1] < 0` was already legal.
- Print `a[j1]` (the padded index of the top digit actually tested) instead of `a[j]`.
- Make that diagnostic bounded: `sprintf(cbuf, ...)` → `snprintf(cbuf, STR_MAX_LEN*2, ...)`. `cbuf` is `char cbuf[STR_MAX_LEN*3]`, so the bound is conservative but safe.

The fold-in that follows (`a[0] += cy` Mersenne / `a[0] -= cy` Fermat) uses **only** `cy`, so it handles `a[j1] == 0` identically to the already-legal `a[j1] < 0` case — the relaxation is provably safe and no wider than the one new state.

### Sibling-path audit

- The **Mersenne** and **Fermat/right-angle** input loops both fall through to this one shared assert block, so the single fix covers both (verified: the Fermat branch contains no separate copy of the guard).
- The reverse-direction `convert_res_FP_bytewise()` uses a different pre-scanned-sign borrow scheme with no equivalent zero-with-carry boundary, and its diagnostic prints no array element — audited and left unchanged.

### Verification

Full carry-arithmetic trace of the normalize loop confirms `cy==+1 && a[j1]==0` is reachable and valid, and that the fold-in is index-independent. Builds clean via `makemake.sh avx2`.
