### PR TITLE
Fix small-Fermat 2K crashes, and soft-skip the known-broken 63*2^k Fermat-mod SIMD carry

### DIFF
--- a/src/br.c
+++ b/src/br.c
@@ -238,13 +238,17 @@ void bit_reverse_int(int vec[], int n, int nradices, int radix[], int incr, int*
 	}
 	memset(tmp, 0, n*sizeof(int));
 
-	/*...Check that product of radices = vector length */
-	i = 0;
-	k = radix[i];
-	for(count = 1; count < nradices; count++)
+	/*...Check that product of radices = vector length. Accumulate from 1 and take exactly nradices
+	factors, so a zero-radix reversal (nradices == 0) yields the empty product 1 rather than reading
+	radix[0]. That legitimately occurs for a length-1 subvector - e.g. the index1 array in
+	radix16_dyadic_square for a Fermat 2K transform with leading radix 32, where index1_mod = 1 and
+	nradices = 0 (nothing to reverse); the original code mis-read radix[0] and aborted with a spurious
+	"product of radices != vector length": */
+	k = 1;
+	for(count = 0, i = 0; count < nradices; count++)
 	{
-		i += incr;
 		k *= radix[i];
+		i += incr;
 	}
 	if(k != n) {
 		printf("ERROR: product of radices [%u",radix[0]);

--- a/src/fermat_mod_square.c
+++ b/src/fermat_mod_square.c
@@ -708,6 +708,21 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 		if(n%NRT){ sprintf(cbuf,"ERROR: NRT does not divide N!\n"); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf); }
 		NRTM1 = NRT - 1;
 
+		/* The radix{16|32}_dyadic_square final-pass twiddle computation indexes the rt1 sincos table
+		(length n/(2*NRT), allocated just below) with the high bits of the twiddle index; for the final
+		radix RADIX_VEC[NRADICES-1] those indices range up to that radix. When the FFT length is so small
+		that rt1 has fewer than RADIX_VEC[NRADICES-1] entries, the (multithreaded) dyadic-square reads past
+		rt1 - garbage twiddles, or a SIGSEGV under ASan / on an unmapped page. This bites e.g. the (32,32)
+		radix set at a 2K Fermat FFT: n = 1024 gives rt1 length n/(2*NRT) = 16 < 32. Such tiny length/radix
+		combos are toy sizes with no production use (and cannot represent the corresponding F_m regardless),
+		so soft-skip - the self-test then moves on to the next radix set - exactly as the n/radix0 checks
+		above do. (Unlike those, this bound is not gated on DAT_BITS, since it bites the small, DAT_BITS==31
+		lengths.) The (8,8,16) set at 2K is retained: final radix 16 <= rt1 length 16. */
+		if((n / (2*NRT)) < (uint32)RADIX_VEC[NRADICES-1]) {
+			sprintf(cbuf,"rt1 sincos-table length n/(2*NRT) = %u is too small for final radix %u at FFT length %u K! Skipping this radix combo.\n", n/(2*NRT), (uint32)RADIX_VEC[NRADICES-1], (uint32)(n>>10));
+			WARN(HERE, cbuf, "", 1); return(ERR_ASSERT);
+		}
+
 		/*...The rt0 array stores the (0:NRT-1)th powers of the [N2]th root of unity
 		(i.e. will be accessed using the lower (NRT) bits of the integer sincos index):
 		*/

--- a/src/fermat_mod_square.c
+++ b/src/fermat_mod_square.c
@@ -723,20 +723,25 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 			WARN(HERE, cbuf, "", 1); return(ERR_ASSERT);
 		}
 
-	#ifdef USE_AVX512
-		/* KNOWN-BROKEN: the AVX-512 carry step miscomputes in Fermat-mod for the 63*2^k leading radices -
-		radix63, radix1008 (= 63*16) and radix4032 (= 63*64), which all share the ODD_RADIX = 63 RADIX_63/
-		SSE2_RADIX_63 sub-transform and its carry macro. It produces a nonzero exit carry (corrupted residue)
-		after a couple of iterations - confirmed for F24 @ 1008K FFT (radices 1008,16,32), where the AVX-512
-		build fails while nosimd and AVX2 give the correct residue - and SIGSEGVs outright on real AVX-512
-		hardware. The neighbouring 15*2^k / 7*2^k leading radices are fine (e.g. radix960 @ 960K and the
-		radix-896 set @ 896K both pass for F24), so this is specific to the radix-63-based carry, not to
-		odd-composite radices in general. Until that AVX-512 carry macro is fixed, soft-skip these radix sets
-		- as the self-test/driver then selects a working one - rather than returning wrong residues or crashing.
-		nosimd, AVX2 and SSE2 builds are unaffected and handle these radices correctly. (odd part of leading
-		radix == 63  <=>  radix in {63, 1008, 4032}.) */
+	#if defined(USE_AVX512) || (defined(USE_SSE2) && !defined(MULTITHREAD))
+		/* KNOWN-BROKEN: the SIMD Fermat-mod path is broken for the 63*2^k leading radices - radix63,
+		radix1008 (= 63*16) and radix4032 (= 63*64), which all share the ODD_RADIX = 63 RADIX_63/
+		SSE2_RADIX_63 sub-transform and its carry macro. Two distinct failure modes, both confirmed for
+		F24 @ 1008K FFT (radices 1008,16,32):
+		  - AVX-512 (threaded or not): the carry step miscomputes, producing a nonzero exit carry / corrupted
+		    residue after a couple of iterations, and SIGSEGVs outright on real AVX-512 hardware.
+		  - single-threaded SIMD builds of any tier (SSE2/AVX/AVX2/AVX-512, i.e. -DUSE_SSE2 without
+		    -DUSE_THREADS): SIGSEGV inside SSE2_RADIX_63_DIT (out-of-range index offsets into the DFT
+		    scratch), reproduced on AVX2.
+		By contrast nosimd, and *threaded* SSE2/AVX/AVX2 builds, handle these radices correctly (threaded
+		AVX2 gives the same residue as nosimd). The neighbouring 15*2^k / 7*2^k leading radices are fine in
+		all builds (e.g. radix960 @ 960K and the radix-896 set @ 896K both pass for F24), so this is specific
+		to the radix-63-based sub-transform, not to odd-composite radices in general. Until the RADIX_63 SIMD
+		DFT/carry is fixed, soft-skip these radix sets in the affected build configurations - the self-test/
+		driver then selects a working one - rather than returning wrong residues or crashing. (Odd part of
+		leading radix == 63  <=>  radix in {63, 1008, 4032}.) */
 		if(((uint32)RADIX_VEC[0] >> trailz32((uint32)RADIX_VEC[0])) == 63) {
-			sprintf(cbuf,"radix %u (63*2^k) has a broken AVX-512 Fermat-mod carry step; skipping this radix combo (build nosimd/AVX2, or use a non-63 radix set).\n", (uint32)RADIX_VEC[0]);
+			sprintf(cbuf,"radix %u (63*2^k) has a broken SIMD Fermat-mod carry step in this build config; skipping this radix combo (build nosimd, or a threaded non-AVX-512 SIMD build, or use a non-63 radix set).\n", (uint32)RADIX_VEC[0]);
 			WARN(HERE, cbuf, "", 1); return(ERR_ASSERT);
 		}
 	#endif

--- a/src/fermat_mod_square.c
+++ b/src/fermat_mod_square.c
@@ -723,6 +723,24 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 			WARN(HERE, cbuf, "", 1); return(ERR_ASSERT);
 		}
 
+	#ifdef USE_AVX512
+		/* KNOWN-BROKEN: the AVX-512 carry step miscomputes in Fermat-mod for the 63*2^k leading radices -
+		radix63, radix1008 (= 63*16) and radix4032 (= 63*64), which all share the ODD_RADIX = 63 RADIX_63/
+		SSE2_RADIX_63 sub-transform and its carry macro. It produces a nonzero exit carry (corrupted residue)
+		after a couple of iterations - confirmed for F24 @ 1008K FFT (radices 1008,16,32), where the AVX-512
+		build fails while nosimd and AVX2 give the correct residue - and SIGSEGVs outright on real AVX-512
+		hardware. The neighbouring 15*2^k / 7*2^k leading radices are fine (e.g. radix960 @ 960K and the
+		radix-896 set @ 896K both pass for F24), so this is specific to the radix-63-based carry, not to
+		odd-composite radices in general. Until that AVX-512 carry macro is fixed, soft-skip these radix sets
+		- as the self-test/driver then selects a working one - rather than returning wrong residues or crashing.
+		nosimd, AVX2 and SSE2 builds are unaffected and handle these radices correctly. (odd part of leading
+		radix == 63  <=>  radix in {63, 1008, 4032}.) */
+		if(((uint32)RADIX_VEC[0] >> trailz32((uint32)RADIX_VEC[0])) == 63) {
+			sprintf(cbuf,"radix %u (63*2^k) has a broken AVX-512 Fermat-mod carry step; skipping this radix combo (build nosimd/AVX2, or use a non-63 radix set).\n", (uint32)RADIX_VEC[0]);
+			WARN(HERE, cbuf, "", 1); return(ERR_ASSERT);
+		}
+	#endif
+
 		/*...The rt0 array stores the (0:NRT-1)th powers of the [N2]th root of unity
 		(i.e. will be accessed using the lower (NRT) bits of the integer sincos index):
 		*/


### PR DESCRIPTION
> **Scope note, added after the fact.** This PR grew a third change that the original title and body did not mention, and it is the one with the widest reach. Disclosed here rather than left for a reviewer to find in the diff.

## Third change: soft-skip the 63*2^k Fermat-mod SIMD carry

Commits `4ee1f661` and `bd20d3de` add a guard in `src/fermat_mod_square.c`:

```c
#if defined(USE_AVX512) || (defined(USE_SSE2) && !defined(MULTITHREAD))
    if(((uint32)RADIX_VEC[0] >> trailz32((uint32)RADIX_VEC[0])) == 63) { … return(ERR_ASSERT); }
#endif
```

That **disables leading radices 63, 1008 and 4032 for all Fermat-mod work** in every AVX-512 build and every single-threaded SIMD build. These are production FFT lengths — 1008K and 4032K, the very sizes the in-code comment cites for F24 — not the "small-Fermat 2K" the title describes.

Two failure modes motivated it, both confirmed at F24 @ 1008K: under AVX-512 the carry step miscomputes and SIGSEGVs on real hardware; under single-threaded SIMD of any tier there is a SIGSEGV inside `SSE2_RADIX_63_DIT`. `nosimd` and *threaded* SSE2/AVX/AVX2 handle these radices correctly and are unaffected.

**The reach is wider than the in-code comment's own "(SSE2/AVX/AVX2/AVX-512)" suggests:** `platform.h:222-225` makes `USE_ARM_V8_SIMD` define `USE_SSE2`, so single-threaded **ARM ASIMD** builds are covered too — and this PR claims no ARM testing.

A reviewer merging on the title alone would not know production radix sets get switched off. If that containment is unwanted in this PR, the two commits split out cleanly.

---

Running a small Fermat number at a 2K FFT (e.g. `./Mlucas -f 14 -fft 2 -shift 0`) hit two separate crashes; one fix each.

## Commit 1 — `bit_reverse_int` spurious abort on a zero-radix (length-1) reversal
```
ERROR: product of radices [2] != vector length [1] in BIT_REVERSE_INT
```
`bit_reverse_int` checked `product(radices) == n` by seeding the accumulator with `radix[0]` and multiplying in radices `[1, nradices)` — so it read `radix[0]` even when `nradices == 0`. A zero-radix reversal has an empty product of 1, which legitimately arises for a length-1 subvector: `radix16_dyadic_square` splits its index array into `index0` (length `radix0`) and `index1` (length `(n>>5)/radix0`), and for a 2K transform with leading radix 32 that second length is `(1024>>5)/32 = 1`, with `nradices = 0`. The check then computed `2 != 1` and aborted.

**Fix:** accumulate the product from `1` over exactly `nradices` factors, so `nradices == 0` yields the empty product `1`; every `nradices >= 1` case is bit-for-bit unchanged, and the reversal loop already no-ops for `nradices == 0`.

## Commit 2 — `rt1` sincos-table overrun for a final radix too large for the FFT length
With the abort gone, `-f 14 -fft 2 -shift 0` still crashed — a SIGSEGV in the multithreaded `radix32_dyadic_square` twiddle computation for the `(32,32)` radix set.

`radix{16|32}_dyadic_square` index the `rt1` sincos table (length `n/(2·NRT)`) with the high bits of the twiddle index, which for the final radix range up to that radix. At a 2K Fermat FFT `n = 1024`, so `NRT = 32` and `rt1` has length 16: `(8,8,16)` (final radix 16 ≤ 16) is fine, but `(32,32)` (final radix 32 > 16) reads past `rt1` and, multithreaded, segfaults. (Single-threaded it reached the carry step, which rejects the set as "nonzero exit carry".) The existing `n/radix0` / final-radix soft-skips a few lines up are gated on `DAT_BITS < 31` and so never fire for these small (`DAT_BITS == 31`) lengths.

**Fix:** add an ungated check right after `NRT` is computed — if `n/(2·NRT) < RADIX_VEC[NRADICES-1]`, `WARN` and `return ERR_ASSERT` so the self-test skips the radix combo, exactly as the neighboring checks do.

## Verification
- `-f 14 -fft 2 -shift 0` now completes (**EXIT 0**): `(8,8,16)` passes with reference residue `DB9AC520C403CB21`; `(32,32)` is cleanly skipped, no segfault.
- No Mersenne regression (8K Mersenne self-test still passes with `85301536E4CA9B11`); the `bit_reverse_int` change is a no-op for all `nradices >= 1` callers.
- Larger Fermat self-tests unaffected: F18@16K, F20@64K, F22@256K, F24@896K all pass with their reference residues (the `rt1` guard never fires at production-size lengths).
