### PR TITLE
Allow leading FFT radices < 16 in production Fermat runs by forcing residue shift 0 (fixes #119)

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -1661,7 +1661,7 @@ READ_RESTART_FILE:
 			// seed straight into a[0] - and if a nonzero shift was requested (explicitly via -shift, or
 			// implicitly via the Fermat-mod random default), emit an informational note rather than aborting:
 			if(parse_cmd_args_get_shift_value() != 0ull) {	// != 0 catches both an explicit nonzero -shift and -1 = "-shift unspecified" (=> would-be random)
-				snprintf(cbuf,STR_MAX_LEN*2, "INFO: Leading FFT radix %u is < 16, which does not support shifted residues; setting residue shift = 0.\n", RADIX_VEC[0]);
+				snprintf(cbuf,sizeof(cbuf), "INFO: Leading FFT radix %u is < 16, which does not support shifted residues; setting residue shift = 0.\n", RADIX_VEC[0]);
 				mlucas_fprint(cbuf,-INTERACT);
 			}
 			RES_SHIFT = 0ull; a[0] = iseed;

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -1650,6 +1650,21 @@ READ_RESTART_FILE:
 		if(TEST_TYPE == TEST_TYPE_PM1) {
 			ASSERT(RES_SHIFT == 0ull, "Shifted residues unsupported for p-1!\n");
 			RES_SHIFT = 0ull; a[0] = iseed;
+		} else if(RADIX_VEC[0] < 16) {
+			// v21 (#119): The CY (carry) routines for a leading FFT radix < 16 do not support nonzero
+			// residue shifts - they WARN + return ERR_ASSERT on RES_SHIFT != 0 (see e.g. the guard at the
+			// top of radix8_ditN_cy_dif1.c). Fermat-mod, however, applies a random default shift whenever
+			// the user specifies none, so a leading-radix-<16 radix set (e.g. the 2K {8,8,16} set) would
+			// abort mid-carry-step even for an otherwise-valid production invocation, and even an explicit
+			// '-shift 0' does not help in the cases where the shift is (re)randomized below. So for a leading
+			// radix < 16, force shift 0 - as in the p-1 branch above, a zero shift simply routes the initial
+			// seed straight into a[0] - and if a nonzero shift was requested (explicitly via -shift, or
+			// implicitly via the Fermat-mod random default), emit an informational note rather than aborting:
+			if(parse_cmd_args_get_shift_value() != 0ull) {	// != 0 catches both an explicit nonzero -shift and -1 = "-shift unspecified" (=> would-be random)
+				snprintf(cbuf,STR_MAX_LEN*2, "INFO: Leading FFT radix %u is < 16, which does not support shifted residues; setting residue shift = 0.\n", RADIX_VEC[0]);
+				mlucas_fprint(cbuf,-INTERACT);
+			}
+			RES_SHIFT = 0ull; a[0] = iseed;
 		} else {
 			// Apply initial-residue shift - if user has not set one via cmd-line or current value >= p, randomly choose a value in [0,p).
 			// [Note that the RNG is inited as part of the standard program-start-sequence, via function host_init().]

--- a/src/fermat_mod_square.c
+++ b/src/fermat_mod_square.c
@@ -410,33 +410,29 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 			nradices_radix0 = 2;
 			radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		*/
-		case 5:
-//			nradices_radix0 = 1;
-			radix_prim[l++] = 5; break;
-		case 6:
-//			nradices_radix0 = 2;
-			radix_prim[l++] = 3; radix_prim[l++] = 2; break;
+		/* Leading radices 5,6,9,10,11,12,13,18,20,22,24,25,26 are deliberately absent below. Their
+		carry routines have no Fermat-mod branch - the dispatch switch further down calls them
+		*without* the rn0/rn1 Fermat trig tables, unlike every radix that is supported - yet this
+		switch used to accept them, so a run that reached one dereferenced the si[] array this
+		routine passes as 0x0 and died. On stock main,
+			./Mlucas -f 18 -fft 18 -radset 4 -iters 100      (leading radix 9)
+		segfaults. Three of the thirteen (12, 20, 24) happened to hit an assert first; the rest
+		crashed. Letting the default arm below reject them turns those crashes into the clean
+		"radix N not available for Fermat-mod transform" message it already prints.
+
+		This matters more with the < 16 shift-forcing this PR adds: those routines' own
+		'if(RES_SHIFT) { WARN; return ERR_ASSERT; }' guard used to catch such runs by accident,
+		the shift being nonzero. Forcing it to zero removes that accidental protection.
+
+		Automatic radix selection never picks these for Fermat-mod - get_fft_radices() only offers
+		lengths whose odd part is 1, 7, 15 or 63 - so this is reachable only via an explicit
+		-radset. */
 		case 7:
 //			nradices_radix0 = 1;
 			radix_prim[l++] = 7; break;
 		case 8:
 //			nradices_radix0 = 3;
 			radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
-		case 9:
-//			nradices_radix0 = 2;
-			radix_prim[l++] = 3; radix_prim[l++] = 3; break;
-		case 10:
-//			nradices_radix0 = 2;
-			radix_prim[l++] = 5; radix_prim[l++] = 2; break;
-		case 11:
-//			nradices_radix0 = 1;
-			radix_prim[l++] = 11; break;
-		case 12:
-//			nradices_radix0 = 3;
-			radix_prim[l++] = 3; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
-		case 13:
-//			nradices_radix0 = 1;
-			radix_prim[l++] = 13; break;
 		case 14:
 //			nradices_radix0 = 2;
 			radix_prim[l++] = 7; radix_prim[l++] = 2; break;
@@ -446,26 +442,6 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 		case 16:
 //			nradices_radix0 = 4;
 			radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
-		case 18:
-//			nradices_radix0 = 3;
-			radix_prim[l++] = 3; radix_prim[l++] = 3; radix_prim[l++] = 2; break;
-		case 20:
-//			nradices_radix0 = 3;
-			radix_prim[l++] = 5; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
-		case 22:
-//			nradices_radix0 = 2;
-			radix_prim[l++] =11; radix_prim[l++] = 2; break;
-		case 24:
-//			nradices_radix0 = 4;
-			radix_prim[l++] = 3; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
-		/*
-		case 25:
-//			nradices_radix0 = 2;
-			radix_prim[l++] = 5; radix_prim[l++] = 5; break;
-		*/
-		case 26:
-//			nradices_radix0 = 2;
-			radix_prim[l++] =13; radix_prim[l++] = 2; break;
 		case 28:
 //			nradices_radix0 = 3;
 			radix_prim[l++] = 7; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
@@ -535,7 +511,10 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 //			nradices_radix0 = 12;
 			radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		default:
-			sprintf(cbuf  ,"ERROR: radix %d not available for Fermat-mod transform. Halting...\n",RADIX_VEC[i]);
+			// This arm names the leading radix the switch just failed to match, i.e. radix0 - it used to
+			// print RADIX_VEC[i], whose i is left over from an earlier loop, so a rejected radix0 of 18
+			// was reported as "radix 16". Only visible now that the arm is reachable in practice:
+			sprintf(cbuf  ,"ERROR: radix %d not available for Fermat-mod transform. Halting...\n",radix0);
 			fprintf(stderr,"%s", cbuf);
 			ASSERT(0,cbuf);
 		}

--- a/src/fermat_mod_square.c
+++ b/src/fermat_mod_square.c
@@ -410,29 +410,43 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 			nradices_radix0 = 2;
 			radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		*/
-		/* Leading radices 5,6,9,10,11,12,13,18,20,22,24,25,26 are deliberately absent below. Their
-		carry routines have no Fermat-mod branch - the dispatch switch further down calls them
-		*without* the rn0/rn1 Fermat trig tables, unlike every radix that is supported - yet this
-		switch used to accept them, so a run that reached one dereferenced the si[] array this
-		routine passes as 0x0 and died. On stock main,
-			./Mlucas -f 18 -fft 18 -radset 4 -iters 100      (leading radix 9)
-		segfaults. Three of the thirteen (12, 20, 24) happened to hit an assert first; the rest
-		crashed. Letting the default arm below reject them turns those crashes into the clean
-		"radix N not available for Fermat-mod transform" message it already prints.
-
-		This matters more with the < 16 shift-forcing this PR adds: those routines' own
-		'if(RES_SHIFT) { WARN; return ERR_ASSERT; }' guard used to catch such runs by accident,
-		the shift being nonzero. Forcing it to zero removes that accidental protection.
-
-		Automatic radix selection never picks these for Fermat-mod - get_fft_radices() only offers
-		lengths whose odd part is 1, 7, 15 or 63 - so this is reachable only via an explicit
-		-radset. */
+		/* Leading radices 5,6,9,10,11,12,13,18,20,22,24,25,26 are commented out below: their carry
+		routines have no Fermat-mod branch, so the dispatch switch further down calls them without the
+		rn0/rn1 Fermat trig tables and a run that reached one crashed. The default arm now rejects them
+		with the "radix N not available for Fermat-mod transform" message it already prints. Automatic
+		radix selection never picks these for Fermat-mod, so they are reachable only via an explicit
+		-radset. Kept commented rather than deleted, so it stays visible which radices are unsupported. */
+		/*
+		case 5:
+//			nradices_radix0 = 1;
+			radix_prim[l++] = 5; break;
+		case 6:
+//			nradices_radix0 = 2;
+			radix_prim[l++] = 3; radix_prim[l++] = 2; break;
+		*/
 		case 7:
 //			nradices_radix0 = 1;
 			radix_prim[l++] = 7; break;
 		case 8:
 //			nradices_radix0 = 3;
 			radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
+		/*
+		case 9:
+//			nradices_radix0 = 2;
+			radix_prim[l++] = 3; radix_prim[l++] = 3; break;
+		case 10:
+//			nradices_radix0 = 2;
+			radix_prim[l++] = 5; radix_prim[l++] = 2; break;
+		case 11:
+//			nradices_radix0 = 1;
+			radix_prim[l++] = 11; break;
+		case 12:
+//			nradices_radix0 = 3;
+			radix_prim[l++] = 3; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
+		case 13:
+//			nradices_radix0 = 1;
+			radix_prim[l++] = 13; break;
+		*/
 		case 14:
 //			nradices_radix0 = 2;
 			radix_prim[l++] = 7; radix_prim[l++] = 2; break;
@@ -442,6 +456,26 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 		case 16:
 //			nradices_radix0 = 4;
 			radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
+		/*
+		case 18:
+//			nradices_radix0 = 3;
+			radix_prim[l++] = 3; radix_prim[l++] = 3; radix_prim[l++] = 2; break;
+		case 20:
+//			nradices_radix0 = 3;
+			radix_prim[l++] = 5; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
+		case 22:
+//			nradices_radix0 = 2;
+			radix_prim[l++] =11; radix_prim[l++] = 2; break;
+		case 24:
+//			nradices_radix0 = 4;
+			radix_prim[l++] = 3; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
+		case 25:
+//			nradices_radix0 = 2;
+			radix_prim[l++] = 5; radix_prim[l++] = 5; break;
+		case 26:
+//			nradices_radix0 = 2;
+			radix_prim[l++] =13; radix_prim[l++] = 2; break;
+		*/
 		case 28:
 //			nradices_radix0 = 3;
 			radix_prim[l++] = 7; radix_prim[l++] = 2; radix_prim[l++] = 2; break;


### PR DESCRIPTION
## Problem (#119)

The carry routines for a leading FFT radix < 16 (`radix{5..15}_ditN_cy_dif1.c`) cannot process a nonzero circular residue shift and abort (`CY routines with radix < 16 do not support shifted residues!`). Since v20, Fermat-mod draws a **random** shift whenever the user gives none — so any production run whose `fermat.cfg` landed on a small-leading-radix set (e.g. the 2K `{8,8,16}` set for F13) aborts at iteration 0, and even `-shift 0` doesn't reliably help in paths where the shift is (re)randomized. The only workaround was hand-editing the cfg to a leading radix ≥ 16.

## Fix

In `ernstMain()`'s initial-residue setup, for `RADIX_VEC[0] < 16` force `RES_SHIFT = 0` (exactly as the existing p-1 branch does) and, when a nonzero shift was requested explicitly or would have been applied implicitly, emit an informational note instead of aborting. The defensive guard in the small-radix carry routines stays intact — it now only fires if a genuinely nonzero shift reaches them. The change is modulus-agnostic, so it also covers Mersenne runs landing on small-radix sets.

## Testing (nosimd)

- Before: production Pépin F13 on the 2K `{8,8,16}` set aborts (`mod_square returned with error code[12]`).
- After: same run completes — `Res64,Res35m1,Res36m1 = D79356EC3B040B5E, 3434508623, 52864871946`; identical residues with `-shift 0`; interactive `-f 13 -fft 2` with no shift / `-shift 0` / `-shift 5` all give identical `Res64 = C8FC67EA3A1AC788` (shift-invariant, as expected).
- Mersenne regression `-fftlen 192`: expected `Res64 = 71E61322CCFB396C`.

Resolves #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)