### PR TITLE
Mfactor: fix checkpoint-savefile corruption and tiny-exponent abort

### DIFF
--- a/src/factor.c
+++ b/src/factor.c
@@ -3770,6 +3770,11 @@ MFACTOR_HELP:
 							{
 								if((res >> l) & 1)	/* If Lth bit = 1, Lth candidate of the inputs is a factor */
 								{
+									// k = 0 yields the trivial "factor" q = 2.k.p+1 = 1, which divides everything. It can
+									// be sieved when the lower factor-bound admits it (e.g. -bmin 0 => kmin 0); skip it, since
+									// 1 is not a factor and PRP-testing it would violate mi64_pprimeF's base-<-modulus
+									// precondition and abort the run (seen with tiny exponents such as -m 23 -bmin 0):
+									if(k_to_try[l] == 0) continue;
 								#ifdef MULTITHREAD
 									pthread_mutex_lock(&mutex_mi64);
 								//	printf("Found Factor: Thread %u locked mutex_mi64 ... ",tid);

--- a/src/factor.c
+++ b/src/factor.c
@@ -3168,6 +3168,12 @@ MFACTOR_HELP:
 			// [ = 272272 or 226304, resp., depending on whether TF_CLASSES = 60 or 4620].
 			// We vectorize the 2nd loop, since each prime therein will hit at most one bit of the sievelet,
 			// i.e. we require no while-loop, only an if(curr_p's startval < bit_len or not) conditional.
+			// The vectorized bit-clearing below cannot handle the 0xFFFFFFFF 'p == curr_p' sentinel start-value
+			// get_startval() sets when the exponent p is itself within the sieving-prime range - only reachable
+			// by tiny exponents (e.g. the '-m 127 -bmax 20' self-test). Fall back to the scalar loop for that
+			// case; the AVX-512 path handles all real (large) exponents, where no sieving prime equals p.
+			const uint32 small_p = (lenP == 1) && (p[0] <= MAX_SIEVING_PRIME);
+			if(!small_p) {
 		// Loop #1:
 			curr_p = p_last_small;
 			for(m = nclear; m < nprime; m++)
@@ -3229,7 +3235,9 @@ MFACTOR_HELP:
 			);
 		/*	}	*/
 
-		#else	/******** Non-SIMD (pre-AVX512) **********/
+			} else	// small_p: the vectorized sieve can't handle the p==curr_p sentinel; use the scalar loop below
+		#endif
+			{	/******** Non-SIMD (pre-AVX512) - also the small-exponent fallback from the AVX-512 path above **********/
 
 		  #ifdef USE_NCQ
 			#warning Using 4-way bit-clear in PerPass_tfSieve.
@@ -3275,7 +3283,7 @@ MFACTOR_HELP:
 				}
 			}
 
-		#endif	// USE_AVX512 ?
+			}	// end of the AVX-512-vs-scalar (incl. small_p fallback) bit-clearing block
 
 //	if(pass==4)printf("\nPass %u: word0 after deep-prime clearing = %16" PRIX64 "\n",pass,bit_map2[0]);
 

--- a/src/factor.c
+++ b/src/factor.c
@@ -4496,11 +4496,13 @@ uint64*kmin, uint64*know, uint64*kmax, uint32*passmin, uint32*passnow, uint32*pa
 			char_addr = strstr(g_in_line, "=");
 			if(!char_addr) {
 				++nerr; fprintf(stderr,"ERROR: Line %d of factoring restart file %s lacks the required = sign!\n",curr_line,fname);
+			} else {
+				++char_addr;	// Skip past the '=' before parsing the value; sscanf("%lf") chokes on a leading '='
+				itmp = sscanf(char_addr, "%lf",bmin);
+				if(itmp != 1) {
+					++nerr; fprintf(stderr,"ERROR: unable to parse Line %d (bmin) of factoring restart file %s. Offending input = %s\n",curr_line,fname, g_in_line);
+				}
 			}
-		}
-		itmp = sscanf(char_addr, "%lf",bmin);
-		if(itmp != 1) {
-			++nerr; fprintf(stderr,"ERROR: unable to parse Line %d (bmin) of factoring restart file %s. Offending input = %s\n",curr_line,fname, g_in_line);
 		}
 
 		/* Line 4: bmax */
@@ -4515,11 +4517,13 @@ uint64*kmin, uint64*know, uint64*kmax, uint32*passmin, uint32*passnow, uint32*pa
 			char_addr = strstr(g_in_line, "=");
 			if(!char_addr) {
 				++nerr; fprintf(stderr,"ERROR: Line %d of factoring restart file %s lacks the required = sign!\n",curr_line,fname);
+			} else {
+				++char_addr;	// Skip past the '=' before parsing the value; sscanf("%lf") chokes on a leading '='
+				itmp = sscanf(char_addr, "%lf",bmax);
+				if(itmp != 1) {
+					++nerr; fprintf(stderr,"ERROR: unable to parse Line %d (bmax) of factoring restart file %s. Offending input = %s\n",curr_line,fname, g_in_line);
+				}
 			}
-		}
-		itmp = sscanf(char_addr, "%lf",bmax);
-		if(itmp != 1) {
-			++nerr; fprintf(stderr,"ERROR: unable to parse Line %d (bmax) of factoring restart file %s. Offending input = %s\n",curr_line,fname, g_in_line);
 		}
 
 	/************************************
@@ -4734,134 +4738,36 @@ uint64 kmin, uint64 know, uint64 kmax, uint32 passmin, uint32 passnow, uint32 pa
 	}
 }
 
-// Only overwrite passnow, know and count fields of savefile:
+// Overwrite the passnow, know and count fields of the savefile. We rewrite the entire file (via
+// init_savefile) rather than patching those fields in place, for two reasons:
+//   (1) The fields are variable-length decimal text (e.g. 'know' grows from "0" to a many-digit value
+//       between checkpoints), so an in-place overwrite would run past the field it means to replace.
+//   (2) Interleaving fgets reads and fprintf writes on a single "r+" (update-mode) stream without an
+//       intervening fseek/fflush is undefined behavior (C11 7.21.5.3p7); in practice it wrote the
+//       updated fields at the wrong offsets, corrupting the savefile and aborting the run at the first
+//       checkpoint. Reading the run-invariant fields back and re-emitting the whole file is both correct
+//       and simpler.
 int write_savefile(const char*fname, const char*pstring, uint32 passnow, uint64 know, uint64 count)
 {
-	 int itmp;
-	uint32 curr_line = 0, nerr = 0, passnow_file = 0;
-	uint64 know_file = 0;
-	char *char_addr;
-	/* TF restart files are in HRF, not binary: */
-	fp = mlucas_fopen(fname,"r+");	// Open in update ("read plus") mode
-	if(!fp) {
-	#ifndef FACTOR_STANDALONE
-		fp = mlucas_fopen(STATFILE,"a");
-		fprintf(	fp,"INFO: Unable to open factoring savefile %s for writing...quitting.\n",fname);
-		fclose(fp); fp = 0x0;
-	#endif
-		fprintf(stderr,"INFO: Unable to open factoring savefile %s for writing...quitting.\n",fname);
-		return -1;
-	} else {
-		/* Line 1: pstring */
-		++curr_line;
-		if(!fgets(g_in_line, STR_MAX_LEN, fp)) {
-			++nerr; fprintf(stderr,"ERROR: unable to read Line %d (current exponent) of factoring restart file %s!\n",curr_line,fname);
-		}
-		/* Strip the expected newline char from g_in_line: */
-		char_addr = strstr(g_in_line, "\n");
-		if(char_addr)
-			*char_addr = '\0';
-		/* Make sure restart-file and current-run pstring match: */
-		if(STRNEQ(g_in_line, pstring)) {
-			++nerr; fprintf(stderr,"ERROR: current exponent %s != Line %d of factoring restart file %s!\n",pstring,curr_line,fname);
-		}
-
-		/* Line 6: know */
-		while(++curr_line < 6) {
-			if(!fgets(g_in_line, STR_MAX_LEN, fp)) {
-				++nerr; fprintf(stderr,"ERROR: unable to read Line %d of factoring restart file %s!\n",curr_line,fname);
-			}
-		}
-		++curr_line;
-		if(!fgets(g_in_line, STR_MAX_LEN, fp)) {
-			++nerr; fprintf(stderr,"ERROR: unable to read Line %d (know) of factoring restart file %s!\n",curr_line,fname);
-		}
-		char_addr = strstr(g_in_line, "know");
-		if(!char_addr) {
-			++nerr; fprintf(stderr,"ERROR: 'know' not found in Line %d of factoring restart file %s!\n",curr_line,fname);
-		} else {
-			char_addr = strstr(g_in_line, "=");
-			if(!char_addr) {
-				++nerr; fprintf(stderr,"ERROR: Line %d of factoring restart file %s lacks the required = sign!\n",curr_line,fname);
-			}
-			char_addr++;
-			know_file = convert_base10_char_uint64(char_addr);
-		}
-		itmp = fprintf(fp,"know = %s\n", &char_buf0[convert_uint64_base10_char (char_buf0, know)]);
-		if(itmp <= 0) {
-			++nerr; fprintf(stderr,"ERROR: unable to write Line %d (know) of factoring restart file %s!\n",curr_line,fname);
-		}
-
-		/* Line 7: kmax: */
-		++curr_line;
-		if(!fgets(g_in_line, STR_MAX_LEN, fp)) {
-			++nerr; fprintf(stderr,"ERROR: unable to read Line %d (kmax) of factoring restart file %s!\n",curr_line,fname);
-		}
-		/* Line 8: passmin: */
-		++curr_line;
-		if(!fgets(g_in_line, STR_MAX_LEN, fp)) {
-			++nerr; fprintf(stderr,"ERROR: unable to read Line %d (passmin) of factoring restart file %s!\n",curr_line,fname);
-		}
-
-		/* Line 9: passnow: */
-		++curr_line;
-		if(!fgets(g_in_line, STR_MAX_LEN, fp)) {
-			++nerr; fprintf(stderr,"ERROR: unable to read Line %d (passnow) of factoring restart file %s!\n",curr_line,fname);
-		}
-		char_addr = strstr(g_in_line, "passnow");
-		if(!char_addr) {
-			++nerr; fprintf(stderr,"ERROR: 'passnow' not found in Line %d of factoring restart file %s!\n",curr_line,fname);
-		} else {
-			char_addr = strstr(g_in_line, "=");
-			if(!char_addr) {
-				++nerr; fprintf(stderr,"ERROR: Line %d of factoring restart file %s lacks the required = sign!\n",curr_line,fname);
-			}
-			char_addr++;
-			passnow_file = convert_base10_char_uint64(char_addr);
-		}
-		itmp = fprintf(fp,"passnow = %s\n", &char_buf0[convert_uint64_base10_char (char_buf0, passnow)]);
-		if(itmp <= 0) {
-			++nerr; fprintf(stderr,"ERROR: unable to write Line %d (passnow) of factoring restart file %s!\n",curr_line,fname);
-		}
-
-		// Check progress: compared to previous checkpoint, passnow should be same and know greater, or passnow should be greater:
-		if(passnow == passnow_file && know > know_file) {
-			/* No-op */
-		} else if(passnow > passnow_file) {
-			/* No-op */
-		} else {
-			++nerr; fprintf(stderr,"ERROR: In factoring restart file %s: compared to previous checkpoint, passnow[%u] should be same as file[%u] and know[%" PRIu64 "] greater than file[%" PRIu64 "], or passnow should be greater!\n",fname,passnow,passnow_file,know,know_file);
-		}
-
-		/* Line 10: passmax: */
-		++curr_line;
-		if(!fgets(g_in_line, STR_MAX_LEN, fp)) {
-			++nerr; fprintf(stderr,"ERROR: unable to read Line %d (passmax) of factoring restart file %s!\n",curr_line,fname);
-		}
-
-		/* Line 11: Number of q's tried: */
-		++curr_line;
-		if(!fgets(g_in_line, STR_MAX_LEN, fp)) {
-			++nerr; fprintf(stderr,"ERROR: unable to read Line %d (#Q tried) of factoring restart file %s!\n",curr_line,fname);
-		}
-		char_addr = strstr(g_in_line, "#Q tried");
-		if(!char_addr) {
-			++nerr; fprintf(stderr,"ERROR: '#Q tried' not found in Line %d of factoring restart file %s!\n",curr_line,fname);
-		} else {
-			char_addr = strstr(g_in_line, "=");
-			if(!char_addr) {
-				++nerr; fprintf(stderr,"ERROR: Line %d of factoring restart file %s lacks the required = sign!\n",curr_line,fname);
-			}
-			char_addr++;
-			/* uint64 count_file = */ convert_base10_char_uint64(char_addr);	// Need to reset == 0 prior to sieving so kvector-fill code works properly
-		}
-		++curr_line; itmp = fprintf(fp,"#Q tried = %s\n", &char_buf0[convert_uint64_base10_char (char_buf0, count)]);
-		if(itmp <= 0) {
-			++nerr; fprintf(stderr,"ERROR: unable to write Line %d (#Q tried) of factoring restart file %s!\n",curr_line,fname);
-		}
-		fclose(fp); fp = 0x0;
-		return (int)nerr;
+	int itmp;
+	double bmin = 0, bmax = 0;
+	uint64 kmin = 0, know_file = 0, kmax = 0, count_file = 0;
+	uint32 passmin = 0, passnow_file = 0, passmax = 0;
+	/* Recover the run-invariant fields (bmin/bmax/kmin/kmax/passmin/passmax) and the previous
+	checkpoint's know/passnow/count from the existing savefile: */
+	itmp = read_savefile(fname, pstring, &bmin,&bmax, &kmin,&know_file,&kmax, &passmin,&passnow_file,&passmax, &count_file);
+	if(itmp) {
+		fprintf(stderr,"ERROR: write_savefile: unable to read savefile %s prior to updating it.\n",fname);
+		return (itmp < 0) ? 1 : itmp;	// Normalize read_savefile's -1 ("no file") to a positive error count
 	}
+	/* Sanity-check forward progress vs the previous checkpoint: either the pass is unchanged and we
+	advanced within it (know increased), or we moved on to a later pass: */
+	if(!((passnow == passnow_file && know > know_file) || (passnow > passnow_file))) {
+		fprintf(stderr,"ERROR: In factoring restart file %s: compared to previous checkpoint, either passnow[%u] must equal file[%u] with know[%" PRIu64 "] > file[%" PRIu64 "], or passnow must exceed file[%u]!\n",fname,passnow,passnow_file,know,know_file,passnow_file);
+		return 1;
+	}
+	/* Rewrite the whole file, preserving the invariants and updating know/passnow/count: */
+	return init_savefile(fname, pstring, bmin,bmax, kmin,know,kmax, passmin,passnow,passmax, count);
 }
 
 /* This is actually an auxiliary source file, but give it a .h extension to allow wildcarded project builds of form 'gcc -c *.c' */

--- a/src/factor.c
+++ b/src/factor.c
@@ -3800,6 +3800,11 @@ MFACTOR_HELP:
 							{
 								if((res >> l) & 1)	/* If Lth bit = 1, Lth candidate of the inputs is a factor */
 								{
+									// k = 0 yields the trivial "factor" q = 2.k.p+1 = 1, which divides everything. It can
+									// be sieved when the lower factor-bound admits it (e.g. -bmin 0 => kmin 0); skip it, since
+									// 1 is not a factor and PRP-testing it would violate mi64_pprimeF's base-<-modulus
+									// precondition and abort the run (seen with tiny exponents such as -m 23 -bmin 0):
+									if(k_to_try[l] == 0) continue;
 								#ifdef MULTITHREAD
 									pthread_mutex_lock(&mutex_mi64);
 								//	printf("Found Factor: Thread %u locked mutex_mi64 ... ",tid);

--- a/src/factor.c
+++ b/src/factor.c
@@ -4534,11 +4534,13 @@ uint64*kmin, uint64*know, uint64*kmax, uint32*passmin, uint32*passnow, uint32*pa
 			char_addr = strstr(g_in_line, "=");
 			if(!char_addr) {
 				++nerr; fprintf(stderr,"ERROR: Line %d of factoring restart file %s lacks the required = sign!\n",curr_line,fname);
+			} else {
+				++char_addr;	// Skip past the '=' before parsing the value; sscanf("%lf") chokes on a leading '='
+				itmp = sscanf(char_addr, "%lf",bmin);
+				if(itmp != 1) {
+					++nerr; fprintf(stderr,"ERROR: unable to parse Line %d (bmin) of factoring restart file %s. Offending input = %s\n",curr_line,fname, g_in_line);
+				}
 			}
-		}
-		itmp = sscanf(char_addr, "%lf",bmin);
-		if(itmp != 1) {
-			++nerr; fprintf(stderr,"ERROR: unable to parse Line %d (bmin) of factoring restart file %s. Offending input = %s\n",curr_line,fname, g_in_line);
 		}
 
 		/* Line 4: bmax */
@@ -4553,11 +4555,13 @@ uint64*kmin, uint64*know, uint64*kmax, uint32*passmin, uint32*passnow, uint32*pa
 			char_addr = strstr(g_in_line, "=");
 			if(!char_addr) {
 				++nerr; fprintf(stderr,"ERROR: Line %d of factoring restart file %s lacks the required = sign!\n",curr_line,fname);
+			} else {
+				++char_addr;	// Skip past the '=' before parsing the value; sscanf("%lf") chokes on a leading '='
+				itmp = sscanf(char_addr, "%lf",bmax);
+				if(itmp != 1) {
+					++nerr; fprintf(stderr,"ERROR: unable to parse Line %d (bmax) of factoring restart file %s. Offending input = %s\n",curr_line,fname, g_in_line);
+				}
 			}
-		}
-		itmp = sscanf(char_addr, "%lf",bmax);
-		if(itmp != 1) {
-			++nerr; fprintf(stderr,"ERROR: unable to parse Line %d (bmax) of factoring restart file %s. Offending input = %s\n",curr_line,fname, g_in_line);
 		}
 
 	/************************************
@@ -4772,134 +4776,36 @@ uint64 kmin, uint64 know, uint64 kmax, uint32 passmin, uint32 passnow, uint32 pa
 	}
 }
 
-// Only overwrite passnow, know and count fields of savefile:
+// Overwrite the passnow, know and count fields of the savefile. We rewrite the entire file (via
+// init_savefile) rather than patching those fields in place, for two reasons:
+//   (1) The fields are variable-length decimal text (e.g. 'know' grows from "0" to a many-digit value
+//       between checkpoints), so an in-place overwrite would run past the field it means to replace.
+//   (2) Interleaving fgets reads and fprintf writes on a single "r+" (update-mode) stream without an
+//       intervening fseek/fflush is undefined behavior (C11 7.21.5.3p7); in practice it wrote the
+//       updated fields at the wrong offsets, corrupting the savefile and aborting the run at the first
+//       checkpoint. Reading the run-invariant fields back and re-emitting the whole file is both correct
+//       and simpler.
 int write_savefile(const char*fname, const char*pstring, uint32 passnow, uint64 know, uint64 count)
 {
-	 int itmp;
-	uint32 curr_line = 0, nerr = 0, passnow_file = 0;
-	uint64 know_file = 0;
-	char *char_addr;
-	/* TF restart files are in HRF, not binary: */
-	fp = mlucas_fopen(fname,"r+");	// Open in update ("read plus") mode
-	if(!fp) {
-	#ifndef FACTOR_STANDALONE
-		fp = mlucas_fopen(STATFILE,"a");
-		fprintf(	fp,"INFO: Unable to open factoring savefile %s for writing...quitting.\n",fname);
-		fclose(fp); fp = 0x0;
-	#endif
-		fprintf(stderr,"INFO: Unable to open factoring savefile %s for writing...quitting.\n",fname);
-		return -1;
-	} else {
-		/* Line 1: pstring */
-		++curr_line;
-		if(!fgets(g_in_line, STR_MAX_LEN, fp)) {
-			++nerr; fprintf(stderr,"ERROR: unable to read Line %d (current exponent) of factoring restart file %s!\n",curr_line,fname);
-		}
-		/* Strip the expected newline char from g_in_line: */
-		char_addr = strstr(g_in_line, "\n");
-		if(char_addr)
-			*char_addr = '\0';
-		/* Make sure restart-file and current-run pstring match: */
-		if(STRNEQ(g_in_line, pstring)) {
-			++nerr; fprintf(stderr,"ERROR: current exponent %s != Line %d of factoring restart file %s!\n",pstring,curr_line,fname);
-		}
-
-		/* Line 6: know */
-		while(++curr_line < 6) {
-			if(!fgets(g_in_line, STR_MAX_LEN, fp)) {
-				++nerr; fprintf(stderr,"ERROR: unable to read Line %d of factoring restart file %s!\n",curr_line,fname);
-			}
-		}
-		++curr_line;
-		if(!fgets(g_in_line, STR_MAX_LEN, fp)) {
-			++nerr; fprintf(stderr,"ERROR: unable to read Line %d (know) of factoring restart file %s!\n",curr_line,fname);
-		}
-		char_addr = strstr(g_in_line, "know");
-		if(!char_addr) {
-			++nerr; fprintf(stderr,"ERROR: 'know' not found in Line %d of factoring restart file %s!\n",curr_line,fname);
-		} else {
-			char_addr = strstr(g_in_line, "=");
-			if(!char_addr) {
-				++nerr; fprintf(stderr,"ERROR: Line %d of factoring restart file %s lacks the required = sign!\n",curr_line,fname);
-			}
-			char_addr++;
-			know_file = convert_base10_char_uint64(char_addr);
-		}
-		itmp = fprintf(fp,"know = %s\n", &char_buf0[convert_uint64_base10_char (char_buf0, know)]);
-		if(itmp <= 0) {
-			++nerr; fprintf(stderr,"ERROR: unable to write Line %d (know) of factoring restart file %s!\n",curr_line,fname);
-		}
-
-		/* Line 7: kmax: */
-		++curr_line;
-		if(!fgets(g_in_line, STR_MAX_LEN, fp)) {
-			++nerr; fprintf(stderr,"ERROR: unable to read Line %d (kmax) of factoring restart file %s!\n",curr_line,fname);
-		}
-		/* Line 8: passmin: */
-		++curr_line;
-		if(!fgets(g_in_line, STR_MAX_LEN, fp)) {
-			++nerr; fprintf(stderr,"ERROR: unable to read Line %d (passmin) of factoring restart file %s!\n",curr_line,fname);
-		}
-
-		/* Line 9: passnow: */
-		++curr_line;
-		if(!fgets(g_in_line, STR_MAX_LEN, fp)) {
-			++nerr; fprintf(stderr,"ERROR: unable to read Line %d (passnow) of factoring restart file %s!\n",curr_line,fname);
-		}
-		char_addr = strstr(g_in_line, "passnow");
-		if(!char_addr) {
-			++nerr; fprintf(stderr,"ERROR: 'passnow' not found in Line %d of factoring restart file %s!\n",curr_line,fname);
-		} else {
-			char_addr = strstr(g_in_line, "=");
-			if(!char_addr) {
-				++nerr; fprintf(stderr,"ERROR: Line %d of factoring restart file %s lacks the required = sign!\n",curr_line,fname);
-			}
-			char_addr++;
-			passnow_file = convert_base10_char_uint64(char_addr);
-		}
-		itmp = fprintf(fp,"passnow = %s\n", &char_buf0[convert_uint64_base10_char (char_buf0, passnow)]);
-		if(itmp <= 0) {
-			++nerr; fprintf(stderr,"ERROR: unable to write Line %d (passnow) of factoring restart file %s!\n",curr_line,fname);
-		}
-
-		// Check progress: compared to previous checkpoint, passnow should be same and know greater, or passnow should be greater:
-		if(passnow == passnow_file && know > know_file) {
-			/* No-op */
-		} else if(passnow > passnow_file) {
-			/* No-op */
-		} else {
-			++nerr; fprintf(stderr,"ERROR: In factoring restart file %s: compared to previous checkpoint, passnow[%u] should be same as file[%u] and know[%" PRIu64 "] greater than file[%" PRIu64 "], or passnow should be greater!\n",fname,passnow,passnow_file,know,know_file);
-		}
-
-		/* Line 10: passmax: */
-		++curr_line;
-		if(!fgets(g_in_line, STR_MAX_LEN, fp)) {
-			++nerr; fprintf(stderr,"ERROR: unable to read Line %d (passmax) of factoring restart file %s!\n",curr_line,fname);
-		}
-
-		/* Line 11: Number of q's tried: */
-		++curr_line;
-		if(!fgets(g_in_line, STR_MAX_LEN, fp)) {
-			++nerr; fprintf(stderr,"ERROR: unable to read Line %d (#Q tried) of factoring restart file %s!\n",curr_line,fname);
-		}
-		char_addr = strstr(g_in_line, "#Q tried");
-		if(!char_addr) {
-			++nerr; fprintf(stderr,"ERROR: '#Q tried' not found in Line %d of factoring restart file %s!\n",curr_line,fname);
-		} else {
-			char_addr = strstr(g_in_line, "=");
-			if(!char_addr) {
-				++nerr; fprintf(stderr,"ERROR: Line %d of factoring restart file %s lacks the required = sign!\n",curr_line,fname);
-			}
-			char_addr++;
-			/* uint64 count_file = */ convert_base10_char_uint64(char_addr);	// Need to reset == 0 prior to sieving so kvector-fill code works properly
-		}
-		++curr_line; itmp = fprintf(fp,"#Q tried = %s\n", &char_buf0[convert_uint64_base10_char (char_buf0, count)]);
-		if(itmp <= 0) {
-			++nerr; fprintf(stderr,"ERROR: unable to write Line %d (#Q tried) of factoring restart file %s!\n",curr_line,fname);
-		}
-		fclose(fp); fp = 0x0;
-		return (int)nerr;
+	int itmp;
+	double bmin = 0, bmax = 0;
+	uint64 kmin = 0, know_file = 0, kmax = 0, count_file = 0;
+	uint32 passmin = 0, passnow_file = 0, passmax = 0;
+	/* Recover the run-invariant fields (bmin/bmax/kmin/kmax/passmin/passmax) and the previous
+	checkpoint's know/passnow/count from the existing savefile: */
+	itmp = read_savefile(fname, pstring, &bmin,&bmax, &kmin,&know_file,&kmax, &passmin,&passnow_file,&passmax, &count_file);
+	if(itmp) {
+		fprintf(stderr,"ERROR: write_savefile: unable to read savefile %s prior to updating it.\n",fname);
+		return (itmp < 0) ? 1 : itmp;	// Normalize read_savefile's -1 ("no file") to a positive error count
 	}
+	/* Sanity-check forward progress vs the previous checkpoint: either the pass is unchanged and we
+	advanced within it (know increased), or we moved on to a later pass: */
+	if(!((passnow == passnow_file && know > know_file) || (passnow > passnow_file))) {
+		fprintf(stderr,"ERROR: In factoring restart file %s: compared to previous checkpoint, either passnow[%u] must equal file[%u] with know[%" PRIu64 "] > file[%" PRIu64 "], or passnow must exceed file[%u]!\n",fname,passnow,passnow_file,know,know_file,passnow_file);
+		return 1;
+	}
+	/* Rewrite the whole file, preserving the invariants and updating know/passnow/count: */
+	return init_savefile(fname, pstring, bmin,bmax, kmin,know,kmax, passmin,passnow,passmax, count);
 }
 
 /* This is actually an auxiliary source file, but give it a .h extension to allow wildcarded project builds of form 'gcc -c *.c' */

--- a/src/factor.c
+++ b/src/factor.c
@@ -3194,6 +3194,12 @@ MFACTOR_HELP:
 			// [ = 272272 or 226304, resp., depending on whether TF_CLASSES = 60 or 4620].
 			// We vectorize the 2nd loop, since each prime therein will hit at most one bit of the sievelet,
 			// i.e. we require no while-loop, only an if(curr_p's startval < bit_len or not) conditional.
+			// The vectorized bit-clearing below cannot handle the 0xFFFFFFFF 'p == curr_p' sentinel start-value
+			// get_startval() sets when the exponent p is itself within the sieving-prime range - only reachable
+			// by tiny exponents (e.g. the '-m 127 -bmax 20' self-test). Fall back to the scalar loop for that
+			// case; the AVX-512 path handles all real (large) exponents, where no sieving prime equals p.
+			const uint32 small_p = (lenP == 1) && (p[0] <= MAX_SIEVING_PRIME);
+			if(!small_p) {
 		// Loop #1:
 			curr_p = p_last_small;
 			for(m = nclear; m < nprime; m++)
@@ -3255,7 +3261,9 @@ MFACTOR_HELP:
 			);
 		/*	}	*/
 
-		#else	/******** Non-SIMD (pre-AVX512) **********/
+			} else	// small_p: the vectorized sieve can't handle the p==curr_p sentinel; use the scalar loop below
+		#endif
+			{	/******** Non-SIMD (pre-AVX512) - also the small-exponent fallback from the AVX-512 path above **********/
 
 		  #ifdef USE_NCQ
 			#warning Using 4-way bit-clear in PerPass_tfSieve.
@@ -3301,7 +3309,7 @@ MFACTOR_HELP:
 				}
 			}
 
-		#endif	// AVX-512 (non-IMCI) sieve ?
+			}	// end of the AVX-512-vs-scalar (incl. small_p fallback) bit-clearing block
 
 //	if(pass==4)printf("\nPass %u: word0 after deep-prime clearing = %16" PRIX64 "\n",pass,bit_map2[0]);
 


### PR DESCRIPTION
While wiring the Mfactor `test_fac` self-test into CI, I found that running an actual Mfactor factoring job aborts. Two independent, pre-existing bugs in the Mfactor savefile/factoring paths, each fixed in its own commit:

## 1. Checkpoint savefile corruption (`write_savefile`/`read_savefile`)

Single-threaded Mfactor runs write a `t{exponent}` checkpoint savefile every 1024 passes and at end-of-pass, and read it back on restart. Both directions were broken, so every run that reached a checkpoint aborted:

- **`write_savefile`** opened the file `"r+"` and interleaved `fgets` reads with `fprintf` writes with **no intervening `fseek`/`fflush`** — undefined behavior (C11 §7.21.5.3p7: input may not be directly followed by output on an update stream without a repositioning call). In practice it wrote fields at the wrong offsets, producing a garbled savefile (duplicated/truncated field names). It also tried to overwrite **variable-length** decimal fields in place (`know` grows from `"0"` to a many-digit value between checkpoints), which cannot work even with correct positioning. Rewritten to read back the run-invariant fields and re-emit the whole file via `init_savefile()`.
- **`read_savefile`** parsed the `bmin`/`bmax` lines with `sscanf(char_addr,"%lf",…)` after locating the `=`, but never advanced past the `=`, so `sscanf` saw `"= 0.000000"` and failed — every restart aborted with *"There were errors reading the savefile"*. Advance past the `=` (as the integer-field parsers already do), and guard a missing `=` instead of scanning through `NULL`.

Verified end-to-end: a from-scratch `-m 127 -bmax 20` run completes and writes a well-formed savefile (`know`/`passnow`/`#Q tried` correctly updated), and a subsequent restart reads it back cleanly and recognizes the completed run.

## 2. Trivial `k=0` candidate aborts tiny-exponent runs

With the default `-bmin 0`, the sieve can present `k = 0`, i.e. the trivial "factor" `q = 2·k·p+1 = 1`. Since 1 divides every M(p), it is flagged as a factor and PRP-tested via `mi64_pprimeF(q,3,…)`, whose Montgomery powering asserts `base < modulus` (`3 < 1` is false) → abort. Trivial to hit, e.g. `./Mfactor -m 23 -bmax 8`. 1 is never a factor, so the trivial `k=0` candidate is skipped. Real runs (`kmin ≥ 1`) never sieve `k=0`, so this is a no-op for them; verified `-m 67 -bmax 20` still finds `q = 193707721` and formerly-aborting tiny cases now exit cleanly.

Both bugs predate the current campaign; the Mfactor checkpoint code was evidently never exercised (note the standing `#error Multithreaded checkpointing stuff needs debug & test!`). This makes single-threaded Mfactor checkpoint/restart actually work.