### PR TITLE
Bound the -radset radix count before writing into rvec[] (stack buffer overflow)

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -4154,19 +4154,32 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 				ASSERT(i64arg < 20, "radset-index argument must be < 2^32 ... halting.");
 				radset = (uint32)i64arg;
 			} else {	// It's a set of complex-FFT radices
+				// One pass over the comma-separated list, bounding the count as we go: stFlag is
+				// STR_MAX_LEN bytes, so a user-supplied -radset arg can hold hundreds of tokens while
+				// rvec[]/rvec2[] hold ten, and the radix-product and FFT-length checks further down
+				// only run once every store has been made - far too late to prevent the overflow.
+				// The last token has no trailing comma, so the loop handles it and then exits.
+				// Derive the capacity from the array itself so the bound cannot drift from it:
+				const uint32 max_rad = sizeof(rvec)/sizeof(rvec[0]);
 				numrad = 0;
-				while(0x0 != (cptr = strchr(char_addr,','))) {
-					// Copy substring into cbuf and null-terminate:
-					strncpy(cbuf,char_addr,(cptr-char_addr));	cbuf[cptr-char_addr] = '\0';
+				for(;;) {
+					cptr = strchr(char_addr,',');
+					if(cptr) {	// Copy substring into cbuf and null-terminate:
+						strncpy(cbuf,char_addr,(cptr-char_addr));	cbuf[cptr-char_addr] = '\0';
+					} else {	// A properly formatted radix-set arg ends with ',[numeric]':
+						strcpy(cbuf,char_addr);
+					}
 					// Convert current radix to long and sanity-check:
 					i64arg = atoll(cbuf);	ASSERT(!(i64arg>>12), "user-supplied radices must be < 2^12 ... halting.");
+					if(numrad >= max_rad) {
+						sprintf(cbuf  , "ERROR: -radset argument specifies more than the %u complex-FFT radices supported.\n",max_rad);
+						fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf);
+					}
 					rvec[numrad++] = (uint32)i64arg;
+					if(!cptr) break;
 					char_addr = cptr+1;
 				}
-				// A properly formatted radix-set arg will end with ',[numeric]', with the numeric in char_addr:
-				i64arg = atoll(char_addr);	ASSERT(!(i64arg>>12), "user-supplied radices must be < 2^12 ... halting.");
-				rvec[numrad++] = (uint32)i64arg;
-				rvec[numrad] = 0;	// Null-terminate the vector just for aesthetics
+				if(numrad < max_rad) { rvec[numrad] = 0; }	// Null-terminate the vector just for aesthetics, if there is room for a terminator
 				// Compute the radix product and make sure it's < 2^30, constraint due to the (fftlen < 2^31) one:
 				rad_prod = 1; i64arg = 1ull;
 				for(i = 0; i < numrad; i++) {
@@ -4184,7 +4197,7 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 				// in which case j holds #radices and rvec2[] holds the corresponding radices on return.
 				// Note that get_fft_radices takes real-FFT length in terms of Kdoubles:
 				i = 0;
-				while(!get_fft_radices(fftlen, i++, (uint32 *)&j, rvec2, 10)) {	// 0-return means radset index is in range
+				while(!get_fft_radices(fftlen, i++, (uint32 *)&j, rvec2, (int)max_rad)) {	// 0-return means radset index is in range
 					if(j != numrad) continue;
 					// #radices matches, see if actual complex radices do
 					for(j = 0; j < numrad; j++) {


### PR DESCRIPTION
## The bug

`-radset` accepts either an index into the `get_fft_radices()` table or an actual
comma-separated list of complex-FFT radices. The list-parsing branch of the `-radset`
handler in `main()` (`src/Mlucas.c`) writes every token it finds into the **10-element**
stack array `rvec[]` — declared in `main()` as
`uint32 numrad = 0, rad_prod = 0, rvec[10], rvec2[10];` — with **no bound on `numrad`**:

```c
numrad = 0;
while(0x0 != (cptr = strchr(char_addr,','))) {
	// Copy substring into cbuf and null-terminate:
	strncpy(cbuf,char_addr,(cptr-char_addr));	cbuf[cptr-char_addr] = '\0';
	// Convert current radix to long and sanity-check:
	i64arg = atoll(cbuf);	ASSERT(!(i64arg>>12), "user-supplied radices must be < 2^12 ... halting.");
	rvec[numrad++] = (uint32)i64arg;	// <-- no bound on numrad
	char_addr = cptr+1;
}
i64arg = atoll(char_addr);	ASSERT(!(i64arg>>12), ...);
rvec[numrad++] = (uint32)i64arg;
rvec[numrad] = 0;	// <-- out of bounds even when numrad == 10
```

The per-token `ASSERT` bounds each radix *value* (< 2^12), not the count. `stFlag` is
`STR_MAX_LEN` = 1024 bytes, so a single `-radset` argument can hold roughly 500 tokens, i.e.
about 2 KB of caller-chosen 32-bit words written past a 40-byte array in `main()`'s frame.

### Why the existing guards are too late

Both post-parse checks run only after every store has already happened:

* `ASSERT(!(i64arg>>30), "Product of complex-FFT radices ... must be < 2^32")` - the
  product loop itself iterates `i < numrad` over the already-overflowed array.
* `ASSERT((rad_prod>>9) == fftlen, ...)` - the FFT-length consistency check, later still.

Neither can prevent an out-of-bounds write; they can only observe the wreckage. Worse, the
value they check (`fftlen`) is one of the locals the overflow can clobber.

## Evidence, before

Collected on `main` @ 590a1a6, so the file:line references inside the sanitizer transcripts
below are that commit's. The parser is unchanged since, apart from `atol` -> `atoll` (#160).

Silent frame corruption in a normal `makemake.sh avx2` build - ten radices parse fine, eleven
do not:

```
$ ./Mlucas -radset 1,1,1,1,1,1,1,1,1,2048 -iters 100      # 10 radices
Assertion 'radset >= 0' failed: User-supplied set of complex-FFT radices not supported.   <-- expected

$ ./Mlucas -radset 1,1,1,1,1,1,1,1,1,1,2048 -iters 100    # 11 radices
ERROR: 0 K must be > 0.                                   <-- 'fftlen' local clobbered
Assertion 'radset >= 0' failed: User-supplied set of complex-FFT radices not supported.
```

That `ERROR: 0 K must be > 0.` comes from the `kblocks == 0` guard at the top of
`get_fft_radices()`, i.e. `fftlen` reached it as 0 even though `rad_prod>>9` was 4 at the
FFT-length consistency check a few lines earlier - the out-of-bounds store overwrote an
adjacent `main()` local. Other counts corrupt other locals, e.g. 30 x `-radset 3` produces a
spurious `ERROR: specified FFT length ... has non-power-of-2 component`.

A `CC=clang CFLAGS="-fdiagnostics-color -Wall -g -Og -fsanitize=address,undefined"` build (the
same flags as the `ASan-Linux` CI job) is unambiguous - `-radset` with 11 radices:

```
../src/Mlucas.c:4160:5: runtime error: index 10 out of bounds for type 'uint32[10]' (aka 'unsigned int[10]')
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../src/Mlucas.c:4160:5
=================================================================
==1101531==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7bf9e31f0568 at pc 0x55b323e6e455 bp 0x7ffffc4a62f0 sp 0x7ffffc4a62e8
WRITE of size 4 at 0x7bf9e31f0568 thread T0

Address 0x7bf9e31f0568 is located in stack of thread T0 at offset 1384 in frame
  This frame has 10 object(s):
    [32, 40) 'Res64' (line 3928)
    [64, 72) 'Res35m1' (line 3928)
    [96, 104) 'Res36m1' (line 3928)
    [128, 1152) 'stFlag' (line 3929)
    [1280, 1284) 'j' (line 3934)
    [1296, 1300) 'idum' (line 3934)
    [1312, 1320) 'cptr' (line 3940)
    [1344, 1384) 'rvec' (line 3942) <== Memory access at offset 1384 overflows this variable
    [1424, 1464) 'rvec2' (line 3942)
    [1504, 1512) 'runtime' (line 3943)
SUMMARY: AddressSanitizer: stack-buffer-overflow
```

Same build, 60 radices - the first out-of-bounds store is now the in-loop one:

```
../src/Mlucas.c:4155:6: runtime error: index 10 out of bounds for type 'uint32[10]'
==1101681==ERROR: AddressSanitizer: stack-buffer-overflow ... WRITE of size 4
    [1344, 1384) 'rvec' (line 3942) <== Memory access at offset 1384 overflows this variable
```

And - not obvious from the non-sanitized runs - the *ten*-radix case, which is a legal count,
is also out of bounds, via the aesthetic terminator store `rvec[numrad] = 0;`:

```
$ ./Mlucas -radset 1,1,1,1,1,1,1,1,1,2048 -iters 100
../src/Mlucas.c:4161:5: runtime error: index 10 out of bounds for type 'uint32[10]'
==1101672==ERROR: AddressSanitizer: stack-buffer-overflow ... WRITE of size 4
    [1344, 1384) 'rvec' (line 3942) <== Memory access at offset 1384 overflows this variable
```

A valid `-radset 16,8,16` on the same before-build produces no such report (only the two
pre-existing, unrelated UBSan diagnostics tracked by #29/#28), so the reports above are
specific to the radix-count overflow.

Full disclosure on one detail: in the AVX2 build I could not turn this into a hard SIGSEGV -
`main()`'s frame is large, so the writes land in other locals and the run aborts at one of the
later `ASSERT`s (exit 134, "core dumped") rather than crashing outright. The defect is the
out-of-bounds write itself; what it hits is a layout accident.

## The fix

Count the comma-separated tokens first and reject an over-long list before any store happens:

* Capacity is derived as `sizeof(rvec)/sizeof(rvec[0])` rather than hardcoded, so it cannot
  drift away from the declaration. There is no pre-existing max-radices constant to reuse -
  `Mdata.h` only defines `MAX_RADIX` (= 4096, the largest leading *radix*), and the
  ten-element limit is spelled as a bare `10` in that same header's
  `extern uint32 NRADICES, RADIX_VEC[10];`, in `get_fft_radices()`'s own `uint32 rvec[10]`
  and at the call site here. `help.txt` documents `-radset` but states no limit on the number
  of radices, so nothing needed updating there; the new message is self-explanatory.
* The same derived value replaces the hardcoded `10` passed as `get_fft_radices()`'s
  `radix_vec_dim` argument - `rvec2[]` has the same declared capacity.
* The aesthetic NUL-terminator store now happens only when there is room, so the maximum legal
  count of 10 radices stays usable instead of being over-tightened to 9.

## Evidence, after

```
$ ./Mlucas -radset 1,1,1,1,1,1,1,1,1,1,2048 -iters 100
ERROR: -radset argument specifies 11 complex-FFT radices, but at most 10 are supported.

$ ./Mlucas -radset $(python3 -c "print(','.join(['16']*60))") -fftlen 1024 -iters 100
ERROR: -radset argument specifies 60 complex-FFT radices, but at most 10 are supported.

$ ./Mlucas -radset $(python3 -c "print(','.join(['1']*500))") -iters 100
ERROR: -radset argument specifies 500 complex-FFT radices, but at most 10 are supported.
```

Re-running all three plus the 10-radix case on the clang ASan+UBSan build: **no
stack-buffer-overflow and no out-of-bounds-index report**, and no new sanitizer diagnostic.
The 10-radix case now reaches the pre-existing `radset >= 0` assert, which is the correct
answer for that (unsupported) radix set.

Legitimate use is untouched - identical Res64 before and after, including the longest radix set
the tables actually contain (2048K radix_set 9 in `get_fft_radices()`: six radices,
`16,8,8,8,8,16`, which is the maximum `numrad` over the whole table):

| invocation | before | after |
|---|---|---|
| `-radset 16,8,16 -iters 100` | `7AFD2F95BF1D2361` | `7AFD2F95BF1D2361` |
| `-fftlen 6144 -radset 1 -iters 100` | `6903363805E74E29` | `6903363805E74E29` |
| `-fftlen 2048 -radset 16,8,8,8,8,16 -iters 100` | `EC810981F56D5EC7` | `EC810981F56D5EC7` |

Build/test performed: clean `bash makemake.sh avx2` (gcc 16.1.1, zero errors), then
`obj_avx2/Mlucas -s tt` -> `13K=E3BC90B0E652C7C0`, `14K=DB8E39C67F8CCA0A`,
`15K=B3C5A1C03E26BB17`, all as expected (the 1K/2K "excessive roundoff error" lines are the
known #101 noise). Plus the clang `-Og -fsanitize=address,undefined` AVX2 build described
above. Not tested on AVX-512 hardware, Windows or ARM - the change is
architecture-independent command-line parsing, so I do not expect any platform sensitivity,
but I have not run those builds.

## This is not #140

`#140` bounds the **`CORE_SET` affinity bitmap** in `src/util.c` (`parseAffinityTriplet()`,
`word < MAX_CORES` should be `word < (MAX_CORES>>6)`) for the `-cpu`/`-nthread` flags, plus
some missing asm clobbers. Different file, different array, different flag, different bound.
This PR touches only `src/Mlucas.c`'s `-radset` list parser and the `rvec[]`/`rvec2[]` locals
in `main()`; the two diffs do not overlap. Also distinct from #91 (NUL-terminating arg copies),
#92 (`cbuf` `snprintf` bounds) and #139 (`mi64` out-of-bounds writes). No existing issue covers
this one.
