### PR TITLE
Set CPU affinity on Windows and macOS (fixes #59)

### DIFF
--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -71,6 +71,25 @@ me at: heber.tomer@gmail.com
 
 #ifdef MULTITHREAD	// Wrap contents of this file in flag (set via platform.h at compile time) ensuring no code built in unthreaded mode
 
+// MacOS has its own versions of these, in /usr/include/X11/Xthreads.h:
+static void * xmalloc(size_t len) {
+	void *ptr = malloc(len);
+	if (ptr == NULL) {
+		printf("failed to allocate %u bytes\n", (uint32)len);
+		exit(-1);
+	}
+	return ptr;
+}
+
+static void * xcalloc(size_t num, size_t len) {
+	void *ptr = calloc(num, len);
+	if (ptr == NULL) {
+		printf("failed to calloc %u bytes\n", (uint32)(num * len));
+		exit(-1);
+	}
+	return ptr;
+}
+
 	#define THREAD_POOL_DEBUG	0
 
 	#if THREAD_POOL_DEBUG
@@ -259,7 +278,7 @@ me at: heber.tomer@gmail.com
 	 * @param data Contains a pointer to the startup data
 	 * @return NULL.
 	 */
-	#if defined(__GNUC__) && (__GNUC__ > 4 || __GNUC__ == 4 && __GNUC_MINOR__>1)
+	#if defined(__GNUC__) && (__GNUC__ > 4 || __GNUC__ == 4 && __GNUC_MINOR__>1) && defined(CPU_IS_X86)
 
 	/* gcc on win32 needs to force 16-byte stack alignment on
 	   thread entry, as this exceeds what windows may provide; see
@@ -270,8 +289,8 @@ me at: heber.tomer@gmail.com
 	#endif
 	static void *worker_thr_routine(void *data)
 	{
-		char cbuf[STR_MAX_LEN*2];
 	#if INCLUDE_HWLOC
+		char cbuf[STR_MAX_LEN*2];
 		char str[80];
 	#endif
 		struct thread_init *init = (struct thread_init *)data;

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -65,6 +65,12 @@ me at: heber.tomer@gmail.com
 #include "threadpool.h"
 #include "util.h"	// This is to get (or not) <hwloc.h>
 
+#if defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
+	#include <windows.h>	// Windows CPU-affinity API: SetThreadAffinityMask()/GetCurrentThread(). MinGW is mapped to
+				// OS_TYPE_LINUX by platform.h but has no sched_setaffinity(), so its Windows build takes this
+				// Win32 path too (MinGW-w64 provides the full Win32 API).
+#endif
+
 #ifdef MULTITHREAD	// Wrap contents of this file in flag (set via platform.h at compile time) ensuring no code built in unthreaded mode
 
 	#define THREAD_POOL_DEBUG	0
@@ -383,37 +389,63 @@ me at: heber.tomer@gmail.com
 
 	 #endif	// INCLUDE_HWLOC?
 
-	#elif defined(OS_TYPE_MACOSX)
+	#elif defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
 
-		thread_t thr = mach_thread_self();
-		thread_extended_policy_data_t epolicy;
-		epolicy.timeshare = FALSE;
-		kern_return_t ret = thread_policy_set(
-			thr, THREAD_EXTENDED_POLICY,
-			(thread_policy_t) &epolicy, THREAD_EXTENDED_POLICY_COUNT);
-		if (ret != KERN_SUCCESS) {
-			printf("thread_policy_set returned %d", ret);
-			exit(-1);
-		}
+		// Windows hard affinity: pin the current worker thread to logical core i. This covers BOTH the
+		// native-Windows toolchain (OS_TYPE_WINDOWS) and MinGW (which platform.h maps to OS_TYPE_LINUX but
+		// which has no sched_setaffinity() and so is deliberately excluded from the Linux branch above) -
+		// MinGW-w64 provides SetThreadAffinityMask(), so this is the affinity path for the MSYS2/MinGW
+		// Windows builds the CI actually produces.
+		// SetThreadAffinityMask() takes a single DWORD_PTR bitmask, so this simple form only
+		// addresses logical CPUs 0-63 within the thread's current processor group. Systems with
+		// >64 logical CPUs are partitioned into 64-CPU processor groups and require the
+		// SetThreadGroupAffinity()/GROUP_AFFINITY API, which we do not handle here; the
+		// single-mask form matches the model used elsewhere in the Windows port.
+		int i,errcode;
 
-		thread_affinity_policy_data_t apolicy;
-		int i = my_id % pool->num_of_cores;	// get cpu mask using sequential thread ID modulo #available cores
+		i = my_id % pool->num_of_cores;	// get cpu index using sequential thread ID modulo #available cores
 		i = mi64_ith_set_bit(CORE_SET, i+1, MAX_CORES>>6);	// Remember, [i]th-bit index in arglist is *unit* offset, i.e. must be in [1,MAX_CORES]
 		if(i < 0) {
 			fprintf(stderr,"Affinity CORE_SET does not have a [%u]th set bit!",my_id % pool->num_of_cores);
 			ASSERT(0, "Aborting.");
 		}
-		apolicy.affinity_tag = i; // set affinity tag
 	  #if THREAD_POOL_DEBUG
-		printf("Setting CPU = %d affinity of worker thread id %u, mach_id = %u\n", i, my_id, thr);
+		printf("Setting affinity of worker thread id %u to logical core %d\n", my_id, i);
 	  #endif
+		// SetThreadAffinityMask returns the thread's previous affinity mask, or 0 on failure:
+		errcode = (SetThreadAffinityMask(GetCurrentThread(), (DWORD_PTR)1 << i) == 0);
+		if (errcode) {
+			fprintf(stderr,"SetThreadAffinityMask failed with error %lu.\nINFO: Your run should be OK, but leaving up to OS to manage thread/core binding.\n", (unsigned long)GetLastError());
+		}
 
-		ret = thread_policy_set(
-			thr, THREAD_EXTENDED_POLICY,
-			(thread_policy_t) &apolicy, THREAD_EXTENDED_POLICY_COUNT);
-		if (ret != KERN_SUCCESS) {
-			printf("thread_policy_set returned %d", ret);
-			exit(-1);
+	#elif defined(OS_TYPE_MACOSX)
+
+		// macOS provides NO hard CPU pinning. The only documented mechanism is the Mach
+		// THREAD_AFFINITY_POLICY, which sets an *affinity tag*: an advisory hint asking the
+		// scheduler to co-locate (share an L2 cache domain) all threads that carry the same tag.
+		// It does NOT pin a thread to a specific logical core and gives no placement guarantee.
+		// We use each worker's logical-core index as its tag so every worker gets a distinct
+		// grouping hint, mirroring the *intent* of the hard pin done on Linux/FreeBSD/Windows.
+		// NOTE: This is advisory only. Apple Silicon (arm64) effectively ignores affinity tags,
+		// so on those machines this call is a no-op.
+		mach_port_t thr = pthread_mach_thread_np(pthread_self());
+		thread_affinity_policy_data_t apolicy;
+		int i,ret;
+
+		i = my_id % pool->num_of_cores;	// get cpu index using sequential thread ID modulo #available cores
+		i = mi64_ith_set_bit(CORE_SET, i+1, MAX_CORES>>6);	// Remember, [i]th-bit index in arglist is *unit* offset, i.e. must be in [1,MAX_CORES]
+		if(i < 0) {
+			fprintf(stderr,"Affinity CORE_SET does not have a [%u]th set bit!",my_id % pool->num_of_cores);
+			ASSERT(0, "Aborting.");
+		}
+		apolicy.affinity_tag = i;	// advisory affinity tag - NOT a hard core pin (see comment above)
+	  #if THREAD_POOL_DEBUG
+		printf("Setting affinity tag = %d of worker thread id %u, mach port = %u\n", i, my_id, (unsigned)thr);
+	  #endif
+		ret = thread_policy_set(thr, THREAD_AFFINITY_POLICY,
+			(thread_policy_t)&apolicy, THREAD_AFFINITY_POLICY_COUNT);
+		if (ret != KERN_SUCCESS) {	// warn but do not abort - affinity is advisory on macOS:
+			fprintf(stderr,"thread_policy_set(THREAD_AFFINITY_POLICY) returned %d.\nINFO: macOS affinity is advisory only, leaving up to OS to manage thread/core binding.\n", ret);
 		}
 
 	#else

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -345,6 +345,30 @@ me at: heber.tomer@gmail.com
 
 	#elif defined(OS_TYPE_LINUX) && !defined(__MINGW32__)
 
+	  #if 0
+	  /*
+		// This is the affinity API tied to pthread library ... interestingly, it's less portable than the
+		// Linux system-centric one below; e.g. GCC gives "error: unknown type name ‘cpuset_t’; did you mean ‘cpu_set_t’?" here:
+		int i,errcode;
+		cpuset_t *cset;
+		pthread_t pth;
+
+		cset = cpuset_create();
+		if (cset == NULL) {
+			err(EXIT_FAILURE, "cpuset_create");
+		}
+		i = my_id % pool->num_of_cores;	// get cpu mask using sequential thread ID modulo #available cores
+		cpuset_set((cpuid_t)i, cset);
+
+		pth = pthread_self();
+		errcode = pthread_setaffinity_np(pth, cpuset_size(cset), cset);
+		if (errcode) {
+			perror("pthread_setaffinity_np");
+		}
+		cpuset_destroy(cset);
+	  */
+	  #else
+
 		cpu_set_t cpu_set;
 		int i,errcode;
 		pid_t thread_id = syscall (SYS_gettid);
@@ -369,6 +393,7 @@ me at: heber.tomer@gmail.com
 			perror("sched_setaffinity");
 			fprintf(stderr,"INFO: Your run should be OK, but leaving up to OS to manage thread/core binding.\n");
 		}
+	  #endif
 
 	#elif defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
 

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -66,9 +66,7 @@ me at: heber.tomer@gmail.com
 #include "util.h"	// This is to get (or not) <hwloc.h>
 
 #if defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
-	#include <windows.h>	// Windows CPU-affinity API: SetThreadAffinityMask()/GetCurrentThread(). MinGW is mapped to
-				// OS_TYPE_LINUX by platform.h but has no sched_setaffinity(), so its Windows build takes this
-				// Win32 path too (MinGW-w64 provides the full Win32 API).
+	#include <windows.h>	// Windows CPU-affinity API (SetThreadGroupAffinity() etc.); see the affinity branch below.
 #endif
 
 #ifdef MULTITHREAD	// Wrap contents of this file in flag (set via platform.h at compile time) ensuring no code built in unthreaded mode
@@ -283,7 +281,45 @@ me at: heber.tomer@gmail.com
 		task_control_t *task;
 
 		// Set CPU affinity masks of the thread:
-	#ifdef __OpenBSD__
+	#if INCLUDE_HWLOC
+
+		// hwloc gives portable, OS-agnostic hard affinity, so when Mlucas is built with -DINCLUDE_HWLOC (the
+		// makemake.sh 'use_hwloc' option) we use it on every platform - this is what makes the v21 '-core' option
+		// work on Windows and macOS as well as on Linux/*BSD, and it also handles Windows >64-CPU processor groups
+		// internally. The per-OS native-API branches below are the fallback used only in non-hwloc builds.
+		int i;
+
+		i = my_id % pool->num_of_cores;
+		i = mi64_ith_set_bit(CORE_SET, i+1, MAX_CORES>>6);	// Remember, [i]th-bit index in arglist is *unit* offset, i.e. must be in [1,MAX_CORES]
+		if(i < 0) {
+			fprintf(stderr,"Affinity CORE_SET does not have a [%u]th set bit!",my_id % pool->num_of_cores);
+			ASSERT(0, "Aborting.");
+		}
+
+	  if(HWLOC_AFFINITY) {	// Global, declared in Mdata.h, defined in Mlucas.c, set in util.c::host_init()
+		hwloc_bitmap_t cpuset = hwloc_bitmap_alloc();
+		hwloc_obj_t obj = hwloc_get_obj_by_type(hw_topology, HWLOC_OBJ_PU, i);
+		if (obj) {
+			hwloc_bitmap_or(cpuset, cpuset, obj->cpuset);
+		} else {
+			snprintf(cbuf,STR_MAX_LEN*2,"[hwloc] Error: HWLOC_OBJ_PU[%u] not found.\n",i);
+			fprintf(stderr,"%s",cbuf);
+		}
+		// Set affinity to specified logical CPUs:
+		if (hwloc_set_cpubind(hw_topology, cpuset, HWLOC_CPUBIND_THREAD)) {
+			int error = errno;
+			hwloc_bitmap_snprintf (str, sizeof (str), cpuset);
+			snprintf(cbuf,STR_MAX_LEN*2,"[hwloc] Warning: Unable to set affinity to cpuset %s: %s; leaving up to OS to manage thread/core binding.\n",str,strerror(error));
+			fprintf(stderr,"%s",cbuf);
+	  #if THREAD_POOL_DEBUG
+		} else {
+			printf("[hwloc] tid = %d: HWLOC_OBJ_PU[%u], lidx %u, pidx %u: setaffinity[%d] to cpuset %s\n",my_id,i,obj->logical_index,obj->os_index,str);
+	  #endif
+		}
+		hwloc_bitmap_free(cpuset);
+	  }	// HWLOC_AFFINITY = True?
+
+	#elif defined(__OpenBSD__)
 
 	  #warning OpenBSD has no user-affinity-setting support ... affinity-setting is up to the OS.
 
@@ -309,30 +345,6 @@ me at: heber.tomer@gmail.com
 
 	#elif defined(OS_TYPE_LINUX) && !defined(__MINGW32__)
 
-	  #if 0
-	  /*
-		// This is the affinity API tied to pthread library ... interestingly, it's less portable than the
-		// Linux system-centric one below; e.g. GCC gives "error: unknown type name ‘cpuset_t’; did you mean ‘cpu_set_t’?" here:
-		int i,errcode;
-		cpuset_t *cset;
-		pthread_t pth;
-
-		cset = cpuset_create();
-		if (cset == NULL) {
-			err(EXIT_FAILURE, "cpuset_create");
-		}
-		i = my_id % pool->num_of_cores;	// get cpu mask using sequential thread ID modulo #available cores
-		cpuset_set((cpuid_t)i, cset);
-
-		pth = pthread_self();
-		errcode = pthread_setaffinity_np(pth, cpuset_size(cset), cset);
-		if (errcode) {
-			perror("pthread_setaffinity_np");
-		}
-		cpuset_destroy(cset);
-	  */
-	  #else
-
 		cpu_set_t cpu_set;
 		int i,errcode;
 		pid_t thread_id = syscall (SYS_gettid);
@@ -346,34 +358,6 @@ me at: heber.tomer@gmail.com
 			fprintf(stderr,"Affinity CORE_SET does not have a [%u]th set bit!",my_id % pool->num_of_cores);
 			ASSERT(0, "Aborting.");
 		}
-
-	 #if INCLUDE_HWLOC
-
-	  if(HWLOC_AFFINITY) {	// Global, declared in Mdata.h, defined in Mlucas.c, set in util.c::host_init()
-		hwloc_bitmap_t cpuset = hwloc_bitmap_alloc();
-		hwloc_obj_t obj = hwloc_get_obj_by_type(hw_topology, HWLOC_OBJ_PU, i);
-		if (obj) {
-			hwloc_bitmap_or(cpuset, cpuset, obj->cpuset);
-		} else {
-			snprintf(cbuf,STR_MAX_LEN*2,"[hwloc] Error: HWLOC_OBJ_PU[%u] not found.\n",i);
-			fprintf(stderr,"%s",cbuf);
-		}
-		// Set affinity to specified logical CPUs:
-		if (hwloc_set_cpubind(hw_topology, cpuset, HWLOC_CPUBIND_THREAD)) {
-			int error = errno;
-			hwloc_bitmap_snprintf (str, sizeof (str), cpuset);
-			snprintf(cbuf,STR_MAX_LEN*2,"[hwloc] Warning: Unable to set affinity to cpuset %s: %s; leaving up to OS to manage thread/core binding.\n",str,strerror(error));
-			fprintf(stderr,"%s",cbuf);
-	  #if THREAD_POOL_DEBUG
-		} else {
-			printf("[hwloc] tid = %d: HWLOC_OBJ_PU[%u], lidx %u, pidx %u: setaffinity[%d] to cpuset %s\n",my_id,i,obj->logical_index,obj->os_index,str);
-	  #endif
-		}
-		hwloc_bitmap_free(cpuset);
-	  }	// HWLOC_AFFINITY = True?
-
-	 #else	// INCLUDE_HWLOC = False:
-
 		// get cpu mask using sequential thread ID modulo #available cores in runtime-specified affinity set:
 		CPU_ZERO (&cpu_set);
 		CPU_SET(i, &cpu_set);
@@ -385,23 +369,17 @@ me at: heber.tomer@gmail.com
 			perror("sched_setaffinity");
 			fprintf(stderr,"INFO: Your run should be OK, but leaving up to OS to manage thread/core binding.\n");
 		}
-	  #endif
-
-	 #endif	// INCLUDE_HWLOC?
 
 	#elif defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
 
-		// Windows hard affinity: pin the current worker thread to logical core i. This covers BOTH the
-		// native-Windows toolchain (OS_TYPE_WINDOWS) and MinGW (which platform.h maps to OS_TYPE_LINUX but
-		// which has no sched_setaffinity() and so is deliberately excluded from the Linux branch above) -
-		// MinGW-w64 provides SetThreadAffinityMask(), so this is the affinity path for the MSYS2/MinGW
-		// Windows builds the CI actually produces.
-		// SetThreadAffinityMask() takes a single DWORD_PTR bitmask, so this simple form only
-		// addresses logical CPUs 0-63 within the thread's current processor group. Systems with
-		// >64 logical CPUs are partitioned into 64-CPU processor groups and require the
-		// SetThreadGroupAffinity()/GROUP_AFFINITY API, which we do not handle here; the
-		// single-mask form matches the model used elsewhere in the Windows port.
-		int i,errcode;
+		// Windows hard affinity (non-hwloc fallback): pin the current worker thread to logical core i. This
+		// covers BOTH the native-Windows toolchain (OS_TYPE_WINDOWS) and MinGW (which platform.h maps to
+		// OS_TYPE_LINUX but which has no sched_setaffinity() and so is deliberately excluded from the Linux
+		// branch above) - MinGW-w64 provides the Win32 affinity API. We use SetThreadGroupAffinity() rather
+		// than the simpler SetThreadAffinityMask() so systems with >64 logical CPUs - which Windows partitions
+		// into 64-CPU processor groups - are handled: logical core i maps to group (i>>6), bit (i&63).
+		int i;
+		GROUP_AFFINITY grp_aff = {0};
 
 		i = my_id % pool->num_of_cores;	// get cpu index using sequential thread ID modulo #available cores
 		i = mi64_ith_set_bit(CORE_SET, i+1, MAX_CORES>>6);	// Remember, [i]th-bit index in arglist is *unit* offset, i.e. must be in [1,MAX_CORES]
@@ -410,12 +388,13 @@ me at: heber.tomer@gmail.com
 			ASSERT(0, "Aborting.");
 		}
 	  #if THREAD_POOL_DEBUG
-		printf("Setting affinity of worker thread id %u to logical core %d\n", my_id, i);
+		printf("Setting affinity of worker thread id %u to logical core %d (group %u, bit %u)\n", my_id, i, (unsigned)(i>>6), (unsigned)(i&63));
 	  #endif
-		// SetThreadAffinityMask returns the thread's previous affinity mask, or 0 on failure:
-		errcode = (SetThreadAffinityMask(GetCurrentThread(), (DWORD_PTR)1 << i) == 0);
-		if (errcode) {
-			fprintf(stderr,"SetThreadAffinityMask failed with error %lu.\nINFO: Your run should be OK, but leaving up to OS to manage thread/core binding.\n", (unsigned long)GetLastError());
+		grp_aff.Group = (WORD)(i >> 6);
+		grp_aff.Mask  = (KAFFINITY)1 << (i & 63);
+		// SetThreadGroupAffinity returns 0 (FALSE) on failure:
+		if (SetThreadGroupAffinity(GetCurrentThread(), &grp_aff, NULL) == 0) {
+			fprintf(stderr,"SetThreadGroupAffinity failed with error %lu.\nINFO: Your run should be OK, but leaving up to OS to manage thread/core binding.\n", (unsigned long)GetLastError());
 		}
 
 	#elif defined(OS_TYPE_MACOSX)

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -302,14 +302,14 @@ me at: heber.tomer@gmail.com
 		if (obj) {
 			hwloc_bitmap_or(cpuset, cpuset, obj->cpuset);
 		} else {
-			snprintf(cbuf,STR_MAX_LEN*2,"[hwloc] Error: HWLOC_OBJ_PU[%u] not found.\n",i);
+			snprintf(cbuf,sizeof(cbuf),"[hwloc] Error: HWLOC_OBJ_PU[%u] not found.\n",i);
 			fprintf(stderr,"%s",cbuf);
 		}
 		// Set affinity to specified logical CPUs:
 		if (hwloc_set_cpubind(hw_topology, cpuset, HWLOC_CPUBIND_THREAD)) {
 			int error = errno;
 			hwloc_bitmap_snprintf (str, sizeof (str), cpuset);
-			snprintf(cbuf,STR_MAX_LEN*2,"[hwloc] Warning: Unable to set affinity to cpuset %s: %s; leaving up to OS to manage thread/core binding.\n",str,strerror(error));
+			snprintf(cbuf,sizeof(cbuf),"[hwloc] Warning: Unable to set affinity to cpuset %s: %s; leaving up to OS to manage thread/core binding.\n",str,strerror(error));
 			fprintf(stderr,"%s",cbuf);
 	  #if THREAD_POOL_DEBUG
 		} else {

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -66,7 +66,7 @@ me at: heber.tomer@gmail.com
 #include "util.h"	// This is to get (or not) <hwloc.h>
 
 #if defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
-	#include <windows.h>	// Windows CPU-affinity API (SetThreadGroupAffinity() etc.); see the affinity branch below.
+	#include <windows.h>	// Windows CPU-affinity API; see the affinity branch below for details.
 #endif
 
 #ifdef MULTITHREAD	// Wrap contents of this file in flag (set via platform.h at compile time) ensuring no code built in unthreaded mode

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -71,25 +71,6 @@ me at: heber.tomer@gmail.com
 
 #ifdef MULTITHREAD	// Wrap contents of this file in flag (set via platform.h at compile time) ensuring no code built in unthreaded mode
 
-// MacOS has its own versions of these, in /usr/include/X11/Xthreads.h:
-static void * xmalloc(size_t len) {
-	void *ptr = malloc(len);
-	if (ptr == NULL) {
-		printf("failed to allocate %u bytes\n", (uint32)len);
-		exit(-1);
-	}
-	return ptr;
-}
-
-static void * xcalloc(size_t num, size_t len) {
-	void *ptr = calloc(num, len);
-	if (ptr == NULL) {
-		printf("failed to calloc %u bytes\n", (uint32)(num * len));
-		exit(-1);
-	}
-	return ptr;
-}
-
 	#define THREAD_POOL_DEBUG	0
 
 	#if THREAD_POOL_DEBUG
@@ -105,7 +86,7 @@ static void * xcalloc(size_t num, size_t len) {
 		queue->tail = 0;
 		queue->num_tasks = 0;
 		queue->max_tasks = max_tasks;
-		queue->tasks = (void **)xcalloc(max_tasks, sizeof(void *));
+		queue->tasks = (void **)CALLOC(max_tasks, sizeof(void *));
 	}
 
 	static void threadpool_queue_free(struct threadpool_queue *queue)
@@ -653,7 +634,7 @@ static void * xcalloc(size_t num, size_t len) {
 				thread_control_t *t)
 	{
 		int i;
-		struct threadpool *pool = (struct threadpool *)xcalloc(1,
+		struct threadpool *pool = (struct threadpool *)CALLOC(1,
 						sizeof(struct threadpool));
 
 		/* Init the mutex and cond vars. */
@@ -686,7 +667,7 @@ static void * xcalloc(size_t num, size_t len) {
 		/* Init the queues. */
 		threadpool_queue_init(&(pool->tasks_queue), queue_size);
 		threadpool_queue_init(&(pool->free_tasks_queue), queue_size);
-		pool->tasks = (task_control_t *)xmalloc(queue_size *
+		pool->tasks = (task_control_t *)MALLOC(queue_size *
 						sizeof(task_control_t));
 
 		/* Add all the free tasks to the free tasks queue. */

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -350,6 +350,30 @@ me at: heber.tomer@gmail.com
 
 	#elif defined(OS_TYPE_LINUX) && !defined(__MINGW32__)
 
+	  #if 0
+	  /*
+		// This is the affinity API tied to pthread library ... interestingly, it's less portable than the
+		// Linux system-centric one below; e.g. GCC gives "error: unknown type name ‘cpuset_t’; did you mean ‘cpu_set_t’?" here:
+		int i,errcode;
+		cpuset_t *cset;
+		pthread_t pth;
+
+		cset = cpuset_create();
+		if (cset == NULL) {
+			err(EXIT_FAILURE, "cpuset_create");
+		}
+		i = my_id % pool->num_of_cores;	// get cpu mask using sequential thread ID modulo #available cores
+		cpuset_set((cpuid_t)i, cset);
+
+		pth = pthread_self();
+		errcode = pthread_setaffinity_np(pth, cpuset_size(cset), cset);
+		if (errcode) {
+			perror("pthread_setaffinity_np");
+		}
+		cpuset_destroy(cset);
+	  */
+	  #else
+
 		cpu_set_t cpu_set;
 		int i,errcode;
 		pid_t thread_id = syscall (SYS_gettid);
@@ -374,6 +398,7 @@ me at: heber.tomer@gmail.com
 			perror("sched_setaffinity");
 			fprintf(stderr,"INFO: Your run should be OK, but leaving up to OS to manage thread/core binding.\n");
 		}
+	  #endif
 
 	#elif defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
 

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -307,14 +307,14 @@ me at: heber.tomer@gmail.com
 		if (obj) {
 			hwloc_bitmap_or(cpuset, cpuset, obj->cpuset);
 		} else {
-			snprintf(cbuf,STR_MAX_LEN*2,"[hwloc] Error: HWLOC_OBJ_PU[%u] not found.\n",i);
+			snprintf(cbuf,sizeof(cbuf),"[hwloc] Error: HWLOC_OBJ_PU[%u] not found.\n",i);
 			fprintf(stderr,"%s",cbuf);
 		}
 		// Set affinity to specified logical CPUs:
 		if (hwloc_set_cpubind(hw_topology, cpuset, HWLOC_CPUBIND_THREAD)) {
 			int error = errno;
 			hwloc_bitmap_snprintf (str, sizeof (str), cpuset);
-			snprintf(cbuf,STR_MAX_LEN*2,"[hwloc] Warning: Unable to set affinity to cpuset %s: %s; leaving up to OS to manage thread/core binding.\n",str,strerror(error));
+			snprintf(cbuf,sizeof(cbuf),"[hwloc] Warning: Unable to set affinity to cpuset %s: %s; leaving up to OS to manage thread/core binding.\n",str,strerror(error));
 			fprintf(stderr,"%s",cbuf);
 	  #if THREAD_POOL_DEBUG
 		} else {

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -66,9 +66,7 @@ me at: heber.tomer@gmail.com
 #include "util.h"	// This is to get (or not) <hwloc.h>
 
 #if defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
-	#include <windows.h>	// Windows CPU-affinity API: SetThreadAffinityMask()/GetCurrentThread(). MinGW is mapped to
-				// OS_TYPE_LINUX by platform.h but has no sched_setaffinity(), so its Windows build takes this
-				// Win32 path too (MinGW-w64 provides the full Win32 API).
+	#include <windows.h>	// Windows CPU-affinity API (SetThreadGroupAffinity() etc.); see the affinity branch below.
 #endif
 
 #ifdef __FreeBSD__
@@ -288,7 +286,45 @@ me at: heber.tomer@gmail.com
 		task_control_t *task;
 
 		// Set CPU affinity masks of the thread:
-	#ifdef __OpenBSD__
+	#if INCLUDE_HWLOC
+
+		// hwloc gives portable, OS-agnostic hard affinity, so when Mlucas is built with -DINCLUDE_HWLOC (the
+		// makemake.sh 'use_hwloc' option) we use it on every platform - this is what makes the v21 '-core' option
+		// work on Windows and macOS as well as on Linux/*BSD, and it also handles Windows >64-CPU processor groups
+		// internally. The per-OS native-API branches below are the fallback used only in non-hwloc builds.
+		int i;
+
+		i = my_id % pool->num_of_cores;
+		i = mi64_ith_set_bit(CORE_SET, i+1, MAX_CORES>>6);	// Remember, [i]th-bit index in arglist is *unit* offset, i.e. must be in [1,MAX_CORES]
+		if(i < 0) {
+			fprintf(stderr,"Affinity CORE_SET does not have a [%u]th set bit!",my_id % pool->num_of_cores);
+			ASSERT(0, "Aborting.");
+		}
+
+	  if(HWLOC_AFFINITY) {	// Global, declared in Mdata.h, defined in Mlucas.c, set in util.c::host_init()
+		hwloc_bitmap_t cpuset = hwloc_bitmap_alloc();
+		hwloc_obj_t obj = hwloc_get_obj_by_type(hw_topology, HWLOC_OBJ_PU, i);
+		if (obj) {
+			hwloc_bitmap_or(cpuset, cpuset, obj->cpuset);
+		} else {
+			snprintf(cbuf,STR_MAX_LEN*2,"[hwloc] Error: HWLOC_OBJ_PU[%u] not found.\n",i);
+			fprintf(stderr,"%s",cbuf);
+		}
+		// Set affinity to specified logical CPUs:
+		if (hwloc_set_cpubind(hw_topology, cpuset, HWLOC_CPUBIND_THREAD)) {
+			int error = errno;
+			hwloc_bitmap_snprintf (str, sizeof (str), cpuset);
+			snprintf(cbuf,STR_MAX_LEN*2,"[hwloc] Warning: Unable to set affinity to cpuset %s: %s; leaving up to OS to manage thread/core binding.\n",str,strerror(error));
+			fprintf(stderr,"%s",cbuf);
+	  #if THREAD_POOL_DEBUG
+		} else {
+			printf("[hwloc] tid = %d: HWLOC_OBJ_PU[%u], lidx %u, pidx %u: setaffinity[%d] to cpuset %s\n",my_id,i,obj->logical_index,obj->os_index,str);
+	  #endif
+		}
+		hwloc_bitmap_free(cpuset);
+	  }	// HWLOC_AFFINITY = True?
+
+	#elif defined(__OpenBSD__)
 
 	  #warning OpenBSD has no user-affinity-setting support ... affinity-setting is up to the OS.
 
@@ -314,30 +350,6 @@ me at: heber.tomer@gmail.com
 
 	#elif defined(OS_TYPE_LINUX) && !defined(__MINGW32__)
 
-	  #if 0
-	  /*
-		// This is the affinity API tied to pthread library ... interestingly, it's less portable than the
-		// Linux system-centric one below; e.g. GCC gives "error: unknown type name ‘cpuset_t’; did you mean ‘cpu_set_t’?" here:
-		int i,errcode;
-		cpuset_t *cset;
-		pthread_t pth;
-
-		cset = cpuset_create();
-		if (cset == NULL) {
-			err(EXIT_FAILURE, "cpuset_create");
-		}
-		i = my_id % pool->num_of_cores;	// get cpu mask using sequential thread ID modulo #available cores
-		cpuset_set((cpuid_t)i, cset);
-
-		pth = pthread_self();
-		errcode = pthread_setaffinity_np(pth, cpuset_size(cset), cset);
-		if (errcode) {
-			perror("pthread_setaffinity_np");
-		}
-		cpuset_destroy(cset);
-	  */
-	  #else
-
 		cpu_set_t cpu_set;
 		int i,errcode;
 		pid_t thread_id = syscall (SYS_gettid);
@@ -351,34 +363,6 @@ me at: heber.tomer@gmail.com
 			fprintf(stderr,"Affinity CORE_SET does not have a [%u]th set bit!",my_id % pool->num_of_cores);
 			ASSERT(0, "Aborting.");
 		}
-
-	 #if INCLUDE_HWLOC
-
-	  if(HWLOC_AFFINITY) {	// Global, declared in Mdata.h, defined in Mlucas.c, set in util.c::host_init()
-		hwloc_bitmap_t cpuset = hwloc_bitmap_alloc();
-		hwloc_obj_t obj = hwloc_get_obj_by_type(hw_topology, HWLOC_OBJ_PU, i);
-		if (obj) {
-			hwloc_bitmap_or(cpuset, cpuset, obj->cpuset);
-		} else {
-			snprintf(cbuf,STR_MAX_LEN*2,"[hwloc] Error: HWLOC_OBJ_PU[%u] not found.\n",i);
-			fprintf(stderr,"%s",cbuf);
-		}
-		// Set affinity to specified logical CPUs:
-		if (hwloc_set_cpubind(hw_topology, cpuset, HWLOC_CPUBIND_THREAD)) {
-			int error = errno;
-			hwloc_bitmap_snprintf (str, sizeof (str), cpuset);
-			snprintf(cbuf,STR_MAX_LEN*2,"[hwloc] Warning: Unable to set affinity to cpuset %s: %s; leaving up to OS to manage thread/core binding.\n",str,strerror(error));
-			fprintf(stderr,"%s",cbuf);
-	  #if THREAD_POOL_DEBUG
-		} else {
-			printf("[hwloc] tid = %d: HWLOC_OBJ_PU[%u], lidx %u, pidx %u: setaffinity[%d] to cpuset %s\n",my_id,i,obj->logical_index,obj->os_index,str);
-	  #endif
-		}
-		hwloc_bitmap_free(cpuset);
-	  }	// HWLOC_AFFINITY = True?
-
-	 #else	// INCLUDE_HWLOC = False:
-
 		// get cpu mask using sequential thread ID modulo #available cores in runtime-specified affinity set:
 		CPU_ZERO (&cpu_set);
 		CPU_SET(i, &cpu_set);
@@ -390,23 +374,17 @@ me at: heber.tomer@gmail.com
 			perror("sched_setaffinity");
 			fprintf(stderr,"INFO: Your run should be OK, but leaving up to OS to manage thread/core binding.\n");
 		}
-	  #endif
-
-	 #endif	// INCLUDE_HWLOC?
 
 	#elif defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
 
-		// Windows hard affinity: pin the current worker thread to logical core i. This covers BOTH the
-		// native-Windows toolchain (OS_TYPE_WINDOWS) and MinGW (which platform.h maps to OS_TYPE_LINUX but
-		// which has no sched_setaffinity() and so is deliberately excluded from the Linux branch above) -
-		// MinGW-w64 provides SetThreadAffinityMask(), so this is the affinity path for the MSYS2/MinGW
-		// Windows builds the CI actually produces.
-		// SetThreadAffinityMask() takes a single DWORD_PTR bitmask, so this simple form only
-		// addresses logical CPUs 0-63 within the thread's current processor group. Systems with
-		// >64 logical CPUs are partitioned into 64-CPU processor groups and require the
-		// SetThreadGroupAffinity()/GROUP_AFFINITY API, which we do not handle here; the
-		// single-mask form matches the model used elsewhere in the Windows port.
-		int i,errcode;
+		// Windows hard affinity (non-hwloc fallback): pin the current worker thread to logical core i. This
+		// covers BOTH the native-Windows toolchain (OS_TYPE_WINDOWS) and MinGW (which platform.h maps to
+		// OS_TYPE_LINUX but which has no sched_setaffinity() and so is deliberately excluded from the Linux
+		// branch above) - MinGW-w64 provides the Win32 affinity API. We use SetThreadGroupAffinity() rather
+		// than the simpler SetThreadAffinityMask() so systems with >64 logical CPUs - which Windows partitions
+		// into 64-CPU processor groups - are handled: logical core i maps to group (i>>6), bit (i&63).
+		int i;
+		GROUP_AFFINITY grp_aff = {0};
 
 		i = my_id % pool->num_of_cores;	// get cpu index using sequential thread ID modulo #available cores
 		i = mi64_ith_set_bit(CORE_SET, i+1, MAX_CORES>>6);	// Remember, [i]th-bit index in arglist is *unit* offset, i.e. must be in [1,MAX_CORES]
@@ -415,12 +393,13 @@ me at: heber.tomer@gmail.com
 			ASSERT(0, "Aborting.");
 		}
 	  #if THREAD_POOL_DEBUG
-		printf("Setting affinity of worker thread id %u to logical core %d\n", my_id, i);
+		printf("Setting affinity of worker thread id %u to logical core %d (group %u, bit %u)\n", my_id, i, (unsigned)(i>>6), (unsigned)(i&63));
 	  #endif
-		// SetThreadAffinityMask returns the thread's previous affinity mask, or 0 on failure:
-		errcode = (SetThreadAffinityMask(GetCurrentThread(), (DWORD_PTR)1 << i) == 0);
-		if (errcode) {
-			fprintf(stderr,"SetThreadAffinityMask failed with error %lu.\nINFO: Your run should be OK, but leaving up to OS to manage thread/core binding.\n", (unsigned long)GetLastError());
+		grp_aff.Group = (WORD)(i >> 6);
+		grp_aff.Mask  = (KAFFINITY)1 << (i & 63);
+		// SetThreadGroupAffinity returns 0 (FALSE) on failure:
+		if (SetThreadGroupAffinity(GetCurrentThread(), &grp_aff, NULL) == 0) {
+			fprintf(stderr,"SetThreadGroupAffinity failed with error %lu.\nINFO: Your run should be OK, but leaving up to OS to manage thread/core binding.\n", (unsigned long)GetLastError());
 		}
 
 	#elif defined(OS_TYPE_MACOSX)

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -76,6 +76,25 @@ me at: heber.tomer@gmail.com
 
 #ifdef MULTITHREAD	// Wrap contents of this file in flag (set via platform.h at compile time) ensuring no code built in unthreaded mode
 
+// MacOS has its own versions of these, in /usr/include/X11/Xthreads.h:
+static void * xmalloc(size_t len) {
+	void *ptr = malloc(len);
+	if (ptr == NULL) {
+		printf("failed to allocate %u bytes\n", (uint32)len);
+		exit(-1);
+	}
+	return ptr;
+}
+
+static void * xcalloc(size_t num, size_t len) {
+	void *ptr = calloc(num, len);
+	if (ptr == NULL) {
+		printf("failed to calloc %u bytes\n", (uint32)(num * len));
+		exit(-1);
+	}
+	return ptr;
+}
+
 	#define THREAD_POOL_DEBUG	0
 
 	#if THREAD_POOL_DEBUG
@@ -264,7 +283,7 @@ me at: heber.tomer@gmail.com
 	 * @param data Contains a pointer to the startup data
 	 * @return NULL.
 	 */
-	#if defined(__GNUC__) && (__GNUC__ > 4 || __GNUC__ == 4 && __GNUC_MINOR__>1)
+	#if defined(__GNUC__) && (__GNUC__ > 4 || __GNUC__ == 4 && __GNUC_MINOR__>1) && defined(CPU_IS_X86)
 
 	/* gcc on win32 needs to force 16-byte stack alignment on
 	   thread entry, as this exceeds what windows may provide; see
@@ -275,8 +294,8 @@ me at: heber.tomer@gmail.com
 	#endif
 	static void *worker_thr_routine(void *data)
 	{
-		char cbuf[STR_MAX_LEN*2];
 	#if INCLUDE_HWLOC
+		char cbuf[STR_MAX_LEN*2];
 		char str[80];
 	#endif
 		struct thread_init *init = (struct thread_init *)data;

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -65,6 +65,12 @@ me at: heber.tomer@gmail.com
 #include "threadpool.h"
 #include "util.h"	// This is to get (or not) <hwloc.h>
 
+#if defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
+	#include <windows.h>	// Windows CPU-affinity API: SetThreadAffinityMask()/GetCurrentThread(). MinGW is mapped to
+				// OS_TYPE_LINUX by platform.h but has no sched_setaffinity(), so its Windows build takes this
+				// Win32 path too (MinGW-w64 provides the full Win32 API).
+#endif
+
 #ifdef __FreeBSD__
 #include <sys/param.h>
 #include <sys/cpuset.h>
@@ -388,37 +394,63 @@ me at: heber.tomer@gmail.com
 
 	 #endif	// INCLUDE_HWLOC?
 
-	#elif defined(OS_TYPE_MACOSX)
+	#elif defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
 
-		thread_t thr = mach_thread_self();
-		thread_extended_policy_data_t epolicy;
-		epolicy.timeshare = FALSE;
-		kern_return_t ret = thread_policy_set(
-			thr, THREAD_EXTENDED_POLICY,
-			(thread_policy_t) &epolicy, THREAD_EXTENDED_POLICY_COUNT);
-		if (ret != KERN_SUCCESS) {
-			printf("thread_policy_set returned %d", ret);
-			exit(-1);
-		}
+		// Windows hard affinity: pin the current worker thread to logical core i. This covers BOTH the
+		// native-Windows toolchain (OS_TYPE_WINDOWS) and MinGW (which platform.h maps to OS_TYPE_LINUX but
+		// which has no sched_setaffinity() and so is deliberately excluded from the Linux branch above) -
+		// MinGW-w64 provides SetThreadAffinityMask(), so this is the affinity path for the MSYS2/MinGW
+		// Windows builds the CI actually produces.
+		// SetThreadAffinityMask() takes a single DWORD_PTR bitmask, so this simple form only
+		// addresses logical CPUs 0-63 within the thread's current processor group. Systems with
+		// >64 logical CPUs are partitioned into 64-CPU processor groups and require the
+		// SetThreadGroupAffinity()/GROUP_AFFINITY API, which we do not handle here; the
+		// single-mask form matches the model used elsewhere in the Windows port.
+		int i,errcode;
 
-		thread_affinity_policy_data_t apolicy;
-		int i = my_id % pool->num_of_cores;	// get cpu mask using sequential thread ID modulo #available cores
+		i = my_id % pool->num_of_cores;	// get cpu index using sequential thread ID modulo #available cores
 		i = mi64_ith_set_bit(CORE_SET, i+1, MAX_CORES>>6);	// Remember, [i]th-bit index in arglist is *unit* offset, i.e. must be in [1,MAX_CORES]
 		if(i < 0) {
 			fprintf(stderr,"Affinity CORE_SET does not have a [%u]th set bit!",my_id % pool->num_of_cores);
 			ASSERT(0, "Aborting.");
 		}
-		apolicy.affinity_tag = i; // set affinity tag
 	  #if THREAD_POOL_DEBUG
-		printf("Setting CPU = %d affinity of worker thread id %u, mach_id = %u\n", i, my_id, thr);
+		printf("Setting affinity of worker thread id %u to logical core %d\n", my_id, i);
 	  #endif
+		// SetThreadAffinityMask returns the thread's previous affinity mask, or 0 on failure:
+		errcode = (SetThreadAffinityMask(GetCurrentThread(), (DWORD_PTR)1 << i) == 0);
+		if (errcode) {
+			fprintf(stderr,"SetThreadAffinityMask failed with error %lu.\nINFO: Your run should be OK, but leaving up to OS to manage thread/core binding.\n", (unsigned long)GetLastError());
+		}
 
-		ret = thread_policy_set(
-			thr, THREAD_EXTENDED_POLICY,
-			(thread_policy_t) &apolicy, THREAD_EXTENDED_POLICY_COUNT);
-		if (ret != KERN_SUCCESS) {
-			printf("thread_policy_set returned %d", ret);
-			exit(-1);
+	#elif defined(OS_TYPE_MACOSX)
+
+		// macOS provides NO hard CPU pinning. The only documented mechanism is the Mach
+		// THREAD_AFFINITY_POLICY, which sets an *affinity tag*: an advisory hint asking the
+		// scheduler to co-locate (share an L2 cache domain) all threads that carry the same tag.
+		// It does NOT pin a thread to a specific logical core and gives no placement guarantee.
+		// We use each worker's logical-core index as its tag so every worker gets a distinct
+		// grouping hint, mirroring the *intent* of the hard pin done on Linux/FreeBSD/Windows.
+		// NOTE: This is advisory only. Apple Silicon (arm64) effectively ignores affinity tags,
+		// so on those machines this call is a no-op.
+		mach_port_t thr = pthread_mach_thread_np(pthread_self());
+		thread_affinity_policy_data_t apolicy;
+		int i,ret;
+
+		i = my_id % pool->num_of_cores;	// get cpu index using sequential thread ID modulo #available cores
+		i = mi64_ith_set_bit(CORE_SET, i+1, MAX_CORES>>6);	// Remember, [i]th-bit index in arglist is *unit* offset, i.e. must be in [1,MAX_CORES]
+		if(i < 0) {
+			fprintf(stderr,"Affinity CORE_SET does not have a [%u]th set bit!",my_id % pool->num_of_cores);
+			ASSERT(0, "Aborting.");
+		}
+		apolicy.affinity_tag = i;	// advisory affinity tag - NOT a hard core pin (see comment above)
+	  #if THREAD_POOL_DEBUG
+		printf("Setting affinity tag = %d of worker thread id %u, mach port = %u\n", i, my_id, (unsigned)thr);
+	  #endif
+		ret = thread_policy_set(thr, THREAD_AFFINITY_POLICY,
+			(thread_policy_t)&apolicy, THREAD_AFFINITY_POLICY_COUNT);
+		if (ret != KERN_SUCCESS) {	// warn but do not abort - affinity is advisory on macOS:
+			fprintf(stderr,"thread_policy_set(THREAD_AFFINITY_POLICY) returned %d.\nINFO: macOS affinity is advisory only, leaving up to OS to manage thread/core binding.\n", ret);
 		}
 
 	#else

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -76,25 +76,6 @@ me at: heber.tomer@gmail.com
 
 #ifdef MULTITHREAD	// Wrap contents of this file in flag (set via platform.h at compile time) ensuring no code built in unthreaded mode
 
-// MacOS has its own versions of these, in /usr/include/X11/Xthreads.h:
-static void * xmalloc(size_t len) {
-	void *ptr = malloc(len);
-	if (ptr == NULL) {
-		printf("failed to allocate %u bytes\n", (uint32)len);
-		exit(-1);
-	}
-	return ptr;
-}
-
-static void * xcalloc(size_t num, size_t len) {
-	void *ptr = calloc(num, len);
-	if (ptr == NULL) {
-		printf("failed to calloc %u bytes\n", (uint32)(num * len));
-		exit(-1);
-	}
-	return ptr;
-}
-
 	#define THREAD_POOL_DEBUG	0
 
 	#if THREAD_POOL_DEBUG
@@ -110,7 +91,7 @@ static void * xcalloc(size_t num, size_t len) {
 		queue->tail = 0;
 		queue->num_tasks = 0;
 		queue->max_tasks = max_tasks;
-		queue->tasks = (void **)xcalloc(max_tasks, sizeof(void *));
+		queue->tasks = (void **)CALLOC(max_tasks, sizeof(void *));
 	}
 
 	static void threadpool_queue_free(struct threadpool_queue *queue)
@@ -658,7 +639,7 @@ static void * xcalloc(size_t num, size_t len) {
 				thread_control_t *t)
 	{
 		int i;
-		struct threadpool *pool = (struct threadpool *)xcalloc(1,
+		struct threadpool *pool = (struct threadpool *)CALLOC(1,
 						sizeof(struct threadpool));
 
 		/* Init the mutex and cond vars. */
@@ -691,7 +672,7 @@ static void * xcalloc(size_t num, size_t len) {
 		/* Init the queues. */
 		threadpool_queue_init(&(pool->tasks_queue), queue_size);
 		threadpool_queue_init(&(pool->free_tasks_queue), queue_size);
-		pool->tasks = (task_control_t *)xmalloc(queue_size *
+		pool->tasks = (task_control_t *)MALLOC(queue_size *
 						sizeof(task_control_t));
 
 		/* Add all the free tasks to the free tasks queue. */

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -66,7 +66,7 @@ me at: heber.tomer@gmail.com
 #include "util.h"	// This is to get (or not) <hwloc.h>
 
 #if defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
-	#include <windows.h>	// Windows CPU-affinity API (SetThreadGroupAffinity() etc.); see the affinity branch below.
+	#include <windows.h>	// Windows CPU-affinity API; see the affinity branch below for details.
 #endif
 
 #ifdef __FreeBSD__

--- a/src/threadpool.h
+++ b/src/threadpool.h
@@ -193,38 +193,6 @@ void threadpool_free(struct threadpool *pool);
 int threadpool_drain(struct threadpool *pool,
 			int blocking);
 
-/********************* utility macros: ********************/
-
-// Don't use any of these at present, but note MacOS has its own versions of these, in /usr/include/X11/Xthreads.h:
-#if 1
-	static void * xmalloc(size_t len) {
-		void *ptr = malloc(len);
-		if (ptr == NULL) {
-			printf("failed to allocate %u bytes\n", (uint32)len);
-			exit(-1);
-		}
-		return ptr;
-	}
-	
-	static void * xcalloc(size_t num, size_t len) {
-		void *ptr = calloc(num, len);
-		if (ptr == NULL) {
-			printf("failed to calloc %u bytes\n", (uint32)(num * len));
-			exit(-1);
-		}
-		return ptr;
-	}
-	
-	static void * xrealloc(void *iptr, size_t len) {
-		void *ptr = realloc(iptr, len);
-		if (ptr == NULL) {
-			printf("failed to reallocate %u bytes\n", (uint32)len);
-			exit(-1);
-		}
-		return ptr;
-	}
-#endif
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Fixes #59.

Mlucas pins its FFT worker threads to logical cores, but only on Linux/FreeBSD; Windows and macOS silently ignored the affinity request. This adds both, in the `worker_thr_routine()` affinity chain in `src/threadpool.c`.

**Windows** — `SetThreadGroupAffinity(GetCurrentThread(), &grp_aff, NULL)`, with `grp_aff.Group = i >> 6` and `grp_aff.Mask = 1 << (i & 63)`. The branch is guarded by `defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)`. This matters: `platform.h` maps MinGW to `OS_TYPE_LINUX`, and the Linux branch excludes `__MINGW32__` (MinGW has no `sched_setaffinity`), so the **MSYS2/MinGW Windows builds the CI actually produces were falling through to the no-affinity `#else`**. MinGW-w64 provides the full Win32 API, so both native-Windows and MinGW now take this path. Failure warns (via `GetLastError()`) and continues, like the Linux branch. The group-affinity form is used rather than the simpler `SetThreadAffinityMask` precisely so that systems with **more than 64 logical CPUs** — which Windows partitions into processor groups — are handled. (An earlier revision of this description said the opposite: that the single-mask form was used and >64-CPU support was absent. Commit `7d1e9f99` replaced it and the text was never updated.)

**macOS** — Mach `THREAD_AFFINITY_POLICY` via `thread_policy_set()` on `pthread_mach_thread_np(pthread_self())`. **macOS has no hard core pinning** — this only sets an advisory *affinity tag* (a hint to co-locate same-tag threads in a shared-L2 domain), which is documented plainly in the code; Apple Silicon effectively ignores it. This also repairs the pre-existing (broken, effectively-disabled) macOS block, which (1) applied the affinity struct with the wrong `THREAD_EXTENDED_POLICY` flavor/count so the tag was never set, (2) `exit(-1)`'d on failure instead of warning, and (3) leaked a mach port via `mach_thread_self()` (switched to `pthread_mach_thread_np`, which doesn't).

Both branches warn-and-continue and are fully `#ifdef`-guarded.

**Two further changes, not in the original description:**

* **hwloc now applies on every platform, not just Linux.** The hwloc block moves out of the `OS_TYPE_LINUX && !__MINGW32__` branch into a top-level `#if INCLUDE_HWLOC` arm that precedes and supersedes every OS branch. In a `use_hwloc` build the FreeBSD, Windows and macOS native-API paths above are therefore unreachable. This is the largest functional change in the PR; the earlier text claiming "the Linux/FreeBSD/hwloc paths are untouched" was wrong.
* **`src/threadpool.h`** loses the `xmalloc`/`xcalloc`/`xrealloc` block (`xrealloc` deleted outright, the other two moved into `threadpool.c`). The PR touches two files, not one.

**Also changed:** `threadpool.c` adds `&& defined(CPU_IS_X86)` to the `__attribute__((force_align_arg_pointer))` guard, narrowing it from *every* GNU-C target to 32-bit x86. That matches the workaround's purpose — the comment above it cites a 2008 pthreads-win32 report about **win32** thread entry giving less than 16-byte alignment. Measured: on x86-64 the attribute is a no-op (gcc 16.1.1 `-O3 -mavx2` emits byte-identical assembly with and without it, no warning), because both the SysV and Windows x64 ABIs already guarantee 16-byte alignment at entry; on aarch64 it produces `warning: 'force_align_arg_pointer' attribute directive ignored [-Wattributes]`. So the narrower guard removes a real ARM warning and costs nothing elsewhere. The Windows/macOS branches can't be compiled on this Linux host, so their API usage was reviewed against the documented signatures — the Windows branch in particular is worth a compile-check on a MinGW runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

