### PR TITLE
Updated CI to build for K1OM and KNL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,11 @@ jobs:
             MODES+=( ASIMD )
         else
             MODES+=( SSE2 AVX AVX2 AVX512 )
+            if echo 'int main(void){return 0;}' | $CC -march=knl -mavx512f -mavx512er -x c -o /dev/null -; then
+                MODES+=( AVX512_KNL )
+            else
+                echo "::warning::Skipping the AVX512_KNL build mode as '$($CC --version | head -n1)' does not support -march=knl."
+            fi
         fi
         for mode in "${MODES[@]}"; do
             echo -e "\n$mode\n"
@@ -102,6 +107,11 @@ jobs:
             MODES+=( ASIMD )
         else
             MODES+=( SSE2 AVX AVX2 AVX512 )
+            if echo 'int main(void){return 0;}' | $CC -march=knl -mavx512f -mavx512er -x c -o /dev/null -; then
+                MODES+=( AVX512_KNL )
+            else
+                echo "::warning::Skipping the AVX512_KNL build mode as '$($CC --version | head -n1)' does not support -march=knl."
+            fi
         fi
         for mode in "${MODES[@]}"; do
             echo -e "\n$mode\n"
@@ -196,6 +206,11 @@ jobs:
             else
                 echo "::warning title=AVX-512 build skipped::$("${CC:-gcc}" --version | head -n1): its assembler can't handle the AVX-512 extended registers (zmm16-31/xmm16-31/k0-7) Mlucas's kernels need; skipping the AVX-512 build mode."
             fi
+            if echo 'int main(void){__asm__ __volatile__("vpxord %%zmm31,%%zmm31,%%zmm31\n\tvmovdqa64 %%xmm16,%%xmm17\n\tkmovw %%k1,%%eax":::"zmm31","xmm16","xmm17","k1","eax");return 0;}' | $CC -march=knl -mavx512f -mavx512er -x c -o /dev/null -; then
+                MODES+=( AVX512_KNL )
+            else
+                echo "::warning::Skipping the AVX512_KNL build mode as '$($CC --version | head -n1)' does not support -march=knl."
+            fi
         fi
         for mode in "${MODES[@]}"; do
             echo -e "\n$mode\n"
@@ -210,6 +225,52 @@ jobs:
                 )
             done
         done
+
+  Linux-K1OM:
+    name: Mlucas K1OM
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - name: Download
+      run: |
+          # https://web.archive.org/web/20210307201727/https://software.intel.com/content/www/us/en/develop/articles/intel-manycore-platform-software-stack-mpss.html
+          wget -nv 'https://web.archive.org/web/20200818141734id_/http://registrationcenter-download.intel.com/akdlm/irc_nas/15904/mpss-3.8.6-linux.tar'
+          tar -xvf mpss-3.8.6-linux.tar
+    - name: Script
+      run: |
+        docker run --rm -i -v "$GITHUB_WORKSPACE:/workspace" -w /workspace centos:7 bash -s <<'EOF'
+        set -e -o pipefail
+        sed -i '/^mirrorlist/d;/^#baseurl=/{s|^#||;s|/mirror|/vault|;}' /etc/yum.repos.d/CentOS*.repo
+        # yum update -y
+        yum install -y make
+        yum localinstall -y mpss-3.8.6/mpss-sdk-k1om-3.8.6-1.x86_64.rpm
+        source /opt/mpss/3.8.6/environment-setup-k1om-mpss-linux
+
+        export CC=k1om-mpss-linux-gcc
+        unset CFLAGS CPPFLAGS
+        $CC --version
+        k1om-mpss-linux-ld --version
+        $CC -dM -E - </dev/null
+
+        bash -e -o pipefail -- makemake.sh no_gmp k1om
+        (cd obj_k1om; make clean)
+        for word in '' 1word 2word 3word 4word nword; do
+            echo -e "\nMfactor $word\n"
+            bash -e -o pipefail -- makemake.sh no_gmp mfac $word k1om || true
+            (
+                cd obj_mfac${word:+_$word}_k1om
+                make clean
+            )
+        done
+        EOF
+    - uses: actions/upload-artifact@v7
+      if: always()
+      with:
+        name: linux_k1om_mlucas
+        path: |
+          ${{ github.workspace }}
+          !mpss-*
 
   ASan-Linux:
     name: AddressSanitizer Linux

--- a/makemake.sh
+++ b/makemake.sh
@@ -267,7 +267,6 @@ if [[ ${#MODES[*]} -eq 1 ]]; then
 			;;
 		avx512_knl)
 			echo "Building for avx512_knl SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
-			echo "Warning: The 'avx512_knl' option is deprecated, use 'avx512' instead."
 			ARGS+=(-DUSE_AVX512 -march=knl -mavx512f -mavx512cd -mavx512er -mfma)
 			;;
 		avx512)


### PR DESCRIPTION
* Updated the CI to build for K1OM (Knights Corner) and KNL (Knights Landing).
  * Long term, it has been discussed if we should remove support for these older platforms. This just adds some basic testing to prevent regressions, especially for major changes like #34 that affect the `USE_IMCI512` code path. Ernst added K1OM support in v21.

There are errors when attempting to build Mlucas for K1OM (looks like missing line continuation characters in the inline assembly):
```
*** There were build errors - see 'obj_k1om/build.log' for details. ***

../src/carry_gcc64.h:17995:3: error: expected identifier or '(' before string constant
   "vmovapd %%zmm3,(%%rsi){%%k6%} \n\t"
   ^
--
../src/carry_gcc64.h:17995:3: error: expected identifier or '(' before string constant
   "vmovapd %%zmm3,(%%rsi){%%k6%} \n\t"
   ^
--
../src/carry_gcc64.h:18081:2: error: expected identifier or '(' before '}' token
  }
  ^
--
../src/carry_gcc64.h:18081:2: error: expected identifier or '(' before '}' token
  }
  ^
```
The KNL builds would also need to be gated to older GCC/Clang compilers that support it. Ubuntu 26.04 and Alpine 3.24 are failing with both GCC and Clang due to the `-mavx512er` option. It looks like KNL support was removed in [GCC 15](https://gcc.gnu.org/gcc-15/changes.html) and [Clang 19](https://releases.llvm.org/19.1.0/tools/clang/docs/ReleaseNotes.html).

@MarkRose - Maybe you would be interested in fixing these issues. If so, please feel free to take over this PR.