### PR TITLE
factor: size k_to_try for the widest SIMD modpow init-warmup (fix OOB read)

### DIFF
--- a/src/factor.c
+++ b/src/factor.c
@@ -1005,7 +1005,7 @@ Others are optional and in some cases mutually exclusive:
 		// TRYQ*NTHREADS-sized (TRYQ can be 4) buffer is over-read. The extra slots are zero (calloc), so
 		// the warmup reads stay valid. Undersized here => OOB read of uninitialized heap, which trips the
 		// 'Ks must be < 2^52' assertion in q32/q64 on hosts whose heap past the alloc isn't zeroed.
-		k_to_try = (uint64 *)calloc(MAX(TRYQ * NTHREADS, 64), sizeof(uint64));
+		k_to_try = (uint64 *)CALLOC(MAX(TRYQ * NTHREADS, 64), sizeof(uint64));
 	#else
 		MAX_THREADS = get_num_cores();
 		ASSERT(MAX_THREADS > 0, "Illegal #Cores value stored in MAX_THREADS");
@@ -1031,7 +1031,7 @@ Others are optional and in some cases mutually exclusive:
 		// TRYQ*NTHREADS-sized (TRYQ can be 4) buffer is over-read. The extra slots are zero (calloc), so
 		// the warmup reads stay valid. Undersized here => OOB read of uninitialized heap, which trips the
 		// 'Ks must be < 2^52' assertion in q32/q64 on hosts whose heap past the alloc isn't zeroed.
-		k_to_try = (uint64 *)calloc(MAX(TRYQ * NTHREADS, 64), sizeof(uint64));
+		k_to_try = (uint64 *)CALLOC(MAX(TRYQ * NTHREADS, 64), sizeof(uint64));
 
 		// Up to TF_PASSES work units (perhaps fewer if a restart) get done by a pool of NTHREADS threads.  Yypically have
 		// NTHREADS <= TF_PASSES, i.e. pool threads get reassigned a fresh work unit as they complete their current one.

--- a/src/factor.c
+++ b/src/factor.c
@@ -1000,7 +1000,12 @@ Others are optional and in some cases mutually exclusive:
 	#ifndef MULTITHREAD
 		#warning Building factor.c in unthreaded (i.e. single-main-thread) mode.
 		ASSERT(NTHREADS == 1, "NTHREADS must == 1 in single-threaded mode!");
-		k_to_try = (uint64 *)calloc(TRYQ * NTHREADS, sizeof(uint64));
+		// Size for the widest one-time SIMD modpow init-warmup below: twopmodq78_3WORD_DOUBLE_q8/q16/
+		// q32/q64 each read a full 8/16/32/64-wide k[] batch (widest q64 = 64) regardless of TRYQ, so a
+		// TRYQ*NTHREADS-sized (TRYQ can be 4) buffer is over-read. The extra slots are zero (calloc), so
+		// the warmup reads stay valid. Undersized here => OOB read of uninitialized heap, which trips the
+		// 'Ks must be < 2^52' assertion in q32/q64 on hosts whose heap past the alloc isn't zeroed.
+		k_to_try = (uint64 *)calloc(MAX(TRYQ * NTHREADS, 64), sizeof(uint64));
 	#else
 		MAX_THREADS = get_num_cores();
 		ASSERT(MAX_THREADS > 0, "Illegal #Cores value stored in MAX_THREADS");
@@ -1021,7 +1026,12 @@ Others are optional and in some cases mutually exclusive:
 		}
 		sprintf(cbuf,"0:%d",NTHREADS-1);
 		parseAffinityString(cbuf);
-		k_to_try = (uint64 *)calloc(TRYQ * NTHREADS, sizeof(uint64));
+		// Size for the widest one-time SIMD modpow init-warmup below: twopmodq78_3WORD_DOUBLE_q8/q16/
+		// q32/q64 each read a full 8/16/32/64-wide k[] batch (widest q64 = 64) regardless of TRYQ, so a
+		// TRYQ*NTHREADS-sized (TRYQ can be 4) buffer is over-read. The extra slots are zero (calloc), so
+		// the warmup reads stay valid. Undersized here => OOB read of uninitialized heap, which trips the
+		// 'Ks must be < 2^52' assertion in q32/q64 on hosts whose heap past the alloc isn't zeroed.
+		k_to_try = (uint64 *)calloc(MAX(TRYQ * NTHREADS, 64), sizeof(uint64));
 
 		// Up to TF_PASSES work units (perhaps fewer if a restart) get done by a pool of NTHREADS threads.  Yypically have
 		// NTHREADS <= TF_PASSES, i.e. pool threads get reassigned a fresh work unit as they complete their current one.


### PR DESCRIPTION
## Problem

The one-time *"init-calls to inline-asm-using modpow functions"* in `main()` (`factor.c`, in the `MULTITHREAD` branch) pass `k_to_try` to `twopmodq78_3WORD_DOUBLE_q8/q16/q32/q64`.

`q32` and `q64` read a full 32- and 64-wide batch of k-values from that array **at function entry** — ahead of the `if(init_sse2) return 0;` early return that the init-mode call takes:

```c
for(j = 0; j < 32; j++) {
    ASSERT((k[j] >> 52) == 0ull, "Ks must be < 2^52!");
    kdbl[j] = (double)k[j];
}
```

`q8` and `q16` are not like that: their `init_sse2` early return comes before their first `k[]` read, so in init mode they never touch the array. (The `k[]` reads near the top of `q16` are inside `#if FAC_DEBUG`.)

But `k_to_try` is allocated with only `TRYQ * NTHREADS` entries, and `TRYQ` is 8 or less in every configuration (4 in the common one), so the q32/q64 warmup calls read **past the end of the buffer** — 28 and 60 elements OOB respectively at `TRYQ = 4, NTHREADS = 1`.

The values don't matter to the warmup (it runs with `p = 0`), but the read itself is out of bounds. On a host whose heap past the allocation isn't zeroed, a stray `k[j] >= 2^52` trips the AVX-512 precondition

```c
ASSERT((k[j] >> 52) == 0ull, "Ks must be < 2^52!")
```

and aborts. This reproduces on Windows/MinGW **AVX-512** CI runners; it's masked elsewhere only because the adjacent heap usually reads back as zero.

## Fix

Size the zero-filled allocation to `MAX(TRYQ * NTHREADS, 64)` (widest warmup = q64 = 64) at both alloc sites (single- and multi-threaded). The extra slots are zero, so the warmup reads stay valid.

## Testing

Reproduced deterministically on Linux under Intel SDE with a dirtied heap:

```
$ MALLOC_PERTURB_=255 sde64 -skx -- ./Mfactor -m 127 -bmax 20
  ...twopmodq78_3WORD_DOUBLE_q32: Setting up...
  Assertion '(k[j] >> 52) == 0ull' failed: Ks must be < 2^52!     # before
  Factoring self-tests completed successfully.                    # after fix
```

nosimd / AVX2 unaffected — q32/q64 are only called under `#ifdef USE_AVX512`, and the q8/q16 calls that the SSE2/AVX builds make return before reading `k[]`. The change only enlarges a zeroed allocation in any case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
