### PR TITLE
mi64: fix out-of-bounds writes and latent memory-safety traps

### DIFF
--- a/src/mi64.c
+++ b/src/mi64.c
@@ -614,11 +614,19 @@ uint64	mi64_shrl(const uint64 x[], uint64 y[], uint32 nshift, uint32 len, uint32
 	So allow output_len to be 1 limb smaller than 17 as a fudge factor to handle arbitrary in-word copy-bit boundaries:
 	*/
 	ASSERT(output_len >= (len-nwshift)-1, "mi64_shrl: output_len must be large enough to hold result!");
+	/* v21: the "fudge factor" case output_len == (len-nwshift)-1 permitted by the above assert was
+	documented ("only copy that many and exit") but never implemented: every write path below wrote
+	the full (len-nwshift) result words, i.e. one word past the caller's buffer. All writes are now
+	clamped to output_len. */
 	// Special-casing for 0 shift count:
 	if(!nshift) {
 		if(x != y) {
-			mi64_set_eq(y, x, len);				// Set y = x...
-			mi64_clear(y+len, output_len - len);// ...and 0 any excess high limbs in y.
+			i = MIN(len, output_len);
+			mi64_set_eq(y, x, i);				// Set y = x...
+			if(output_len > len)
+				mi64_clear(y+len, output_len - len);// ...and 0 any excess high limbs in y.
+				// (Note the guard: the old unguarded form passed a huge unsigned count if
+				// output_len < len, wiping (2^32 - small) words beyond the buffer.)
 		}
 		return 0ull;
 	}
@@ -638,18 +646,19 @@ uint64	mi64_shrl(const uint64 x[], uint64 y[], uint32 nshift, uint32 len, uint32
 		hi64 = x[nwshift-1];
 	}
 	if(!rembits) {	// Whole-word shift:
-		for(i = 0; i < len-nwshift; i++) {
+		for(i = 0; i < len-nwshift && i < (int)output_len; i++) {	// v21: clamp to output_len (fudge-factor case)
 			y[i] = x[i+nwshift];
 		}
 	} else {	// nshift not an exact multiple of the wordlength:
 		m64bits = (64-rembits);
 		if(nwshift)
 			hi64 = (hi64 >> rembits) + (x[nwshift] << m64bits);
-		for(i = 0; i < len-nwshift-1; i++) {
+		for(i = 0; i < len-nwshift-1 && i < (int)output_len; i++) {	// v21: clamp to output_len (fudge-factor case)
 			y[i] = (x[i+nwshift] >> rembits) + (x[i+nwshift+1] << m64bits);	// Ex: on exit have just finished y[37] = x[1130]>>48 + x[1131]<<16
 		}																	// thus 2432 of our 2448 target bits
 		// Most-significant element gets zeros shifted in from the left:
-		y[i] = (x[i+nwshift] >> rembits);									// Ex: y[len-nwshift-1] = y[38] = x[1131]>>48
+		if(i < (int)output_len)	// v21: in the fudge-factor case the caller asked for one fewer word - skip it
+			y[i] = (x[i+nwshift] >> rembits);								// Ex: y[len-nwshift-1] = y[38] = x[1131]>>48
 		for(i = len-nwshift; i < output_len; i++) {
 			y[i] = 0ull;
 		}
@@ -2271,6 +2280,9 @@ uint64	mi64_add_cyin(const uint64 x[], const uint64 y[], uint64 z[], uint32 len,
 
 	uint64	mi64_add(const uint64 x[], const uint64 y[], uint64 z[], uint32 len)
 	{
+		// v21: the C implementation asserts len != 0; the ASM path must do the same, since its loop
+		// counter setup ("decq" before the first termination check) would treat len == 0 as 2^64:
+		ASSERT(len != 0, "mi64_add: zero-length array!");
 	#if 0//def USE_AVX
 		#error experimental-only code ... still needs debugging! [Jul 2016 - carry into topmost word missing]
 		// Hybrid int64 / sse2 -based impl of ?-folded adc loop
@@ -4222,7 +4234,8 @@ void mi64_vcvtuqq2pd(const uint64 a[], double b[])
 	uint32 i;
 	__asm__ volatile (\
 		"movq	%[__a],%%rax				\n\t	vpxorq	%%zmm30,%%zmm30,%%zmm30	\n\t"/* 0.0 */\
-		"movq	%[__b],%%rbx				\n\t	vmovaps		(%%rax),%%zmm0 	\n\t"/* Load uint64 inputs */\
+		"movq	%[__b],%%rbx				\n\t	vmovups		(%%rax),%%zmm0 	\n\t"/* Load uint64 inputs - v21: unaligned
+											load, the caller's uint64[] carries no 64-byte alignment guarantee */\
 		"vpcmpuq $0,%%zmm30,%%zmm0,%%k1		\n\t"/* 0-Inputs need 0-masking of result of code below */\
 		"vplzcntq	%%zmm0,%%zmm1			\n\t"/* #leading zeros in inputs */\
 		/* IEEE64 exp-fields for 1,2[lz=63,62] = 0x3ff,0x400, so offset we add to shift-aligned data is 62-1 (the -1 accounts for the unhidden-bit becoming hidden) higher than 0x400 = 0x43D0...0 - #lz: */\
@@ -4233,7 +4246,7 @@ void mi64_vcvtuqq2pd(const uint64 a[], double b[])
 		"vpsrlq		$11,%%zmm0,%%zmm0		\n\t"/* == inputs >> (11-lz) bits, leftmost set bit at low bit of DP-exponent field */\
 		"vpaddq		%%zmm1,%%zmm0,%%zmm0	\n\t"/* Note above rshift truncates any off-shifted low bits; results now in DP form. */
 	"vpandq	%%zmm30,%%zmm0,%%zmm0%{%%k1%}	\n\t"/* 0-Inputs need 0-masking of result */\
-		"vmovaps	%%zmm0,(%%rbx) 	\n\t"/* uint64 inputs */\
+		"vmovups	%%zmm0,(%%rbx) 	\n\t"/* v21: unaligned store, ditto for the output double[] */\
 		:					/* outputs: none */\
 		: [__a] "m" (a)	/* All inputs from memory addresses here */\
 		 ,[__b] "m" (b)\
@@ -5143,12 +5156,15 @@ int mi64_div_mont(const uint64 x[], const uint64 y[], uint32 lenX, uint32 lenY, 
 			free((void *)scratch);	scratch = yinv = cy = tmp = itmp = lo = hi = w = rem_save = 0x0;
 		}
 		/* (re)Allocate the needed auxiliary storage: */
-		scratch = (uint64 *)calloc((lenD*8), sizeof(uint64));	ASSERT(scratch != 0x0, "alloc fail!");
+		// v21: +1 pad word: the in-place (r == 0x0) restore of a single-word remainder below writes
+		// rem_save[nws], and nws can equal lenD (e.g. divisor 3*2^65: lenD = 2, nshift = 65, nws = 2),
+		// so the last (rem_save) section needs lenD+1 words:
+		scratch = (uint64 *)calloc((lenD*8 + 1), sizeof(uint64));	ASSERT(scratch != 0x0, "alloc fail!");
 	}
 	// These ptrs just point to various disjoint length-lenD sections of the shared local-storage chunk;
 	// since some of them are treated as vars, reset 'em all on each entry, as well as re-zeroing the whole memblock:
-	memset(scratch, 0ull, 8*(lenD<<3));	// (8*lenD) words of 8 bytes each
-	// The 10-multiplier in the preceding calloc & memset corr. to number of pointers inited here:
+	memset(scratch, 0ull, (lenD<<3)*8 + 8);	// (8*lenD + 1) words of 8 bytes each
+	// The 8-multiplier in the preceding calloc & memset corr. to number of pointers inited here:
 	yinv         = scratch;
 	cy           = scratch +   lenD;
 	tmp          = scratch + 2*lenD;
@@ -5230,7 +5246,9 @@ int mi64_div_mont(const uint64 x[], const uint64 y[], uint32 lenX, uint32 lenY, 
 		nbs = nshift&63;
 		// Save the bottom nshift bits of x (we work with copy of x saved in v) prior to right-shifting:
 		mi64_set_eq(rem_save, x, nws);
-		mask = ((uint64)-1 >> (64 - nbs));
+		// v21: guard the nbs == 0 case (nshift an exact multiple of 64): the previous unguarded
+		// (uint64)-1 >> 64 is UB in C (x86 happens to give the intended all-ones, but only by luck):
+		mask = nbs ? ((uint64)-1 >> (64 - nbs)) : (uint64)-1;
 		rem_save[nws-1] &= mask;
 		mi64_shrl(x,v,nshift,lenX,lenX);
 		mi64_shrl(y,w,nshift,lenD,lenD);
@@ -6385,7 +6403,7 @@ int mi64_is_div_by_scalar64_x4(const uint64 x[], uint64 q0, uint64 q1, uint64 q2
 	uint32 nshift0,nshift1,nshift2,nshift3;
 	uint64 qinv0,qinv1,qinv2,qinv3,cy0,cy1,cy2,cy3;
 
-	ASSERT((len == 0), "0 length!");
+	ASSERT((len != 0), "0 length!");	// v21: condition was inverted (== 0), aborting on every legitimate call
 	trailx = trailz64(x[0]);
 	ASSERT(trailx < 64, "0 low word!");
 
@@ -7056,15 +7074,18 @@ printf("\n");
 #endif
 uint64 mi64_div_by_scalar64_u2(uint64 x[], uint64 q, uint32 lenu, uint64 y[])	// x declared non-const in folded versions to permit 0-padding
 {														// lenu = unpadded length
-	if(lenu < 2) return mi64_div_by_scalar64(x,q,lenu,y);
+	/* v21: Odd lengths formerly zero-padded x in place (temporarily writing x[lenu] - one past the
+	end of a caller's exactly-sized array - and writing the quotient with the padded length). Route
+	odd lengths to the scalar variant instead and keep this routine strictly within [0, lenu): */
+	if(lenu < 2 || (lenu&1)) return mi64_div_by_scalar64(x,q,lenu,y);
 #ifndef YES_ASM
 	uint64 tmp0,tmp1,bw0,bw1;
 #endif
 #if MI64_DIV_MONT64_U2
 	int dbg = 0;
 #endif
-	int npad = (lenu&1),len = lenu + npad,len2 = (len>>1),nshift,lshift = -1;	// Pad to even length
-	uint64 qinv,cy0,cy1,rpow,rem_save = 0,xsave,itmp64,mask,*iptr0,*iptr1,ptr_incr;
+	int i,j,len = lenu,len2 = (len>>1),nshift,lshift = -1;	// lenu is even here (see dispatch above)
+	uint64 qinv,cy0,cy1,rpow,rem_save = 0,itmp64,mask,*iptr0,*iptr1,ptr_incr;
 	ASSERT((x != 0) && (len != 0), "Null input array or length parameter!");
 	ASSERT(q > 0, "0 modulus!");
 	// Unit modulus needs special handling to return proper 0 remainder rather than 1:
@@ -7072,8 +7093,6 @@ uint64 mi64_div_by_scalar64_u2(uint64 x[], uint64 q, uint32 lenu, uint64 y[])	//
 		if(y) mi64_set_eq(y,x,len);
 		return 0ull;
 	}
-	xsave = x[lenu];	x[lenu] = 0ull;	// Zero-pad one-beyond element to remove even-length restriction
-										// Will restore input value of x[lenu] just prior to returning.
 	/* q must be odd for Montgomery-style modmul to work, so first shift off any low 0s: */
 	nshift = trailz64(q);
 	if(nshift) {
@@ -7380,7 +7399,6 @@ See similar behavior for 4-way-split version of the algorithm.
 #endif
 
 	ASSERT(cy1 == 0, "cy check!");	// all but the uppermost carryout are generally nonzero
-	x[lenu] = xsave;	// Restore input value of zero-padding one-beyond element x[lenu] prior to return
 	return rpow;
 }
 
@@ -7398,7 +7416,13 @@ kinds of unique-in-this-sourcefile named labels to local labels inside the ASM:
 // x declared non-const in folded versions to permit 0-padding:
 uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 {														// lenu = unpadded length
-	if(lenu < 4) return mi64_div_by_scalar64(x,q,lenu,y);
+	/* v21: Lengths which are not a multiple of 4 formerly zero-padded x in place (temporarily
+	writing x[lenu .. lenu+2]) and wrote the quotient with the padded length - i.e. up to 3 words
+	past the end of a caller's exactly-sized x and y arrays. All in-tree callers pass exactly-
+	lenu-word arrays, so route non-multiple-of-4 lengths to the 2-folded/scalar variants instead
+	and keep this routine strictly within [0, lenu): */
+	if(lenu < 4 || (lenu&1)) return mi64_div_by_scalar64(x,q,lenu,y);
+	if(lenu&2) return mi64_div_by_scalar64_u2(x,q,lenu,y);
 #ifndef YES_ASM
 	uint32 i0,i1,i2,i3;
 	uint64 tmp0,tmp1,tmp2,tmp3,bw0,bw1,bw2,bw3;
@@ -7406,20 +7430,9 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 #if MI64_DIV_MONT64_U4
 	int dbg = 0;
 #endif
-	int i,len = (lenu+3) & ~0x3,len4 = (len>>2),npad = len-lenu,nshift,lshift = -1;	// Pad to multiple-of-4 length
-	uint64 qinv,cy0,cy1,cy2,cy3,rpow,rem_save = 0,mask,*iptr0;
-#ifndef YES_ASM
-	int len2 = (len>>1);
-	uint64 *iptr1,*iptr2,*iptr3;
-#else // YES_ASM
-  #ifndef USE_AVX2
-	int len2 = (len>>1);
-	uint64 *iptr1,*iptr2;
-	uint64 ptr_incr,ptr_inc2;
-  #endif
+	int i,j,len = lenu,len2 = (len>>1),len4 = (len>>2),nshift,lshift = -1;	// lenu is a multiple of 4 here (see dispatch above)
+	uint64 qinv,cy0,cy1,cy2,cy3,rpow,rem_save = 0,itmp64,mask,*iptr0,*iptr1,*iptr2,*iptr3, ptr_incr,ptr_inc2;
 	uint64 *xy_ptr_diff;
-#endif
-	uint64 pads[3];
 	// Local-alloc-related statics - these should only ever be updated in single-thread mode:
 	static int first_entry = TRUE;
 	static uint32 len_save = 10;	// Initial-alloc values
@@ -7439,12 +7452,6 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 	if(q == 1ull) {
 		if(y) mi64_set_eq(y,x,len);
 		return 0ull;
-	}
-
-	// Zero-pad to next-higher multiple of 4 to remove length == 0 (mod 4) restriction.
-	// Will restore input values of the 0-pad elements just prior to returning:
-	for(i = 0; i < npad; i++) {
-		pads[i] = x[lenu+i];	x[lenu+i] = 0ull;
 	}
 
 	/* q must be odd for Montgomery-style modmul to work, so first shift off any low 0s: */
@@ -8049,10 +8056,6 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 
 #endif
 	ASSERT(cy3 == 0, "cy check!");	// all but the uppermost carryout are generally nonzero
-	// Restore input values of 0-pad elements prior to return:
-	for(i = 0; i < npad; i++) {
-		x[lenu+i] = pads[i];
-	}
 	return rpow;
 }
 
@@ -8383,13 +8386,19 @@ uint32 mi64_twopmodq(const uint64 p[], uint32 len_p, const uint64 k, uint64 q[],
 		lenp_save = len_p;
 		pshift = (uint64 *)realloc(pshift, (len_p+1)*sizeof(uint64));
 	}
+	/* v21: Two latent traps fixed here: (a) the q-buffer reallocs were sized by lenQ (the effective
+	length of the current q) but the skip-gate records len - a later call with the same nominal len
+	but a larger effective lenQ would skip the realloc and overrun the smaller buffers, so size by
+	len (>= lenQ) to match the gate; (b) the old code also re-realloc'ed pshift here with the
+	CURRENT call's len_p without updating lenp_save, which could silently SHRINK pshift (large-len
+	call with small len_p) while lenp_save still recorded the larger value - the block above already
+	handles pshift growth correctly, so drop that realloc entirely: */
 	if(len > lenq_save) {
 		lenq_save = len;
-		pshift = (uint64 *)realloc(pshift, (len_p+1)*sizeof(uint64));
-		qhalf  = (uint64 *)realloc(qhalf , (lenQ   )*sizeof(uint64));
-		qinv   = (uint64 *)realloc(qinv  , (lenQ   )*sizeof(uint64));
-		x      = (uint64 *)realloc(x     , (lenQ   )*sizeof(uint64));
-		lo     = (uint64 *)realloc(lo    , (2*lenQ )*sizeof(uint64));
+		qhalf  = (uint64 *)realloc(qhalf , (len    )*sizeof(uint64));
+		qinv   = (uint64 *)realloc(qinv  , (len    )*sizeof(uint64));
+		x      = (uint64 *)realloc(x     , (len    )*sizeof(uint64));
+		lo     = (uint64 *)realloc(lo    , (2*len  )*sizeof(uint64));
 	}
 	ASSERT(pshift != 0x0 && qhalf != 0x0 && qinv != 0x0 && x != 0x0 && lo != 0x0, "alloc failed!");
 	hi = lo + lenQ;	// Pointer to high half of double-wide product
@@ -8424,7 +8433,11 @@ uint32 mi64_twopmodq(const uint64 p[], uint32 len_p, const uint64 k, uint64 q[],
 	Every little bit counts (literally in this case :), right?
 	*/
 	/* Extract leftmost log2_numbits bits of pshift (if >= qbits, use the leftmost log2_numbits-1) and subtract from qbits: */
-	pbits = mi64_extract_lead64(pshift,len_p,&lo64);
+	// v21: extract over the effective length lenP, not the nominal len_p: pshift words above lenP
+	// are stale after a realloc (and semantically not part of the value), so reading them here could
+	// yield garbage lead bits and hence a wrong start_index/zshift (cf. the qmmp variant, which
+	// already passes lenP):
+	pbits = mi64_extract_lead64(pshift,lenP,&lo64);
 	ASSERT(pbits >= log2_numbits, "leadz64!");
 //	if(pbits >= 64)
 		lead_chunk = lo64>>(64-log2_numbits);

--- a/src/mi64.c
+++ b/src/mi64.c
@@ -2280,8 +2280,10 @@ uint64	mi64_add_cyin(const uint64 x[], const uint64 y[], uint64 z[], uint32 len,
 
 	uint64	mi64_add(const uint64 x[], const uint64 y[], uint64 z[], uint32 len)
 	{
-		// v21: the C implementation asserts len != 0; the ASM path must do the same, since its loop
-		// counter setup ("decq" before the first termination check) would treat len == 0 as 2^64:
+		// v21: guard len == 0 - the ASM loop's "decq" precedes its first termination check, so a zero
+		// length would run 2^64 iterations. Note this does *not* restore parity with the C variant: the
+		// live C arm below silently returns 0 for len == 0, its matching assert being dead code inside
+		// an "#if 0" block. Aborting is the safer of the two, but the two arms now differ:
 		ASSERT(len != 0, "mi64_add: zero-length array!");
 	#if 0//def USE_AVX
 		#error experimental-only code ... still needs debugging! [Jul 2016 - carry into topmost word missing]
@@ -6179,11 +6181,10 @@ uint64 radix_power64(const uint64 q, const uint64 qinv, uint32 n)
 			"cmovcq %%rbx,%%rax	\n\t"/* if CF = 1 (CMPSD = true), overwrite dest (rax = itmp64-q) with source (rbx = itmp64+q), else leave dest = itmp64-q. */\
 		"rad_pow64_end: 	\n\t"\
 			"movq	%%rax,%[__itmp64]	\n\t"\
-		:	/* outputs: none */\
+		: [__itmp64] "+m" (itmp64)	/* output: itmp64 (asm stores through it) */\
 		: [__fquo] "m" (fquo)	/* All inputs from memory addresses here */\
 		 ,[__rnd] "m" (rnd)	\
 		 ,[__q] "m" (q)	\
-		 ,[__itmp64] "m" (itmp64)	\
 		: "cc","memory","rax","rbx","rcx","rdx","xmm0","xmm1"	/* Clobbered registers */\
 		);
 
@@ -6344,11 +6345,10 @@ int mi64_is_div_by_scalar64(const uint64 x[], uint64 q, uint32 len)
 	"jnz loop_start 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 
 		"movq	%%rdx,%[__cy]	\n\t"\
-		:	/* outputs: none */\
+		: [__cy] "+m" (cy)	/* output: cy (asm stores through it) */\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy] "m" (cy)	\
 		 ,[__len] "m" (len)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r10"	/* Clobbered registers */\
 		);
@@ -6374,11 +6374,10 @@ int mi64_is_div_by_scalar64(const uint64 x[], uint64 q, uint32 len)
 	"jnz loop_start 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 
 		"movq	%%rdx,%[__cy]	\n\t"\
-		:	/* outputs: none */\
+		: [__cy] "+m" (cy)	/* output: cy (asm stores through it) */\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy] "m" (cy)	\
 		 ,[__len] "m" (len)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r10"	/* Clobbered registers */\
 		);
@@ -6481,7 +6480,10 @@ int mi64_is_div_by_scalar64_x4(const uint64 x[], uint64 q0, uint64 q1, uint64 q2
 	"jnz loop4x 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%r8 ,%[__cy1]	\n\t	movq	%%r9 ,%[__cy2]	\n\t	movq	%%rdx,%[__cy3]	\n\t"\
-	:	/* outputs: none */\
+	: [__cy0] "+m" (cy0)	/* outputs: cy0-3 (asm stores through them) */\
+	 ,[__cy1] "+m" (cy1)	\
+	 ,[__cy2] "+m" (cy2)	\
+	 ,[__cy3] "+m" (cy3)	\
 	: [__q0] "m" (q0)	/* All inputs from memory addresses here */\
 	 ,[__q1] "m" (q1)	\
 	 ,[__q2] "m" (q2)	\
@@ -6491,10 +6493,6 @@ int mi64_is_div_by_scalar64_x4(const uint64 x[], uint64 q0, uint64 q1, uint64 q2
 	 ,[__qinv2] "m" (qinv2)	\
 	 ,[__qinv3] "m" (qinv3)	\
 	 ,[__x] "m" (x)	\
-	 ,[__cy0] "m" (cy0)	\
-	 ,[__cy1] "m" (cy1)	\
-	 ,[__cy2] "m" (cy2)	\
-	 ,[__cy3] "m" (cy3)	\
 	 ,[__len] "m" (len)	\
 	: "cc","memory","rax","rcx","rdx","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
 	);
@@ -6584,12 +6582,11 @@ ASSERT(!nshift, "2-way folded ISDIV requires odd q!");
 	"jnz loop2a 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%rdx,%[__cy1]	"\
-		:	/* outputs: none */\
+		: [__cy0] "+m" (cy0)	/* outputs: cy0,cy1 (asm stores through them) */\
+		 ,[__cy1] "+m" (cy1)	\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
 		 ,[__len] "m" (len)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r10","r11","r12"		/* Clobbered registers */\
 		);
@@ -6716,14 +6713,13 @@ ASSERT(!nshift, "4-way folded ISDIV requires odd q!");
 	"subq	$1,%%rcx \n\t"\
 	"jnz loop4u 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%r8 ,%[__cy1]	\n\t	movq	%%r9 ,%[__cy2]	\n\t	movq	%%rax,%[__cy3]	\n\t"\
-	:	/* outputs: none */\
+	: [__cy0] "+m" (cy0)	/* outputs: cy0-3 (asm stores through them) */\
+	 ,[__cy1] "+m" (cy1)	\
+	 ,[__cy2] "+m" (cy2)	\
+	 ,[__cy3] "+m" (cy3)	\
 	: [__q] "m" (q)	/* All inputs from memory addresses here */\
 	 ,[__qinv] "m" (qinv)	\
 	 ,[__x] "m" (x)	\
-	 ,[__cy0] "m" (cy0)	\
-	 ,[__cy1] "m" (cy1)	\
-	 ,[__cy2] "m" (cy2)	\
-	 ,[__cy3] "m" (cy3)	\
 	 ,[__len] "m" (len)	\
 	: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
 	);
@@ -6764,14 +6760,13 @@ ASSERT(!nshift, "4-way folded ISDIV requires odd q!");
 	"subq	$1,%%rcx \n\t"\
 	"jnz loop4u 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%r8 ,%[__cy1]	\n\t	movq	%%r9 ,%[__cy2]	\n\t	movq	%%rdx,%[__cy3]	\n\t"\
-	:	/* outputs: none */\
+	: [__cy0] "+m" (cy0)	/* outputs: cy0-3 (asm stores through them) */\
+	 ,[__cy1] "+m" (cy1)	\
+	 ,[__cy2] "+m" (cy2)	\
+	 ,[__cy3] "+m" (cy3)	\
 	: [__q] "m" (q)	/* All inputs from memory addresses here */\
 	 ,[__qinv] "m" (qinv)	\
 	 ,[__x] "m" (x)	\
-	 ,[__cy0] "m" (cy0)	\
-	 ,[__cy1] "m" (cy1)	\
-	 ,[__cy2] "m" (cy2)	\
-	 ,[__cy3] "m" (cy3)	\
 	 ,[__len] "m" (len)	\
 	: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
 	);
@@ -7183,12 +7178,11 @@ See similar behavior for 4-way-split version of the algorithm.
 	"subq	$1,%%rcx \n\t"\
 	"jnz loop2b 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%rdx,%[__cy1]	\n\t"\
-		:	/* outputs: none */\
+		: [__cy0] "+m" (cy0)	/* outputs: cy0,cy1 (asm stores through them) */\
+		 ,[__cy1] "+m" (cy1)	\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
 		 ,[__len2] "m" (len2)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r10","r11","r12"		/* Clobbered registers */\
 		);
@@ -7245,12 +7239,11 @@ See similar behavior for 4-way-split version of the algorithm.
 		"andq	%%rsi,%%rdi			\n\t	andq	%%rsi,%%rdx		\n\t"/* q & (-cy0|1) */\
 		"addq	%%rdi,%%rax			\n\t	addq	%%rdx,%%r12		\n\t"/* cy0|1 = tmp0|1 + ((-cy0|1)&q) */\
 		"movq	%%rax,%[__cy0]		\n\t	movq	%%r12,%[__cy1]	\n\t"\
-		:	/* outputs: none */\
+		: [__cy0] "+m" (cy0)	/* outputs: cy0,cy1 (asm stores through them) */\
+		 ,[__cy1] "+m" (cy1)	\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
 		 ,[__len2] "m" (len2)	\
 		 ,[__n] "m" (nshift)	\
 		 ,[__iptr0] "m" (iptr0)	/* Output pointers (will both point to itmp64 if no quotient desired.) */\
@@ -7346,14 +7339,13 @@ See similar behavior for 4-way-split version of the algorithm.
 	"subq	$1,%%rcx	\n\t"\
 	"jnz loop2d			\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%rdx,%[__cy1]	"\
-		:	/* outputs: none */\
+		: [__cy0] "+m" (cy0)	/* outputs: cy0,cy1 (asm reads and stores through them) */\
+		 ,[__cy1] "+m" (cy1)	\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__iptr0] "m" (iptr0)	/* Input pointers (point to x,x+len2 if q odd, y,y+len2 if q even) */\
 		 ,[__iptr1] "m" (iptr1)	\
 		 ,[__y] "m" (y)	\
-		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
 		 ,[__len2] "m" (len2)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14"		/* Clobbered registers */\
 		);
@@ -7384,14 +7376,13 @@ See similar behavior for 4-way-split version of the algorithm.
 	"subq	$1,%%rcx	\n\t"\
 	"jnz loop2d			\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"							\n\t	movq	%%rdx,%[__cy1]	"/* Only useful carryout is cy1, check-equal-to-zero */\
-		:	/* outputs: none */\
+		: [__cy1] "+m" (cy1)	/* output: cy1 (asm stores through it); cy0 is read-only below */\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__iptr0] "m" (iptr0)	/* Input pointers (point to x,x+len2 if q odd, y,y+len2 if q even) */\
 		 ,[__iptr1] "m" (iptr1)	\
 		 ,[__y] "m" (y)	\
 		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
 		 ,[__len2] "m" (len2)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","r8","r9","r10","r11","r12","r13","r14"		/* Clobbered registers */\
 		);
@@ -7612,14 +7603,13 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 	"subq	$1,%%rcx \n\t"\
 	"jnz 0b \n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%r8 ,%[__cy1]	\n\t	movq	%%r9 ,%[__cy2]	\n\t	movq	%%rax,%[__cy3]	\n\t"\
-	:	/* outputs: none */\
+	: [__cy0] "+m" (cy0)	/* outputs: cy0-3 (asm stores through them) */\
+	 ,[__cy1] "+m" (cy1)	\
+	 ,[__cy2] "+m" (cy2)	\
+	 ,[__cy3] "+m" (cy3)	\
 	: [__q] "m" (q)	/* All inputs from memory addresses here */\
 	 ,[__qinv] "m" (qinv)	\
 	 ,[__x] "m" (iptr0)	\
-	 ,[__cy0] "m" (cy0)	\
-	 ,[__cy1] "m" (cy1)	\
-	 ,[__cy2] "m" (cy2)	\
-	 ,[__cy3] "m" (cy3)	\
 	 ,[__len] "m" (len)	\
 	: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
 	);
@@ -7674,14 +7664,13 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 	"subq	$1,%%rcx \n\t"\
 	"jnz 0b	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%r8 ,%[__cy1]	\n\t	movq	%%r9 ,%[__cy2]	\n\t	movq	%%rdx,%[__cy3]	\n\t"\
-		:	/* outputs: none */\
+		: [__cy0] "+m" (cy0)	/* outputs: cy0-3 (asm stores through them) */\
+		 ,[__cy1] "+m" (cy1)	\
+		 ,[__cy2] "+m" (cy2)	\
+		 ,[__cy3] "+m" (cy3)	\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
-		 ,[__cy2] "m" (cy2)	\
-		 ,[__cy3] "m" (cy3)	\
 		 ,[__len] "m" (len)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
 		);
@@ -7751,14 +7740,13 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 		"addq	%%r9 ,%%r12			\n\t	addq	%%rdx,%%r13		\n\t"/* cy2|3 = tmp2|3 + ((-cy2|3)&q) */\
 		"movq	%%rax,%[__cy0]		\n\t	movq	%%r11,%[__cy1]	\n\t"\
 		"movq	%%r12,%[__cy2]		\n\t	movq	%%r13,%[__cy3]	\n\t"\
-		:	/* outputs: none */\
+		: [__cy0] "+m" (cy0)	/* outputs: cy0-3 (asm reads and stores through them) */\
+		 ,[__cy1] "+m" (cy1)	\
+		 ,[__cy2] "+m" (cy2)	\
+		 ,[__cy3] "+m" (cy3)	\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
-		 ,[__cy2] "m" (cy2)	\
-		 ,[__cy3] "m" (cy3)	\
 		 ,[__len4] "m" (len4)	\
 		 ,[__n] "m" (nshift)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
@@ -7838,14 +7826,13 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 		"addq	%%r9 ,%%r12			\n\t	addq	%%rdx,%%r13		\n\t"/* cy2|3 = tmp2|3 + ((-cy2|3)&q) */\
 		"movq	%%rax,%[__cy0]		\n\t	movq	%%r11,%[__cy1]	\n\t"\
 		"movq	%%r12,%[__cy2]		\n\t	movq	%%r13,%[__cy3]	\n\t"\
-		:	/* outputs: none */\
+		: [__cy0] "+m" (cy0)	/* outputs: cy0-3 (asm reads and stores through them) */\
+		 ,[__cy1] "+m" (cy1)	\
+		 ,[__cy2] "+m" (cy2)	\
+		 ,[__cy3] "+m" (cy3)	\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
-		 ,[__cy2] "m" (cy2)	\
-		 ,[__cy3] "m" (cy3)	\
 		 ,[__len4] "m" (len4)	\
 		 ,[__n] "m" (nshift)	\
 		 ,[__iptr0] "m" (iptr0)	/* Output base-pointer */\
@@ -7981,7 +7968,7 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 	"subq	$1,%%rcx \n\t"\
 	"jnz loop4c 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rax,%[__cy3]	\n\t"\
-	:	/* outputs: none */\
+	: [__cy3] "+m" (cy3)	/* output: cy3 (asm stores through it); cy0-2 are read-only above */\
 	: [__q] "m" (q)	/* All inputs from memory addresses here */\
 	 ,[__qinv] "m" (qinv)	\
 	 ,[__x] "m" (iptr0)	\
@@ -7989,7 +7976,6 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 	 ,[__cy0] "m" (cy0)	\
 	 ,[__cy1] "m" (cy1)	\
 	 ,[__cy2] "m" (cy2)	\
-	 ,[__cy3] "m" (cy3)	\
 	 ,[__len] "m" (len)	\
 	: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
 	);
@@ -8038,7 +8024,7 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 	"subq	$1,%%rcx \n\t"\
 	"jnz loop4c 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rdx,%[__cy3]	\n\t"\
-	:	/* outputs: none */\
+	: [__cy3] "+m" (cy3)	/* output: cy3 (asm stores through it); cy0-2 are read-only above */\
 	: [__q] "m" (q)	/* All inputs from memory addresses here */\
 	 ,[__qinv] "m" (qinv)	\
 	 ,[__iptr0] "m" (iptr0)	/* Input pointers (point to x,x+len2 if q odd, y,y+len2 if q even) */\
@@ -8047,7 +8033,6 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 	 ,[__cy0] "m" (cy0)	\
 	 ,[__cy1] "m" (cy1)	\
 	 ,[__cy2] "m" (cy2)	\
-	 ,[__cy3] "m" (cy3)	\
 	 ,[__len4] "m" (len4)	\
 	: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
 	);

--- a/src/mi64.c
+++ b/src/mi64.c
@@ -614,11 +614,19 @@ uint64	mi64_shrl(const uint64 x[], uint64 y[], uint32 nshift, uint32 len, uint32
 	So allow output_len to be 1 limb smaller than 17 as a fudge factor to handle arbitrary in-word copy-bit boundaries:
 	*/
 	ASSERT(output_len >= (len-nwshift)-1, "mi64_shrl: output_len must be large enough to hold result!");
+	/* v21: the "fudge factor" case output_len == (len-nwshift)-1 permitted by the above assert was
+	documented ("only copy that many and exit") but never implemented: every write path below wrote
+	the full (len-nwshift) result words, i.e. one word past the caller's buffer. All writes are now
+	clamped to output_len. */
 	// Special-casing for 0 shift count:
 	if(!nshift) {
 		if(x != y) {
-			mi64_set_eq(y, x, len);				// Set y = x...
-			mi64_clear(y+len, output_len - len);// ...and 0 any excess high limbs in y.
+			i = MIN(len, output_len);
+			mi64_set_eq(y, x, i);				// Set y = x...
+			if(output_len > len)
+				mi64_clear(y+len, output_len - len);// ...and 0 any excess high limbs in y.
+				// (Note the guard: the old unguarded form passed a huge unsigned count if
+				// output_len < len, wiping (2^32 - small) words beyond the buffer.)
 		}
 		return 0ull;
 	}
@@ -638,18 +646,19 @@ uint64	mi64_shrl(const uint64 x[], uint64 y[], uint32 nshift, uint32 len, uint32
 		hi64 = x[nwshift-1];
 	}
 	if(!rembits) {	// Whole-word shift:
-		for(i = 0; i < len-nwshift; i++) {
+		for(i = 0; i < len-nwshift && i < (int)output_len; i++) {	// v21: clamp to output_len (fudge-factor case)
 			y[i] = x[i+nwshift];
 		}
 	} else {	// nshift not an exact multiple of the wordlength:
 		m64bits = (64-rembits);
 		if(nwshift)
 			hi64 = (hi64 >> rembits) + (x[nwshift] << m64bits);
-		for(i = 0; i < len-nwshift-1; i++) {
+		for(i = 0; i < len-nwshift-1 && i < (int)output_len; i++) {	// v21: clamp to output_len (fudge-factor case)
 			y[i] = (x[i+nwshift] >> rembits) + (x[i+nwshift+1] << m64bits);	// Ex: on exit have just finished y[37] = x[1130]>>48 + x[1131]<<16
 		}																	// thus 2432 of our 2448 target bits
 		// Most-significant element gets zeros shifted in from the left:
-		y[i] = (x[i+nwshift] >> rembits);									// Ex: y[len-nwshift-1] = y[38] = x[1131]>>48
+		if(i < (int)output_len)	// v21: in the fudge-factor case the caller asked for one fewer word - skip it
+			y[i] = (x[i+nwshift] >> rembits);								// Ex: y[len-nwshift-1] = y[38] = x[1131]>>48
 		for(i = len-nwshift; i < output_len; i++) {
 			y[i] = 0ull;
 		}
@@ -2271,6 +2280,9 @@ uint64	mi64_add_cyin(const uint64 x[], const uint64 y[], uint64 z[], uint32 len,
 
 	uint64	mi64_add(const uint64 x[], const uint64 y[], uint64 z[], uint32 len)
 	{
+		// v21: the C implementation asserts len != 0; the ASM path must do the same, since its loop
+		// counter setup ("decq" before the first termination check) would treat len == 0 as 2^64:
+		ASSERT(len != 0, "mi64_add: zero-length array!");
 	#if 0//def USE_AVX
 		#error experimental-only code ... still needs debugging! [Jul 2016 - carry into topmost word missing]
 		// Hybrid int64 / sse2 -based impl of ?-folded adc loop
@@ -4222,7 +4234,8 @@ void mi64_vcvtuqq2pd(const uint64 a[], double b[])
 	uint32 i;
 	__asm__ volatile (\
 		"movq	%[__a],%%rax				\n\t	vpxorq	%%zmm30,%%zmm30,%%zmm30	\n\t"/* 0.0 */\
-		"movq	%[__b],%%rbx				\n\t	vmovaps		(%%rax),%%zmm0 	\n\t"/* Load uint64 inputs */\
+		"movq	%[__b],%%rbx				\n\t	vmovups		(%%rax),%%zmm0 	\n\t"/* Load uint64 inputs - v21: unaligned
+											load, the caller's uint64[] carries no 64-byte alignment guarantee */\
 		"vpcmpuq $0,%%zmm30,%%zmm0,%%k1		\n\t"/* 0-Inputs need 0-masking of result of code below */\
 		"vplzcntq	%%zmm0,%%zmm1			\n\t"/* #leading zeros in inputs */\
 		/* IEEE64 exp-fields for 1,2[lz=63,62] = 0x3ff,0x400, so offset we add to shift-aligned data is 62-1 (the -1 accounts for the unhidden-bit becoming hidden) higher than 0x400 = 0x43D0...0 - #lz: */\
@@ -4233,7 +4246,7 @@ void mi64_vcvtuqq2pd(const uint64 a[], double b[])
 		"vpsrlq		$11,%%zmm0,%%zmm0		\n\t"/* == inputs >> (11-lz) bits, leftmost set bit at low bit of DP-exponent field */\
 		"vpaddq		%%zmm1,%%zmm0,%%zmm0	\n\t"/* Note above rshift truncates any off-shifted low bits; results now in DP form. */
 	"vpandq	%%zmm30,%%zmm0,%%zmm0%{%%k1%}	\n\t"/* 0-Inputs need 0-masking of result */\
-		"vmovaps	%%zmm0,(%%rbx) 	\n\t"/* uint64 inputs */\
+		"vmovups	%%zmm0,(%%rbx) 	\n\t"/* v21: unaligned store, ditto for the output double[] */\
 		:					/* outputs: none */\
 		: [__a] "m" (a)	/* All inputs from memory addresses here */\
 		 ,[__b] "m" (b)\
@@ -5149,12 +5162,15 @@ int mi64_div_mont(const uint64 x[], const uint64 y[], uint32 lenX, uint32 lenY, 
 			free((void *)scratch);	scratch = yinv = cy = tmp = itmp = lo = hi = w = rem_save = 0x0;
 		}
 		/* (re)Allocate the needed auxiliary storage: */
-		scratch = (uint64 *)calloc((lenD*8), sizeof(uint64));	ASSERT(scratch != 0x0, "alloc fail!");
+		// v21: +1 pad word: the in-place (r == 0x0) restore of a single-word remainder below writes
+		// rem_save[nws], and nws can equal lenD (e.g. divisor 3*2^65: lenD = 2, nshift = 65, nws = 2),
+		// so the last (rem_save) section needs lenD+1 words:
+		scratch = (uint64 *)calloc((lenD*8 + 1), sizeof(uint64));	ASSERT(scratch != 0x0, "alloc fail!");
 	}
 	// These ptrs just point to various disjoint length-lenD sections of the shared local-storage chunk;
 	// since some of them are treated as vars, reset 'em all on each entry, as well as re-zeroing the whole memblock:
-	memset(scratch, 0ull, 8*(lenD<<3));	// (8*lenD) words of 8 bytes each
-	// The 10-multiplier in the preceding calloc & memset corr. to number of pointers inited here:
+	memset(scratch, 0ull, (lenD<<3)*8 + 8);	// (8*lenD + 1) words of 8 bytes each
+	// The 8-multiplier in the preceding calloc & memset corr. to number of pointers inited here:
 	yinv         = scratch;
 	cy           = scratch +   lenD;
 	tmp          = scratch + 2*lenD;
@@ -5236,7 +5252,9 @@ int mi64_div_mont(const uint64 x[], const uint64 y[], uint32 lenX, uint32 lenY, 
 		nbs = nshift&63;
 		// Save the bottom nshift bits of x (we work with copy of x saved in v) prior to right-shifting:
 		mi64_set_eq(rem_save, x, nws);
-		mask = ((uint64)-1 >> (64 - nbs));
+		// v21: guard the nbs == 0 case (nshift an exact multiple of 64): the previous unguarded
+		// (uint64)-1 >> 64 is UB in C (x86 happens to give the intended all-ones, but only by luck):
+		mask = nbs ? ((uint64)-1 >> (64 - nbs)) : (uint64)-1;
 		rem_save[nws-1] &= mask;
 		mi64_shrl(x,v,nshift,lenX,lenX);
 		mi64_shrl(y,w,nshift,lenD,lenD);
@@ -6402,7 +6420,7 @@ int mi64_is_div_by_scalar64_x4(const uint64 x[], uint64 q0, uint64 q1, uint64 q2
 	uint32 nshift0,nshift1,nshift2,nshift3;
 	uint64 qinv0,qinv1,qinv2,qinv3,cy0,cy1,cy2,cy3;
 
-	ASSERT((len == 0), "0 length!");
+	ASSERT((len != 0), "0 length!");	// v21: condition was inverted (== 0), aborting on every legitimate call
 	trailx = trailz64(x[0]);
 	ASSERT(trailx < 64, "0 low word!");
 
@@ -7073,15 +7091,18 @@ printf("\n");
 #endif
 uint64 mi64_div_by_scalar64_u2(uint64 x[], uint64 q, uint32 lenu, uint64 y[])	// x declared non-const in folded versions to permit 0-padding
 {														// lenu = unpadded length
-	if(lenu < 2) return mi64_div_by_scalar64(x,q,lenu,y);
+	/* v21: Odd lengths formerly zero-padded x in place (temporarily writing x[lenu] - one past the
+	end of a caller's exactly-sized array - and writing the quotient with the padded length). Route
+	odd lengths to the scalar variant instead and keep this routine strictly within [0, lenu): */
+	if(lenu < 2 || (lenu&1)) return mi64_div_by_scalar64(x,q,lenu,y);
 #ifndef YES_ASM
 	uint64 tmp0,tmp1,bw0,bw1;
 #endif
 #if MI64_DIV_MONT64_U2
 	int dbg = 0;
 #endif
-	int npad = (lenu&1),len = lenu + npad,len2 = (len>>1),nshift,lshift = -1;	// Pad to even length
-	uint64 qinv,cy0,cy1,rpow,rem_save = 0,xsave,itmp64,mask,*iptr0,*iptr1,ptr_incr;
+	int i,j,len = lenu,len2 = (len>>1),nshift,lshift = -1;	// lenu is even here (see dispatch above)
+	uint64 qinv,cy0,cy1,rpow,rem_save = 0,itmp64,mask,*iptr0,*iptr1,ptr_incr;
 	ASSERT((x != 0) && (len != 0), "Null input array or length parameter!");
 	ASSERT(q > 0, "0 modulus!");
 	// Unit modulus needs special handling to return proper 0 remainder rather than 1:
@@ -7089,8 +7110,6 @@ uint64 mi64_div_by_scalar64_u2(uint64 x[], uint64 q, uint32 lenu, uint64 y[])	//
 		if(y) mi64_set_eq(y,x,len);
 		return 0ull;
 	}
-	xsave = x[lenu];	x[lenu] = 0ull;	// Zero-pad one-beyond element to remove even-length restriction
-										// Will restore input value of x[lenu] just prior to returning.
 	/* q must be odd for Montgomery-style modmul to work, so first shift off any low 0s: */
 	nshift = trailz64(q);
 	if(nshift) {
@@ -7397,7 +7416,6 @@ See similar behavior for 4-way-split version of the algorithm.
 #endif
 
 	ASSERT(cy1 == 0, "cy check!");	// all but the uppermost carryout are generally nonzero
-	x[lenu] = xsave;	// Restore input value of zero-padding one-beyond element x[lenu] prior to return
 	return rpow;
 }
 
@@ -7415,7 +7433,13 @@ kinds of unique-in-this-sourcefile named labels to local labels inside the ASM:
 // x declared non-const in folded versions to permit 0-padding:
 uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 {														// lenu = unpadded length
-	if(lenu < 4) return mi64_div_by_scalar64(x,q,lenu,y);
+	/* v21: Lengths which are not a multiple of 4 formerly zero-padded x in place (temporarily
+	writing x[lenu .. lenu+2]) and wrote the quotient with the padded length - i.e. up to 3 words
+	past the end of a caller's exactly-sized x and y arrays. All in-tree callers pass exactly-
+	lenu-word arrays, so route non-multiple-of-4 lengths to the 2-folded/scalar variants instead
+	and keep this routine strictly within [0, lenu): */
+	if(lenu < 4 || (lenu&1)) return mi64_div_by_scalar64(x,q,lenu,y);
+	if(lenu&2) return mi64_div_by_scalar64_u2(x,q,lenu,y);
 #ifndef YES_ASM
 	uint32 i0,i1,i2,i3;
 	uint64 tmp0,tmp1,tmp2,tmp3,bw0,bw1,bw2,bw3;
@@ -7423,20 +7447,9 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 #if MI64_DIV_MONT64_U4
 	int dbg = 0;
 #endif
-	int i,len = (lenu+3) & ~0x3,len4 = (len>>2),npad = len-lenu,nshift,lshift = -1;	// Pad to multiple-of-4 length
-	uint64 qinv,cy0,cy1,cy2,cy3,rpow,rem_save = 0,mask,*iptr0;
-#ifndef YES_ASM
-	int len2 = (len>>1);
-	uint64 *iptr1,*iptr2,*iptr3;
-#else // YES_ASM
-  #ifndef USE_AVX2
-	int len2 = (len>>1);
-	uint64 *iptr1,*iptr2;
-	uint64 ptr_incr,ptr_inc2;
-  #endif
+	int i,j,len = lenu,len2 = (len>>1),len4 = (len>>2),nshift,lshift = -1;	// lenu is a multiple of 4 here (see dispatch above)
+	uint64 qinv,cy0,cy1,cy2,cy3,rpow,rem_save = 0,itmp64,mask,*iptr0,*iptr1,*iptr2,*iptr3, ptr_incr,ptr_inc2;
 	uint64 *xy_ptr_diff;
-#endif
-	uint64 pads[3];
 	// Local-alloc-related statics - these should only ever be updated in single-thread mode:
 	static int first_entry = TRUE;
 	static uint32 len_save = 10;	// Initial-alloc values
@@ -7456,12 +7469,6 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 	if(q == 1ull) {
 		if(y) mi64_set_eq(y,x,len);
 		return 0ull;
-	}
-
-	// Zero-pad to next-higher multiple of 4 to remove length == 0 (mod 4) restriction.
-	// Will restore input values of the 0-pad elements just prior to returning:
-	for(i = 0; i < npad; i++) {
-		pads[i] = x[lenu+i];	x[lenu+i] = 0ull;
 	}
 
 	/* q must be odd for Montgomery-style modmul to work, so first shift off any low 0s: */
@@ -8066,10 +8073,6 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 
 #endif
 	ASSERT(cy3 == 0, "cy check!");	// all but the uppermost carryout are generally nonzero
-	// Restore input values of 0-pad elements prior to return:
-	for(i = 0; i < npad; i++) {
-		x[lenu+i] = pads[i];
-	}
 	return rpow;
 }
 
@@ -8400,13 +8403,19 @@ uint32 mi64_twopmodq(const uint64 p[], uint32 len_p, const uint64 k, uint64 q[],
 		lenp_save = len_p;
 		pshift = (uint64 *)realloc(pshift, (len_p+1)*sizeof(uint64));
 	}
+	/* v21: Two latent traps fixed here: (a) the q-buffer reallocs were sized by lenQ (the effective
+	length of the current q) but the skip-gate records len - a later call with the same nominal len
+	but a larger effective lenQ would skip the realloc and overrun the smaller buffers, so size by
+	len (>= lenQ) to match the gate; (b) the old code also re-realloc'ed pshift here with the
+	CURRENT call's len_p without updating lenp_save, which could silently SHRINK pshift (large-len
+	call with small len_p) while lenp_save still recorded the larger value - the block above already
+	handles pshift growth correctly, so drop that realloc entirely: */
 	if(len > lenq_save) {
 		lenq_save = len;
-		pshift = (uint64 *)realloc(pshift, (len_p+1)*sizeof(uint64));
-		qhalf  = (uint64 *)realloc(qhalf , (lenQ   )*sizeof(uint64));
-		qinv   = (uint64 *)realloc(qinv  , (lenQ   )*sizeof(uint64));
-		x      = (uint64 *)realloc(x     , (lenQ   )*sizeof(uint64));
-		lo     = (uint64 *)realloc(lo    , (2*lenQ )*sizeof(uint64));
+		qhalf  = (uint64 *)realloc(qhalf , (len    )*sizeof(uint64));
+		qinv   = (uint64 *)realloc(qinv  , (len    )*sizeof(uint64));
+		x      = (uint64 *)realloc(x     , (len    )*sizeof(uint64));
+		lo     = (uint64 *)realloc(lo    , (2*len  )*sizeof(uint64));
 	}
 	ASSERT(pshift != 0x0 && qhalf != 0x0 && qinv != 0x0 && x != 0x0 && lo != 0x0, "alloc failed!");
 	hi = lo + lenQ;	// Pointer to high half of double-wide product
@@ -8441,7 +8450,11 @@ uint32 mi64_twopmodq(const uint64 p[], uint32 len_p, const uint64 k, uint64 q[],
 	Every little bit counts (literally in this case :), right?
 	*/
 	/* Extract leftmost log2_numbits bits of pshift (if >= qbits, use the leftmost log2_numbits-1) and subtract from qbits: */
-	pbits = mi64_extract_lead64(pshift,len_p,&lo64);
+	// v21: extract over the effective length lenP, not the nominal len_p: pshift words above lenP
+	// are stale after a realloc (and semantically not part of the value), so reading them here could
+	// yield garbage lead bits and hence a wrong start_index/zshift (cf. the qmmp variant, which
+	// already passes lenP):
+	pbits = mi64_extract_lead64(pshift,lenP,&lo64);
 	ASSERT(pbits >= log2_numbits, "leadz64!");
 //	if(pbits >= 64)
 		lead_chunk = lo64>>(64-log2_numbits);

--- a/src/mi64.c
+++ b/src/mi64.c
@@ -7096,7 +7096,7 @@ uint64 mi64_div_by_scalar64_u2(uint64 x[], uint64 q, uint32 lenu, uint64 y[])	//
 #if MI64_DIV_MONT64_U2
 	int dbg = 0;
 #endif
-	int i,j,len = lenu,len2 = (len>>1),nshift,lshift = -1;	// lenu is even here (see dispatch above)
+	int len = lenu,len2 = (len>>1),nshift,lshift = -1;	// lenu is even here (see dispatch above)
 	uint64 qinv,cy0,cy1,rpow,rem_save = 0,itmp64,mask,*iptr0,*iptr1,ptr_incr;
 	ASSERT((x != 0) && (len != 0), "Null input array or length parameter!");
 	ASSERT(q > 0, "0 modulus!");
@@ -7438,8 +7438,14 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 #if MI64_DIV_MONT64_U4
 	int dbg = 0;
 #endif
-	int i,j,len = lenu,len2 = (len>>1),len4 = (len>>2),nshift,lshift = -1;	// lenu is a multiple of 4 here (see dispatch above)
-	uint64 qinv,cy0,cy1,cy2,cy3,rpow,rem_save = 0,itmp64,mask,*iptr0,*iptr1,*iptr2,*iptr3, ptr_incr,ptr_inc2;
+	int len = lenu,len4 = (len>>2),nshift,lshift = -1;	// lenu is a multiple of 4 here (see dispatch above)
+#ifndef YES_ASM	// i and len2 are used only by the portable-C arm below:
+	int i,len2 = (len>>1);
+#endif
+	uint64 qinv,cy0,cy1,cy2,cy3,rpow,rem_save = 0,mask,*iptr0;
+#ifndef YES_ASM	// likewise iptr1..3:
+	uint64 *iptr1,*iptr2,*iptr3;
+#endif
 	uint64 *xy_ptr_diff;
 	// Local-alloc-related statics - these should only ever be updated in single-thread mode:
 	static int first_entry = TRUE;

--- a/src/mi64.c
+++ b/src/mi64.c
@@ -2280,8 +2280,10 @@ uint64	mi64_add_cyin(const uint64 x[], const uint64 y[], uint64 z[], uint32 len,
 
 	uint64	mi64_add(const uint64 x[], const uint64 y[], uint64 z[], uint32 len)
 	{
-		// v21: the C implementation asserts len != 0; the ASM path must do the same, since its loop
-		// counter setup ("decq" before the first termination check) would treat len == 0 as 2^64:
+		// v21: guard len == 0 - the ASM loop's "decq" precedes its first termination check, so a zero
+		// length would run 2^64 iterations. Note this does *not* restore parity with the C variant: the
+		// live C arm below silently returns 0 for len == 0, its matching assert being dead code inside
+		// an "#if 0" block. Aborting is the safer of the two, but the two arms now differ:
 		ASSERT(len != 0, "mi64_add: zero-length array!");
 	#if 0//def USE_AVX
 		#error experimental-only code ... still needs debugging! [Jul 2016 - carry into topmost word missing]
@@ -6196,11 +6198,10 @@ uint64 radix_power64(const uint64 q, const uint64 qinv, uint32 n)
 			"cmovcq %%rbx,%%rax	\n\t"/* if CF = 1 (CMPSD = true), overwrite dest (rax = itmp64-q) with source (rbx = itmp64+q), else leave dest = itmp64-q. */\
 		"rad_pow64_end: 	\n\t"\
 			"movq	%%rax,%[__itmp64]	\n\t"\
-		:	/* outputs: none */\
+		: [__itmp64] "+m" (itmp64)	/* output: itmp64 (asm stores through it) */\
 		: [__fquo] "m" (fquo)	/* All inputs from memory addresses here */\
 		 ,[__rnd] "m" (rnd)	\
 		 ,[__q] "m" (q)	\
-		 ,[__itmp64] "m" (itmp64)	\
 		: "cc","memory","rax","rbx","rcx","rdx","xmm0","xmm1"	/* Clobbered registers */\
 		);
 
@@ -6361,11 +6362,10 @@ int mi64_is_div_by_scalar64(const uint64 x[], uint64 q, uint32 len)
 	"jnz loop_start 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 
 		"movq	%%rdx,%[__cy]	\n\t"\
-		:	/* outputs: none */\
+		: [__cy] "+m" (cy)	/* output: cy (asm stores through it) */\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy] "m" (cy)	\
 		 ,[__len] "m" (len)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r10"	/* Clobbered registers */\
 		);
@@ -6391,11 +6391,10 @@ int mi64_is_div_by_scalar64(const uint64 x[], uint64 q, uint32 len)
 	"jnz loop_start 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 
 		"movq	%%rdx,%[__cy]	\n\t"\
-		:	/* outputs: none */\
+		: [__cy] "+m" (cy)	/* output: cy (asm stores through it) */\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy] "m" (cy)	\
 		 ,[__len] "m" (len)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r10"	/* Clobbered registers */\
 		);
@@ -6498,7 +6497,10 @@ int mi64_is_div_by_scalar64_x4(const uint64 x[], uint64 q0, uint64 q1, uint64 q2
 	"jnz loop4x 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%r8 ,%[__cy1]	\n\t	movq	%%r9 ,%[__cy2]	\n\t	movq	%%rdx,%[__cy3]	\n\t"\
-	:	/* outputs: none */\
+	: [__cy0] "+m" (cy0)	/* outputs: cy0-3 (asm stores through them) */\
+	 ,[__cy1] "+m" (cy1)	\
+	 ,[__cy2] "+m" (cy2)	\
+	 ,[__cy3] "+m" (cy3)	\
 	: [__q0] "m" (q0)	/* All inputs from memory addresses here */\
 	 ,[__q1] "m" (q1)	\
 	 ,[__q2] "m" (q2)	\
@@ -6508,10 +6510,6 @@ int mi64_is_div_by_scalar64_x4(const uint64 x[], uint64 q0, uint64 q1, uint64 q2
 	 ,[__qinv2] "m" (qinv2)	\
 	 ,[__qinv3] "m" (qinv3)	\
 	 ,[__x] "m" (x)	\
-	 ,[__cy0] "m" (cy0)	\
-	 ,[__cy1] "m" (cy1)	\
-	 ,[__cy2] "m" (cy2)	\
-	 ,[__cy3] "m" (cy3)	\
 	 ,[__len] "m" (len)	\
 	: "cc","memory","rax","rcx","rdx","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
 	);
@@ -6601,12 +6599,11 @@ ASSERT(!nshift, "2-way folded ISDIV requires odd q!");
 	"jnz loop2a 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%rdx,%[__cy1]	"\
-		:	/* outputs: none */\
+		: [__cy0] "+m" (cy0)	/* outputs: cy0,cy1 (asm stores through them) */\
+		 ,[__cy1] "+m" (cy1)	\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
 		 ,[__len] "m" (len)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r10","r11","r12"		/* Clobbered registers */\
 		);
@@ -6733,14 +6730,13 @@ ASSERT(!nshift, "4-way folded ISDIV requires odd q!");
 	"subq	$1,%%rcx \n\t"\
 	"jnz loop4u 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%r8 ,%[__cy1]	\n\t	movq	%%r9 ,%[__cy2]	\n\t	movq	%%rax,%[__cy3]	\n\t"\
-	:	/* outputs: none */\
+	: [__cy0] "+m" (cy0)	/* outputs: cy0-3 (asm stores through them) */\
+	 ,[__cy1] "+m" (cy1)	\
+	 ,[__cy2] "+m" (cy2)	\
+	 ,[__cy3] "+m" (cy3)	\
 	: [__q] "m" (q)	/* All inputs from memory addresses here */\
 	 ,[__qinv] "m" (qinv)	\
 	 ,[__x] "m" (x)	\
-	 ,[__cy0] "m" (cy0)	\
-	 ,[__cy1] "m" (cy1)	\
-	 ,[__cy2] "m" (cy2)	\
-	 ,[__cy3] "m" (cy3)	\
 	 ,[__len] "m" (len)	\
 	: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
 	);
@@ -6781,14 +6777,13 @@ ASSERT(!nshift, "4-way folded ISDIV requires odd q!");
 	"subq	$1,%%rcx \n\t"\
 	"jnz loop4u 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%r8 ,%[__cy1]	\n\t	movq	%%r9 ,%[__cy2]	\n\t	movq	%%rdx,%[__cy3]	\n\t"\
-	:	/* outputs: none */\
+	: [__cy0] "+m" (cy0)	/* outputs: cy0-3 (asm stores through them) */\
+	 ,[__cy1] "+m" (cy1)	\
+	 ,[__cy2] "+m" (cy2)	\
+	 ,[__cy3] "+m" (cy3)	\
 	: [__q] "m" (q)	/* All inputs from memory addresses here */\
 	 ,[__qinv] "m" (qinv)	\
 	 ,[__x] "m" (x)	\
-	 ,[__cy0] "m" (cy0)	\
-	 ,[__cy1] "m" (cy1)	\
-	 ,[__cy2] "m" (cy2)	\
-	 ,[__cy3] "m" (cy3)	\
 	 ,[__len] "m" (len)	\
 	: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
 	);
@@ -7200,12 +7195,11 @@ See similar behavior for 4-way-split version of the algorithm.
 	"subq	$1,%%rcx \n\t"\
 	"jnz loop2b 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%rdx,%[__cy1]	\n\t"\
-		:	/* outputs: none */\
+		: [__cy0] "+m" (cy0)	/* outputs: cy0,cy1 (asm stores through them) */\
+		 ,[__cy1] "+m" (cy1)	\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
 		 ,[__len2] "m" (len2)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r10","r11","r12"		/* Clobbered registers */\
 		);
@@ -7262,12 +7256,11 @@ See similar behavior for 4-way-split version of the algorithm.
 		"andq	%%rsi,%%rdi			\n\t	andq	%%rsi,%%rdx		\n\t"/* q & (-cy0|1) */\
 		"addq	%%rdi,%%rax			\n\t	addq	%%rdx,%%r12		\n\t"/* cy0|1 = tmp0|1 + ((-cy0|1)&q) */\
 		"movq	%%rax,%[__cy0]		\n\t	movq	%%r12,%[__cy1]	\n\t"\
-		:	/* outputs: none */\
+		: [__cy0] "+m" (cy0)	/* outputs: cy0,cy1 (asm stores through them) */\
+		 ,[__cy1] "+m" (cy1)	\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
 		 ,[__len2] "m" (len2)	\
 		 ,[__n] "m" (nshift)	\
 		 ,[__iptr0] "m" (iptr0)	/* Output pointers (will both point to itmp64 if no quotient desired.) */\
@@ -7363,14 +7356,13 @@ See similar behavior for 4-way-split version of the algorithm.
 	"subq	$1,%%rcx	\n\t"\
 	"jnz loop2d			\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%rdx,%[__cy1]	"\
-		:	/* outputs: none */\
+		: [__cy0] "+m" (cy0)	/* outputs: cy0,cy1 (asm reads and stores through them) */\
+		 ,[__cy1] "+m" (cy1)	\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__iptr0] "m" (iptr0)	/* Input pointers (point to x,x+len2 if q odd, y,y+len2 if q even) */\
 		 ,[__iptr1] "m" (iptr1)	\
 		 ,[__y] "m" (y)	\
-		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
 		 ,[__len2] "m" (len2)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14"		/* Clobbered registers */\
 		);
@@ -7401,14 +7393,13 @@ See similar behavior for 4-way-split version of the algorithm.
 	"subq	$1,%%rcx	\n\t"\
 	"jnz loop2d			\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"							\n\t	movq	%%rdx,%[__cy1]	"/* Only useful carryout is cy1, check-equal-to-zero */\
-		:	/* outputs: none */\
+		: [__cy1] "+m" (cy1)	/* output: cy1 (asm stores through it); cy0 is read-only below */\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__iptr0] "m" (iptr0)	/* Input pointers (point to x,x+len2 if q odd, y,y+len2 if q even) */\
 		 ,[__iptr1] "m" (iptr1)	\
 		 ,[__y] "m" (y)	\
 		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
 		 ,[__len2] "m" (len2)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","r8","r9","r10","r11","r12","r13","r14"		/* Clobbered registers */\
 		);
@@ -7629,14 +7620,13 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 	"subq	$1,%%rcx \n\t"\
 	"jnz 0b \n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%r8 ,%[__cy1]	\n\t	movq	%%r9 ,%[__cy2]	\n\t	movq	%%rax,%[__cy3]	\n\t"\
-	:	/* outputs: none */\
+	: [__cy0] "+m" (cy0)	/* outputs: cy0-3 (asm stores through them) */\
+	 ,[__cy1] "+m" (cy1)	\
+	 ,[__cy2] "+m" (cy2)	\
+	 ,[__cy3] "+m" (cy3)	\
 	: [__q] "m" (q)	/* All inputs from memory addresses here */\
 	 ,[__qinv] "m" (qinv)	\
 	 ,[__x] "m" (iptr0)	\
-	 ,[__cy0] "m" (cy0)	\
-	 ,[__cy1] "m" (cy1)	\
-	 ,[__cy2] "m" (cy2)	\
-	 ,[__cy3] "m" (cy3)	\
 	 ,[__len] "m" (len)	\
 	: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
 	);
@@ -7691,14 +7681,13 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 	"subq	$1,%%rcx \n\t"\
 	"jnz 0b	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%r8 ,%[__cy1]	\n\t	movq	%%r9 ,%[__cy2]	\n\t	movq	%%rdx,%[__cy3]	\n\t"\
-		:	/* outputs: none */\
+		: [__cy0] "+m" (cy0)	/* outputs: cy0-3 (asm stores through them) */\
+		 ,[__cy1] "+m" (cy1)	\
+		 ,[__cy2] "+m" (cy2)	\
+		 ,[__cy3] "+m" (cy3)	\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
-		 ,[__cy2] "m" (cy2)	\
-		 ,[__cy3] "m" (cy3)	\
 		 ,[__len] "m" (len)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
 		);
@@ -7768,14 +7757,13 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 		"addq	%%r9 ,%%r12			\n\t	addq	%%rdx,%%r13		\n\t"/* cy2|3 = tmp2|3 + ((-cy2|3)&q) */\
 		"movq	%%rax,%[__cy0]		\n\t	movq	%%r11,%[__cy1]	\n\t"\
 		"movq	%%r12,%[__cy2]		\n\t	movq	%%r13,%[__cy3]	\n\t"\
-		:	/* outputs: none */\
+		: [__cy0] "+m" (cy0)	/* outputs: cy0-3 (asm reads and stores through them) */\
+		 ,[__cy1] "+m" (cy1)	\
+		 ,[__cy2] "+m" (cy2)	\
+		 ,[__cy3] "+m" (cy3)	\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
-		 ,[__cy2] "m" (cy2)	\
-		 ,[__cy3] "m" (cy3)	\
 		 ,[__len4] "m" (len4)	\
 		 ,[__n] "m" (nshift)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
@@ -7855,14 +7843,13 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 		"addq	%%r9 ,%%r12			\n\t	addq	%%rdx,%%r13		\n\t"/* cy2|3 = tmp2|3 + ((-cy2|3)&q) */\
 		"movq	%%rax,%[__cy0]		\n\t	movq	%%r11,%[__cy1]	\n\t"\
 		"movq	%%r12,%[__cy2]		\n\t	movq	%%r13,%[__cy3]	\n\t"\
-		:	/* outputs: none */\
+		: [__cy0] "+m" (cy0)	/* outputs: cy0-3 (asm reads and stores through them) */\
+		 ,[__cy1] "+m" (cy1)	\
+		 ,[__cy2] "+m" (cy2)	\
+		 ,[__cy3] "+m" (cy3)	\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
-		 ,[__cy2] "m" (cy2)	\
-		 ,[__cy3] "m" (cy3)	\
 		 ,[__len4] "m" (len4)	\
 		 ,[__n] "m" (nshift)	\
 		 ,[__iptr0] "m" (iptr0)	/* Output base-pointer */\
@@ -7998,7 +7985,7 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 	"subq	$1,%%rcx \n\t"\
 	"jnz loop4c 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rax,%[__cy3]	\n\t"\
-	:	/* outputs: none */\
+	: [__cy3] "+m" (cy3)	/* output: cy3 (asm stores through it); cy0-2 are read-only above */\
 	: [__q] "m" (q)	/* All inputs from memory addresses here */\
 	 ,[__qinv] "m" (qinv)	\
 	 ,[__x] "m" (iptr0)	\
@@ -8006,7 +7993,6 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 	 ,[__cy0] "m" (cy0)	\
 	 ,[__cy1] "m" (cy1)	\
 	 ,[__cy2] "m" (cy2)	\
-	 ,[__cy3] "m" (cy3)	\
 	 ,[__len] "m" (len)	\
 	: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
 	);
@@ -8055,7 +8041,7 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 	"subq	$1,%%rcx \n\t"\
 	"jnz loop4c 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rdx,%[__cy3]	\n\t"\
-	:	/* outputs: none */\
+	: [__cy3] "+m" (cy3)	/* output: cy3 (asm stores through it); cy0-2 are read-only above */\
 	: [__q] "m" (q)	/* All inputs from memory addresses here */\
 	 ,[__qinv] "m" (qinv)	\
 	 ,[__iptr0] "m" (iptr0)	/* Input pointers (point to x,x+len2 if q odd, y,y+len2 if q even) */\
@@ -8064,7 +8050,6 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 	 ,[__cy0] "m" (cy0)	\
 	 ,[__cy1] "m" (cy1)	\
 	 ,[__cy2] "m" (cy2)	\
-	 ,[__cy3] "m" (cy3)	\
 	 ,[__len4] "m" (len4)	\
 	: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
 	);


### PR DESCRIPTION
Findings from a systematic memory-safety audit of the Mfactor-linked sources. Two commits:

**Commit 1 — confirmed OOB writes + latent traps** (each OOB item reproduces as an ASan heap-buffer-overflow with exactly-sized buffers):
1. `mi64_div_by_scalar64_u2/_u4`: in-place zero-padding wrote `x[lenu]`(`.._u2`, on **every** call) / `x[lenu..lenu+2]`(`_u4`), and wrote the quotient `y[]` with the padded length — up to 3 words past the caller's exactly-sized arrays (all in-tree callers pass exactly-`lenu`-word arrays). Fixed by dispatching non-multiple-of-fold lengths to the narrower variants and deleting the pad machinery — the folded routines now never touch memory outside `[0, lenu)`.
2. `mi64_div_mont`: single-word-remainder restore writes `rem_save[nws]` with `nws == lenD` possible (e.g. divisor `3*2^65`) — one word past the scratch section; +1 pad word. Also guarded an `(uint64)-1 >> 64` UB for `nshift % 64 == 0`.
3. `mi64_twopmodq`: static q-buffer reallocs sized by `lenQ` but gated on `len` (skip-then-overrun trap); a `pshift` re-realloc that could silently shrink it; lead-bits extraction over the nominal rather than effective length (stale-word read after realloc).
4. `mi64_shrl`: the documented "fudge factor" (`output_len` one word short) was never implemented — every path wrote one word past the buffer; the 0-shift path passed a *negative count* to `mi64_clear` (≈2^32-word wipe). All writes now clamped.
5. `mi64_is_div_by_scalar64_x4`: inverted ASSERT (`len == 0`) aborted every legitimate call.
6. `mi64_add`, ASM variant: added a `len != 0` guard, because the ASM loop counts down with `decq` before its first termination test and would therefore treat `len == 0` as 2^64 iterations. Note that this does **not** restore parity with the C variant, contrary to what an earlier revision of this description said: the live non-`YES_ASM` `mi64_add` — the `#elif 1` 2-folded loop — has no such assert and silently returns 0 for `len == 0`. Its matching assert is dead code inside the preceding `#if 0` arm. So after this change the ASM variant aborts where the C variant returns 0; making the C side match is a separate call for the maintainer.
7. `mi64_vcvtuqq2pd`: `vmovaps` → `vmovups` (caller arrays carry no 64-byte-alignment contract).

**Commit 2 — asm-operand hardening:** converted every asm-written operand declared as a plain input-`"m"` to a `"+m"` output, following the file's own Jan-2025 precedent where this exact pattern caused a real miscompile. 17 asm blocks across 7 functions: `radix_power64` (1), `mi64_is_div_by_scalar64` (2), `mi64_is_div_by_scalar64_x4` (1), `mi64_is_div_by_scalar64_u2` (1), `mi64_is_div_by_scalar64_u4` (2), `mi64_div_by_scalar64_u2` (4), `mi64_div_by_scalar64_u4` (6). All blocks use named operands; none positional.

## Testing
- ASan harness (exactly-sized buffers; 1-word-divisor `mi64_div` at lengths 6/7/70, `mi64_div` by `3*2^65` with no remainder array, `mi64_shrl` fudge cases): red on pristine main at the first case, all green after.
- Semantic check `quotient*q + rem == dividend` across nosimd/AVX2 × `-O1`+ASan/`-O3`: byte-identical remainders in every config.
- Warning-neutral at `-O2/-O3 -Wall`; AVX-512 compile clean; Mfactor self-test passes on the integration branch carrying these commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
