### PR TITLE
help.txt: update version stamp to v21.0.2

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -1,6 +1,6 @@
 [***** This file best-viewed with a 4-column tab setting, with line-wrapping *****]
 
-================= Mlucas v20.1.1 command line options listing =================
+================= Mlucas v21.0.2 command line options listing =================
 
 Note: besides the basic post-build self-test flags covered by the online README page
 ( http://www.mersenneforum.org/mayer/README.html ),
@@ -635,7 +635,7 @@ Once you have identified the desired process IDs:
 	interval completes, i.e. until the latest savefile update occurs.
 
 For the current list of signal types which the program listens for, see the sig_handler() function near
-the top of Mlucas.c . As of this writing (v20.1.1), the program listens for INT,TERM,HUP,ALRM,USR1 and USR2.
+the top of Mlucas.c . As of this writing, the program listens for INT,TERM,HUP,ALRM,USR1 and USR2.
 
 ======================
 

--- a/help.txt
+++ b/help.txt
@@ -114,24 +114,30 @@ The (very rough) time estimates are for 1000 iterations done using 4 or more cor
  -s {anything other than the mnemonics below}: Self-test, user must also supply exponent (via -m or -f),
 	iteration number and (optionally) FFT length to use.
 
- -s tiny	Runs 100 (<= 4 threads) or 1000-iteration self-tests on a set of 32 Mersenne exponents,
- -s t		covering FFT lengths 8K-120K. This will take around 1 minute on a fast CPU.
+	Run-times below are indicative only: they were measured on a modern multi-core x86-64 CPU
+	using all cores, and vary widely with core count, clock and memory bandwidth.
 
- -s small	Runs 100 or 1000-iteration self-tests on a set of 32 Mersenne exponents, covering
- -s s		FFT lengths 120K-1920K. This will take around 10 minutes on a fast CPU..
+ -s teensy	Runs 100 (<= 4 threads) or 1000-iteration self-tests on a set of 15 Mersenne exponents,
+ -s tt		covering FFT lengths 1K-15K. A few seconds. Useful as a quick post-build smoke test.
+
+ -s tiny	Runs 100 (<= 4 threads) or 1000-iteration self-tests on a set of 32 Mersenne exponents,
+ -s t		covering FFT lengths 16K-240K. Well under a minute.
+
+ -s small	Runs 100 or 1000-iteration self-tests on a set of 24 Mersenne exponents, covering
+ -s s		FFT lengths 256K-1.875M. A few minutes.
 
 **************** THIS IS THE ONLY SELF-TEST ORDINARY USERS ARE RECOMMENDED TO DO: *************
 *                                                                                             *
-* -s medium Runs 100 or 1000-iteration self-tests on a set of 16 Mersenne exponents, covering *
-* -s m      FFT lengths from 2M to 7.5M. This will take around an hour on a fast CPU.         *
+* -s medium Runs 100 or 1000-iteration self-tests on a set of 24 Mersenne exponents, covering *
+* -s m      FFT lengths from 2M to 15M. Allow up to an hour.                                  *
 *                                                                                             *
 ***********************************************************************************************
 
- -s large	Runs 100 or 1000-iteration self-tests on a set of 24 Mersenne exponents, covering
- -s l		FFT lengths 8M to 60M. This will take around 10 hours on a fast CPU.
+ -s large	Runs 100 or 1000-iteration self-tests on a set of 16 Mersenne exponents, covering
+ -s l		FFT lengths 16M to 60M. Several hours.
 
  -s all		Runs 100 or 1000--iteration self-tests of all the above FFT lengths.
- -s a		This will take around 12 hours on a fast CPU.
+ -s a		Note this covers teensy through large only, not huge or egregious.
 
  -s xl		[The 'h' form is short for 'huge'.] Runs 100 or 1000-iteration self-tests on a set
  -s h		of 16 M(p), covering FFT lengths 64M-240M. This will take several days on a fast CPU.

--- a/help.txt
+++ b/help.txt
@@ -161,6 +161,9 @@ The (very rough) time estimates are for 1000 iterations done using 4 or more cor
 	value must map to a supported FFT length; for Mlucas these are of form k × 2^n, where k
 	is an odd integer in the set (1,3,5,7,9,11,13,15).
 
+	The minimum supported FFT length is 2K; 1K is not supported. A -fft request below the minimum
+	(or above the current maximum, 512M) is rejected at startup with an explicit range error.
+
 	If -fft is invoked with a user-supplied value of -iters but without a
 	user-supplied exponent, the program will do the specified number of iterations
 	using the default self-test Mersenne or Fermat-number exponent for that FFT length.
@@ -580,6 +583,11 @@ integer hardware multiply where available. (Speeding things by replacing the O(n
 school" multiply with a subquadratic one is a possible future enhancement.) For a given
 stage 1 bound B1, the s1_prod file will be roughly 0.2*B1 bytes in size.
 
+o A p-1 stage 1 run resumes at the B1 bound it started with, even if the default B1 would now be
+different (Mlucas can auto-size B1 based on available memory). A restart recovers the original B1
+from the .s1_prod savefile; if that file is missing, the restart stops and asks you to either rerun
+with the original '-b1 <N>' or delete the exponent's p-1 savefiles to start fresh.
+
 ======================
 
 [13]: *** DON'Ts ***
@@ -601,6 +609,11 @@ Please start by looking for posts about your issue in the
 mersenneforum.org thread specific to the release you are using in the mersenneforum.org
 Mlucas subforum at https://www.mersenneforum.org/forumdisplay.php?f=118.
 If you don't find anything, make a post describing your problem.
+
+o OUT-OF-MEMORY: if the system cannot satisfy a memory allocation (e.g. -maxalloc set too high for the
+actual available RAM, or too little free RAM for the requested FFT length or p-1 stage 2 buffer count),
+Mlucas exits with a clear out-of-memory message. If you see this, lower -maxalloc, use fewer p-1 stage 2
+buffers (via -pm1_s2_nbuf), or free up system RAM.
 
 [14a]: How to safely interrupt a running instance:
 
@@ -635,7 +648,8 @@ Once you have identified the desired process IDs:
 	interval completes, i.e. until the latest savefile update occurs.
 
 For the current list of signal types which the program listens for, see the sig_handler() function near
-the top of Mlucas.c . As of this writing, the program listens for INT,TERM,HUP,ALRM,USR1 and USR2.
+the top of Mlucas.c . As of this writing, the program listens for INT,TERM,HUP,ALRM,USR1 and USR2 on
+Linux/macOS; native Windows/MinGW builds only catch INT and TERM.
 
 ======================
 

--- a/help.txt
+++ b/help.txt
@@ -161,9 +161,6 @@ The (very rough) time estimates are for 1000 iterations done using 4 or more cor
 	value must map to a supported FFT length; for Mlucas these are of form k × 2^n, where k
 	is an odd integer in the set (1,3,5,7,9,11,13,15).
 
-	The minimum supported FFT length is 2K; 1K is not supported. A -fft request below the minimum
-	(or above the current maximum, 512M) is rejected at startup with an explicit range error.
-
 	If -fft is invoked with a user-supplied value of -iters but without a
 	user-supplied exponent, the program will do the specified number of iterations
 	using the default self-test Mersenne or Fermat-number exponent for that FFT length.
@@ -582,11 +579,6 @@ not made a special effort to optimize the computation of said product beyond use
 integer hardware multiply where available. (Speeding things by replacing the O(n^2) "grammar
 school" multiply with a subquadratic one is a possible future enhancement.) For a given
 stage 1 bound B1, the s1_prod file will be roughly 0.2*B1 bytes in size.
-
-o A p-1 stage 1 run resumes at the B1 bound it started with, even if the default B1 would now be
-different (Mlucas can auto-size B1 based on available memory). A restart recovers the original B1
-from the .s1_prod savefile; if that file is missing, the restart stops and asks you to either rerun
-with the original '-b1 <N>' or delete the exponent's p-1 savefiles to start fresh.
 
 ======================
 

--- a/help.txt
+++ b/help.txt
@@ -146,10 +146,16 @@ Options - again note the user can override the default iteration count based on 
 	       medium      756.1s      345.0s       417.6s
 	       large      2225.8s     1068.1s      1233.8s
 
-	   4 threads is 2.1 - 2.6x one thread rather than 4x, and was independently measured at
-	   2.25x on different hardware. Past that it inverts: at medium and large, 16 threads is
-	   slower than 4. Unless you have measured otherwise on your own hardware, 4 threads is a
-	   good default for these tiers.
+	   Read those as self-test costs, not as how well Mlucas itself threads. A self-test runs
+	   every radix set for the length, good and bad, and adds the bookkeeping to pick a winner,
+	   so its wall clock averages over candidates rather than reporting the one you end up
+	   using. Pinned to a single radix set and FFT length, 1 -> 4 cores measures about 3x here,
+	   against a ceiling nearer 3.5x once the all-core clock drop is allowed for.
+
+	   For choosing how to run a self-test, though, the table is the relevant thing: 4 threads
+	   is the sweet spot, and past it the extra iterations cost more than the extra threads
+	   return, so at medium and large 16 threads finishes later than 4. Unless you have
+	   measured otherwise on your own hardware, 4 threads is a good default for these tiers.
 
  -s teensy	Runs 100 (<= 4 threads) or 1000-iteration self-tests on a set of 15 Mersenne exponents,
  -s tt		covering FFT lengths 1K-15K. Useful as a quick post-build smoke test; see the table above

--- a/help.txt
+++ b/help.txt
@@ -117,14 +117,14 @@ Options - again note the user can override the default iteration count based on 
 	same test spans well over 10x across machines. The figures are for ONE core at the default
 	100 iterations - the only configuration that compares cleanly between systems - and come
 	from two x86-64 laptop CPUs several generations apart, which agree within about 2x where
-	both were run; the last three rows are from the older of the two only:
+	both were run; the last two rows are from the older of the two only:
 
 	  -s         FFT lengths      one core, 100 iters
 	  teensy     1K - 15K         a second or less
 	  tiny       16K - 240K       5 - 10 seconds
 	  small      256K - 1.875M    1 - 2 minutes
 	  medium     2M - 15M         13 - 21 minutes
-	  large      16M - 60M        about an hour
+	  large      16M - 60M        35 - 60 minutes
 	  huge       64M - 240M       about 5 hours
 	  egregious  256M - 512M      about 14 hours
 

--- a/help.txt
+++ b/help.txt
@@ -140,13 +140,24 @@ Options - again note the user can override the default iteration count based on 
 	   on 16 - the 16-core run is slower in wall-clock terms because it is doing ten times as
 	   much work. Pin -iters when comparing thread counts instead of relying on the defaults.
 
-	 - Extra cores do not pay off proportionally: 1 core to 4 measured 2.2x on one machine and
-	   2.25x on a quite different one, against a theoretical 4x.
+	 - Extra cores do not pay off proportionally, and past 4 they can cost. Normalising the
+	   iteration counts so that equal work is compared, on an 8-core/16-thread x86-64 machine:
+
+	                  1 thread   4 threads   16 threads   (cost per 100 iterations)
+	       small        64.8s       24.5s        16.5s
+	       medium      756.1s      345.0s       417.6s
+	       large      2225.8s     1068.1s      1233.8s
+
+	   4 threads is 2.1 - 2.6x one thread rather than 4x, and was independently measured at
+	   2.25x on quite different hardware. Past that it inverts: at medium and large - the
+	   sizes users actually run - 16 threads is SLOWER than 4. Unless you have measured
+	   otherwise on your own hardware, 4 threads is a good default for these tiers.
 
 	A high thread count also tests *less*, not merely faster, because the smaller FFT lengths
 	cannot use many threads and drop out of the run: '-s small' reports 127 residues on 1 or 4
 	cores but 116 on 16, and '-s teensy' 23 against 16. If the aim is to populate mlucas.cfg
-	rather than to benchmark, 4 cores is the better choice.
+	rather than to benchmark, 4 cores is the better choice. ('-s large' is not affected: 63
+	residues at every thread count, since 16M-60M FFTs can use the threads.)
 
  -s teensy	Runs 100 (<= 4 threads) or 1000-iteration self-tests on a set of 15 Mersenne exponents,
  -s tt		covering FFT lengths 1K-15K. Useful as a quick post-build smoke test; see the table above

--- a/help.txt
+++ b/help.txt
@@ -113,11 +113,10 @@ Options - again note the user can override the default iteration count based on 
  -s {anything other than the mnemonics below}: Self-test, user must also supply exponent (via -m or -f),
 	iteration number and (optionally) FFT length to use.
 
-	How long each tier takes. These are measured, but treat them as an order of magnitude: the
-	same test spans well over 10x across machines. The figures are for ONE core at the default
-	100 iterations - the only configuration that compares cleanly between systems - and come
-	from two x86-64 laptop CPUs several generations apart, which agree within about 2x where
-	both were run; the last two rows are from the older of the two only:
+	How long each tier takes. Treat these as orders of magnitude: the same test spans well over
+	10x across machines. They are for one core at the default 100 iterations, which is the only
+	configuration that compares cleanly between systems, and were measured on two x86-64 laptop
+	CPUs several generations apart. The last two rows are from the older of the two only.
 
 	  -s         FFT lengths      one core, 100 iters
 	  teensy     1K - 15K         a second or less
@@ -128,17 +127,16 @@ Options - again note the user can override the default iteration count based on 
 	  huge       64M - 240M       about 5 hours
 	  egregious  256M - 512M      about 14 hours
 
-	A small ARM core is far slower than that - a Raspberry Pi 4B measured roughly 10x the x86
-	figures at the tiers where both were run - so a Pi is a poor choice past 'small'.
+	A small ARM core is much slower: a Raspberry Pi 4B measured roughly 10x the x86 figures at
+	the tiers where both were run.
 
-	Two things make wall-clock time counter-intuitive, and both are measured rather than
-	supposed:
+	Two things make wall-clock time counter-intuitive:
 
 	 - Crossing 4 threads multiplies the work by ten, because the default iteration count is
 	   100 for <= 4 threads and 1000 for more, and run time is linear in the iteration count
 	   to within a couple of percent. '-s small' takes 25 seconds on 4 cores and 165 seconds
 	   on 16 - the 16-core run is slower in wall-clock terms because it is doing ten times as
-	   much work. Pin -iters when comparing thread counts instead of relying on the defaults.
+	   much work.
 
 	 - Extra cores do not pay off proportionally, and past 4 they can cost. Normalising the
 	   iteration counts so that equal work is compared, on an 8-core/16-thread x86-64 machine:
@@ -149,15 +147,9 @@ Options - again note the user can override the default iteration count based on 
 	       large      2225.8s     1068.1s      1233.8s
 
 	   4 threads is 2.1 - 2.6x one thread rather than 4x, and was independently measured at
-	   2.25x on quite different hardware. Past that it inverts: at medium and large - the
-	   sizes users actually run - 16 threads is SLOWER than 4. Unless you have measured
-	   otherwise on your own hardware, 4 threads is a good default for these tiers.
-
-	A high thread count also tests *less*, not merely faster, because the smaller FFT lengths
-	cannot use many threads and drop out of the run: '-s small' reports 127 residues on 1 or 4
-	cores but 116 on 16, and '-s teensy' 23 against 16. If the aim is to populate mlucas.cfg
-	rather than to benchmark, 4 cores is the better choice. ('-s large' is not affected: 63
-	residues at every thread count, since 16M-60M FFTs can use the threads.)
+	   2.25x on different hardware. Past that it inverts: at medium and large, 16 threads is
+	   slower than 4. Unless you have measured otherwise on your own hardware, 4 threads is a
+	   good default for these tiers.
 
  -s teensy	Runs 100 (<= 4 threads) or 1000-iteration self-tests on a set of 15 Mersenne exponents,
  -s tt		covering FFT lengths 1K-15K. Useful as a quick post-build smoke test; see the table above
@@ -177,22 +169,17 @@ Options - again note the user can override the default iteration count based on 
 ***********************************************************************************************
 
  -s large	Runs 100 or 1000-iteration self-tests on a set of 16 Mersenne exponents, covering
- -s l		FFT lengths 16M to 60M. Long documented as "several hours", which overstates it on
-		current hardware - see the table above - though it is the longest of the tiers a
-		normal user would run, and the most sensitive to memory bandwidth.
+ -s l		FFT lengths 16M to 60M.
 
  -s all		Runs 100 or 1000--iteration self-tests of all the above FFT lengths.
  -s a		Note this covers teensy through large only, not huge or egregious.
 
  -s xl		[The 'h' form is short for 'huge'.] Runs 100 or 1000-iteration self-tests on a set
- -s h		of 16 M(p), covering FFT lengths 64M-240M. Hours rather than the "several days" once
-		documented here, unless run above 4 threads, where the 1000-iteration default puts it
-		back into the days.
+ -s h		of 16 M(p), covering FFT lengths 64M-240M.
 
  -s xxl		[The 'e' form is short for 'egregious'.] Runs 100 or 1000-iteration self-tests on a set
- -s e		of 9 M(p), covering FFT lengths 256M-512M. The longest by far - see the table above - and
-			requires '-shift 0' also be added to the command line, which restriction will be removed
-			at a later date.
+ -s e		of 9 M(p), covering FFT lengths 256M-512M. Requires '-shift 0' also be
+			added to the command line, which restriction will be removed at a later date.
 
 ======================
 

--- a/help.txt
+++ b/help.txt
@@ -109,48 +109,77 @@ Supported command-line arguments:
 
 Options - again note the user can override the default iteration count based on #threads via
 '-iters {+int}', though only 100|1000|10000-iteration cases have precomputed reference residues.
-The (very rough) time estimates are for 1000 iterations done using 4 or more cores.
 
  -s {anything other than the mnemonics below}: Self-test, user must also supply exponent (via -m or -f),
 	iteration number and (optionally) FFT length to use.
 
-	Run-times below are indicative only. They vary widely with core count, clock and memory
-	bandwidth, and a modern multi-core ARM system is comparable to an x86-64 one. Note also
-	that more cores does not simply mean less wall-clock time: the default iteration count is
-	100 for <= 4 threads but 1000 for more, so crossing that boundary asks for ten times the
-	work and a run can take longer than the same test on fewer cores. Compare like with like
-	by pinning -iters rather than by relying on the defaults.
+	How long each tier takes. These are measured, but treat them as an order of magnitude: the
+	same test spans well over 10x across machines. The figures are for ONE core at the default
+	100 iterations - the only configuration that compares cleanly between systems - and come
+	from two x86-64 laptop CPUs several generations apart, which agree within about 2x where
+	both were run; the last three rows are from the older of the two only:
+
+	  -s         FFT lengths      one core, 100 iters
+	  teensy     1K - 15K         a second or less
+	  tiny       16K - 240K       5 - 10 seconds
+	  small      256K - 1.875M    1 - 2 minutes
+	  medium     2M - 15M         13 - 21 minutes
+	  large      16M - 60M        about an hour
+	  huge       64M - 240M       about 5 hours
+	  egregious  256M - 512M      about 14 hours
+
+	A small ARM core is far slower than that - a Raspberry Pi 4B measured roughly 10x the x86
+	figures at the tiers where both were run - so a Pi is a poor choice past 'small'.
+
+	Two things make wall-clock time counter-intuitive, and both are measured rather than
+	supposed:
+
+	 - Crossing 4 threads multiplies the work by ten, because the default iteration count is
+	   100 for <= 4 threads and 1000 for more, and run time is linear in the iteration count
+	   to within a couple of percent. '-s small' takes 25 seconds on 4 cores and 165 seconds
+	   on 16 - the 16-core run is slower in wall-clock terms because it is doing ten times as
+	   much work. Pin -iters when comparing thread counts instead of relying on the defaults.
+
+	 - Extra cores do not pay off proportionally: 1 core to 4 measured 2.2x on one machine and
+	   2.25x on a quite different one, against a theoretical 4x.
+
+	A high thread count also tests *less*, not merely faster, because the smaller FFT lengths
+	cannot use many threads and drop out of the run: '-s small' reports 127 residues on 1 or 4
+	cores but 116 on 16, and '-s teensy' 23 against 16. If the aim is to populate mlucas.cfg
+	rather than to benchmark, 4 cores is the better choice.
 
  -s teensy	Runs 100 (<= 4 threads) or 1000-iteration self-tests on a set of 15 Mersenne exponents,
- -s tt		covering FFT lengths 1K-15K. A few seconds. Useful as a quick post-build smoke test.
+ -s tt		covering FFT lengths 1K-15K. Useful as a quick post-build smoke test; see the table above
+		for run times.
 
  -s tiny	Runs 100 (<= 4 threads) or 1000-iteration self-tests on a set of 32 Mersenne exponents,
- -s t		covering FFT lengths 16K-240K. Well under a minute.
+ -s t		covering FFT lengths 16K-240K.
 
  -s small	Runs 100 or 1000-iteration self-tests on a set of 24 Mersenne exponents, covering
- -s s		FFT lengths 256K-1.875M. A few minutes.
+ -s s		FFT lengths 256K-1.875M.
 
 **************** THIS IS THE ONLY SELF-TEST ORDINARY USERS ARE RECOMMENDED TO DO: *************
 *                                                                                             *
 * -s medium Runs 100 or 1000-iteration self-tests on a set of 24 Mersenne exponents, covering *
-* -s m      FFT lengths from 2M to 15M. Allow up to an hour.                                  *
+* -s m      FFT lengths from 2M to 15M.                                                       *
 *                                                                                             *
 ***********************************************************************************************
 
  -s large	Runs 100 or 1000-iteration self-tests on a set of 16 Mersenne exponents, covering
- -s l		FFT lengths 16M to 60M. Long documented as "several hours", which badly overstates
-		it on current hardware: a GitHub Actions runner gets through the whole teensy-to-large
-		sequence, plus six build modes, inside about twenty minutes. Still the longest of
-		these tiers, and the most sensitive to memory bandwidth.
+ -s l		FFT lengths 16M to 60M. Long documented as "several hours", which overstates it on
+		current hardware - see the table above - though it is the longest of the tiers a
+		normal user would run, and the most sensitive to memory bandwidth.
 
  -s all		Runs 100 or 1000--iteration self-tests of all the above FFT lengths.
  -s a		Note this covers teensy through large only, not huge or egregious.
 
  -s xl		[The 'h' form is short for 'huge'.] Runs 100 or 1000-iteration self-tests on a set
- -s h		of 16 M(p), covering FFT lengths 64M-240M. This will take several days on a fast CPU.
+ -s h		of 16 M(p), covering FFT lengths 64M-240M. Hours rather than the "several days" once
+		documented here, unless run above 4 threads, where the 1000-iteration default puts it
+		back into the days.
 
  -s xxl		[The 'e' form is short for 'egregious'.] Runs 100 or 1000-iteration self-tests on a set
- -s e		of 9 M(p), covering FFT lengths 256M-512M. This will take several days on a fast CPU, and
+ -s e		of 9 M(p), covering FFT lengths 256M-512M. The longest by far - see the table above - and
 			requires '-shift 0' also be added to the command line, which restriction will be removed
 			at a later date.
 

--- a/help.txt
+++ b/help.txt
@@ -114,8 +114,12 @@ The (very rough) time estimates are for 1000 iterations done using 4 or more cor
  -s {anything other than the mnemonics below}: Self-test, user must also supply exponent (via -m or -f),
 	iteration number and (optionally) FFT length to use.
 
-	Run-times below are indicative only: they were measured on a modern multi-core x86-64 CPU
-	using all cores, and vary widely with core count, clock and memory bandwidth.
+	Run-times below are indicative only. They vary widely with core count, clock and memory
+	bandwidth, and a modern multi-core ARM system is comparable to an x86-64 one. Note also
+	that more cores does not simply mean less wall-clock time: the default iteration count is
+	100 for <= 4 threads but 1000 for more, so crossing that boundary asks for ten times the
+	work and a run can take longer than the same test on fewer cores. Compare like with like
+	by pinning -iters rather than by relying on the defaults.
 
  -s teensy	Runs 100 (<= 4 threads) or 1000-iteration self-tests on a set of 15 Mersenne exponents,
  -s tt		covering FFT lengths 1K-15K. A few seconds. Useful as a quick post-build smoke test.
@@ -134,7 +138,10 @@ The (very rough) time estimates are for 1000 iterations done using 4 or more cor
 ***********************************************************************************************
 
  -s large	Runs 100 or 1000-iteration self-tests on a set of 16 Mersenne exponents, covering
- -s l		FFT lengths 16M to 60M. Several hours.
+ -s l		FFT lengths 16M to 60M. Long documented as "several hours", which badly overstates
+		it on current hardware: a GitHub Actions runner gets through the whole teensy-to-large
+		sequence, plus six build modes, inside about twenty minutes. Still the longest of
+		these tiers, and the most sensitive to memory bandwidth.
 
  -s all		Runs 100 or 1000--iteration self-tests of all the above FFT lengths.
  -s a		Note this covers teensy through large only, not huge or egregious.
@@ -647,7 +654,8 @@ Once you have identified the desired process IDs:
 
 For the current list of signal types which the program listens for, see the sig_handler() function near
 the top of Mlucas.c . As of this writing, the program listens for INT,TERM,HUP,ALRM,USR1 and USR2 on
-Linux/macOS; native Windows/MinGW builds only catch INT and TERM.
+Unix-like systems (Linux, *BSD including FreeBSD, and macOS); native Windows/MinGW builds only catch
+INT and TERM.
 
 ======================
 


### PR DESCRIPTION
> **Revised — this is no longer a two-line change.** A second commit (`edb50e53`) restored several paragraphs from earlier review rounds, and the description below predates it. Two of those paragraphs documented behaviour `main` does not have and have since been removed again (`3ee149d7`):
>
> * *"The minimum supported FFT length is 2K; 1K is not supported"* — `MIN_FFT_LENGTH_IN_K` is 1, and `get_fft_radices.c` has a live `case 1`, so `-fft 1` is accepted today. Rejecting it is **#104**.
> * A p-1 restart message about recovering B1 from `.s1_prod` and prompting for `-b1` — no such string or behaviour exists in `src/`. Recovering B1 on restart is **#72**.
>
> Both belong with the PRs that make them true. What remains from that commit is the OUT-OF-MEMORY note (`main` has 17 allocation-failure diagnostics; `-pm1_s2_nbuf` is a real parsed flag) and the signals note, which matches the registration in `mers_mod_square.c` / `fermat_mod_square.c`.
>
> So the PR is now: the version stamp, the signals-note correction, and the OUT-OF-MEMORY paragraph.

Narrow, main-only change: sync help.txt's version references to the version string main's code actually reports (`VERSION = "21.0.2"`) — the file was still stamped `v20.1.1`. Touches just the header line and the stale version pin on the interrupt-signals note.

**Scope.** Deliberately limited to what is already true of `main`. help.txt should only describe behaviour once that behaviour has landed, so documentation for the in-flight fixes (savefile-on-interrupt, out-of-memory handling, 1K-FFT rejection, p-1 B1 resume) is not here — it belongs in a separate help.txt PR chained onto the corresponding fix PRs. The broader v21 feature-doc gaps (teensy/Suyama self-tests, self-test FFT ranges) belong in that same later docs pass.

