### PR TITLE
Make the default FFT length Fermat-aware; stop the self-test retry loop from spinning forever

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -3939,6 +3939,8 @@ int 	main(int argc, char *argv[])
 #endif
 	char *cptr = 0x0;
 	int		quick_self_test = 0, fftlen = 0, radset = -1;
+	// v21: State used to guarantee the remedial-timing-self-test retry loop below makes progress:
+	uint32	selftest_fftlen_prev = 0, selftest_count = 0;
 	uint32 numrad = 0, rad_prod = 0, rvec[10], rvec2[10];	/* Temporary storage for FFT radices */
 	double	runtime,/* wruntime, */ runtime_best,wruntime_best, tdiff;	// v20: w-prefixed are weighted by associated ROEs
 	double	roerr_avg = 0, roerr_max = 0;
@@ -4359,6 +4361,12 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 	if(!modType)
 		modType = MODULUS_TYPE_MERSENNE;
 
+	// v21: Keep the MODULUS_TYPE global in sync with our local modType - main() itself calls
+	// get_default_fft_length(), which needs to know whether to use the Mersenne-mod or the
+	// Fermat-mod schedule of supported FFT lengths. (ernstMain() re-sets the global from its
+	// own mod_type argument on each call, and for workfile-driven runs from the workfile entry.)
+	MODULUS_TYPE = modType;
+
 	// Now that have determined the modType, copy any user-set FFT length into the appropriate field:
 	if(fftlen) {
 		/* Don't set userSetExponent here, since -fftlen can be invoked without an explicit exponent */
@@ -4427,23 +4435,64 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 					sprintf(cbuf, "ERROR: FFT length %d K not available.\n",k);
 					fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf);
 				}
+				/* v21: The cfg-file entry a remedial self-test writes is permanent, so a repeat request
+				for a length we have already self-tested means this retry cycle is making no progress -
+				bail with a diagnostic rather than spinning forever. A legitimate second request always
+				names a different (larger) length, e.g. one reached via roundoff-triggered FFT upsizing.
+				The self-test counter is a belt-and-braces bound in case some path we have not foreseen
+				manages to cycle over two or more alternating lengths:
+				*/
+				if(k == selftest_fftlen_prev) {
+					sprintf(cbuf, "ERROR: A timing self-test at FFT length %u K has already been run in this session, yet the\n"
+						"production run still finds no entry for that length in %s. Refusing to loop.\n"
+						"Please check that %s is writeable and contains exactly one valid entry for %u K,\n"
+						"or generate one manually via a '-fft %u -iters 100' self-test.\n", k,CONFIGFILE,CONFIGFILE,k,k);
+					fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf);
+				}
+				if(++selftest_count > 16) {
+					sprintf(cbuf, "ERROR: %u remedial timing self-tests have been run in this session, the latest for FFT\n"
+						"length %u K, and the production run still cannot start. Refusing to loop - please check %s.\n", selftest_count,k,CONFIGFILE);
+					fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf);
+				}
+				selftest_fftlen_prev = k;
 
+				/* v21: Run the remedial self-test using the modulus type the failed production run
+				actually used - previously this was unconditionally forced to MODULUS_TYPE_MERSENNE,
+				so for a workfile-driven Fermat assignment the self-test wrote mlucas.cfg while the
+				missing entry was in fermat.cfg, and the retry re-requested the same length forever:
+				*/
+				modType = MODULUS_TYPE;
 			/**** IF POSSIBLE, USE ONE OF THE STANDARD TEST EXPONENTS HERE, SO CAN CHECK RES64s!!! ****/
-				for(i = 0; i < numTest; i++) {
-					if(MvecPtr[i].fftLength == k) {
-						userSetExponent = 0;
-						start = i; finish = start+1;
-						break;
+				if(modType == MODULUS_TYPE_FERMAT) {
+					for(i = 0; i < numFerm; i++) {
+						if(FermVec[i].fftLength == k) {
+							userSetExponent = 0;
+							start = i; finish = start+1;
+							break;
+						}
+					}
+					if(i == numFerm) {
+						userSetExponent = 1;
+						/* For a Fermat-mod run ESTRING holds the Fermat-number index, not the binary exponent: */
+						FermVec[numFerm].Fidx = (uint32)convert_base10_char_uint64(ESTRING);
+						FermVec[numFerm].fftLength = k;
+						start = numFerm; finish = start+1;
+					}
+				} else {
+					for(i = 0; i < numTest; i++) {
+						if(MvecPtr[i].fftLength == k) {
+							userSetExponent = 0;
+							start = i; finish = start+1;
+							break;
+						}
+					}
+					if(i == numTest) {
+						userSetExponent = 1;
+						MvecPtr[numTest].exponent = convert_base10_char_uint64(ESTRING);
+						MvecPtr[numTest].fftLength = k;
+						start = numTest; finish = start+1;
 					}
 				}
-				if(i == numTest) {
-					userSetExponent = 1;
-					MvecPtr[numTest].exponent = convert_base10_char_uint64(ESTRING);
-					MvecPtr[numTest].fftLength = k;
-					start = numTest; finish = start+1;
-				}
-
-				modType = MODULUS_TYPE_MERSENNE;
 				goto TIMING_TEST_LOOP;
 			}
 			/* ...Otherwise barf. */
@@ -4840,11 +4889,26 @@ TIMING_TEST_LOOP:
 			/* if just adding entry for a single FFT length needed for current exponent, return to here: */
 			if (quick_self_test) {
 				quick_self_test = selfTest = 0; start = numTest; finish = start+1;
+				/* v21: The remedial self-test may have been run with modType switched to the production
+				run's modulus type - restore the value the (necessarily Mersenne-mod) ERNST_MAIN block
+				above was entered with before retrying the production run: */
+				modType = MODULUS_TYPE_MERSENNE;
 				goto ERNST_MAIN;
 			}
 		}
 
 		fprintf(stderr, "/ **************************************************************************** /\n\n");
+	}
+
+	/* v21: Getting here with quick_self_test still set means the remedial timing self-test above failed
+	to produce a usable cfg-file entry for the length the production run needs (e.g. every radix set at
+	that length was rejected for excessive roundoff error). Previously we fell straight through to the
+	"Done" print and a 0 exit status, silently having done no work on the assignment at all:
+	*/
+	if(quick_self_test) {
+		sprintf(cbuf, "ERROR: The timing self-test at FFT length %u K yielded no usable radix set, so no %s\n"
+			"entry could be written and the current assignment cannot be run. PLEASE CHECK YOUR BUILD OPTIONS.\n", k,CONFIGFILE);
+		fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf);
 	}
 
 DONE:

--- a/src/get_fft_radices.c
+++ b/src/get_fft_radices.c
@@ -2616,13 +2616,31 @@ void	test_fft_radixtables()
 
 /*
 !...Set vector length, based on number of bits (p) in numbers to be FFT-multiplied.
-Returns: FFT length in units of kdoubles, i.e. raw FFT length = (return value << 10) doubles:
+Returns: FFT length in units of kdoubles, i.e. raw FFT length = (return value << 10) doubles.
+
+The candidate lengths are of the form {8,9,10,11,12,13,14,15}*2^m for Mersenne-mod, but
+Fermat-mod (right-angle-transform) runs only support FFT lengths whose odd part is one of
+[1,7,15,63] - see help.txt, section [5]. On the above grid the leading-radix values whose
+resulting lengths have such an odd part are just {8,14,15} (giving lengths 2^k, 7*2^k and
+15*2^k, respectively), so for MODULUS_TYPE_FERMAT we simply restrict the candidate vector
+to those three. Without this, e.g. F16 gets a default length of 3K = 12*2^8 and F18 one of
+13K, and no Fermat-mod carry routine implements either: the affected Fermat indices are
+F16 (3K), F17 (6K), F18 (13K), F19 (26K), F20 (52K), F21 (104K) and F22 (208K); all other
+Fermat indices in [13,33] happen to get a legal default from the Mersenne-mod schedule.
+
+Note the 63*2^k lengths (1008K, 2016K, 4032K, ...) are not of the form {8,...,15}*2^m at
+all, hence never were candidates here, and we deliberately do not add them: they would win
+over the adjacent power of 2 by a mere 1.6% while forcing use of the radix-63 family
+(radix63/1008/4032), which has known Fermat-mod correctness defects. Those lengths remain
+available via the -fft command-line flag.
 */
 uint32 get_default_fft_length(uint64 p)
 {
 	uint32 nradices;
-	uint32 leadingRadixVec[N_LEADING_RADICES] = {8,9,10,11,12,13,14,15};
-	uint32 i, twoK, fftLen;
+	const uint32 mersLeadingRadixVec[N_LEADING_RADICES] = {8,9,10,11,12,13,14,15};
+	const uint32 fermLeadingRadixVec[3]                 = {8,14,15};
+	const uint32 *leadingRadixVec;
+	uint32 i, nLeadingRadices, twoK, fftLen;
 
 	ASSERT(PMAX > PMIN,"get_default_fft_length: PMAX > PMIN");
 	if(p < PMIN || p > PMAX)
@@ -2632,7 +2650,13 @@ uint32 get_default_fft_length(uint64 p)
 		return 0;
 	}
 
-	/* Starting with N = 1K, Loop over all FFT lengths of form {8,9,10,11,12,13,14,15}*2^m,
+	if(MODULUS_TYPE == MODULUS_TYPE_FERMAT) {
+		leadingRadixVec = fermLeadingRadixVec;	nLeadingRadices = 3;
+	} else {
+		leadingRadixVec = mersLeadingRadixVec;	nLeadingRadices = N_LEADING_RADICES;
+	}
+
+	/* Starting with N = 1K, Loop over all FFT lengths of form {leading radix}*2^m,
 	and return the smallest one for which maxP >= p: */
 	i = 0;
 	ASSERT(1024%leadingRadixVec[i] == 0,"get_default_fft_length: 1024%leadingRadixVec[0] == 0");
@@ -2656,7 +2680,7 @@ uint32 get_default_fft_length(uint64 p)
 			return (fftLen >> 10);
 
 	CYCLE:
-		i = (i+1) % N_LEADING_RADICES;
+		i = (i+1) % nLeadingRadices;
 		if(i == 0)
 			twoK *= 2;
 		fftLen = leadingRadixVec[i]*twoK;


### PR DESCRIPTION
## The bug

A Fermat-number assignment read from `worktodo.txt` can spin forever, re-running the same remedial timing self-test and never starting the test.

Reproduced on unmodified `main` (590a1a6), clean directory, `fermat.cfg` present but without the length the run asks for (which is what `config-fermat.sh` produces, since it only ever generates *legal* Fermat lengths):

| workfile entry | unmodified `main` |
|---|---|
| `PRP=n/a,1,2,65536,+1,99,0,3,5,"825753601"` (F16 cofactor) | **5427 cycles in 400 s and still spinning** when I killed it; 5427 junk duplicate 3K lines appended to `mlucas.cfg` |
| `Fermat,Test=16` | 29 cycles, then `exit 0` with "Done ..." having done no work; 29 junk 3K lines in `mlucas.cfg` |

Every cycle logs the same line:

```
INFO: FFT length 3072 = 3 K not found in the 'fermat.cfg' file.
```

The Pépin case only escapes by luck — the loop ends when roundoff noise happens to push the last self-test over the `MaxErr >= 0.4375` rejection threshold, so no cfg entry gets written and the `goto ERNST_MAIN` is skipped. With a quieter length it does not terminate. Both cases also leave `mlucas.cfg` with many duplicate entries for one length, which will later trip `get_preferred_fft_radix`'s "Multiple cfg-file entries for FFT length ..." assert on an unrelated *Mersenne* run.

## Root cause

**Part 1 — the default FFT length is illegal for Fermat-mod.**

`ernstMain()` (`src/Mlucas.c`) picks the default length via `get_default_fft_length()`. That function (`src/get_fft_radices.c`) enumerates lengths of the form `{8,9,10,11,12,13,14,15}*2^m` and has no `MODULUS_TYPE` awareness — but Fermat-mod (right-angle transform) runs only support lengths whose odd part is one of `[1,7,15,63]` (`help.txt`, section [5]). So a Fermat run gets:

| | F16 | F17 | F18 | F19 | F20 | F21 | F22 |
|---|---|---|---|---|---|---|---|
| upstream default | 3K | 6K (FMA) / 7K | 13K | 26K | 52K | 104K | 208K |
| odd part | 3 | 3 / **7** | 13 | 13 | 13 | 13 | 13 |

F17 is the one column that depends on the build: `given_N_get_maxP()` uses `AsympConst = 0.4` under `USE_FMADD` and `0.6` otherwise, and at 0.6 F17's default is already the legal 7K. So the affected indices are F16 and F18–F22 in every build, plus F17 on FMA builds (AVX2, AVX-512, and other FMA targets). (The new code comment in `get_fft_radices.c` lists F17 unconditionally; that is the FMA case.)

None of the illegal lengths is implemented by any Fermat-mod carry routine. `-f 16` with no `-fft` — i.e. the 3K default, radix set `{12,8,16}` — dies with `radix12_ditN_cy_dif1: Fermat-mod only available for radices 7,8,9,15 and their multiples!`, and `-f 18` / `-f 19` with `ERROR: radix 16 not available for Fermat-mod transform`. F13–F15 and F23–F33 happen to land on a legal length already, which is why this was never noticed.

**Part 2 — the guard in `ernstMain()`'s `SETUP_FFT` block does not cover the workfile path.**

```c
if (!fft_length || MODULUS_TYPE == MODULUS_TYPE_MERSENNE) return ERR_RUN_SELFTEST_FORLENGTH + (kblocks << 8);
```

`fft_length` is 0 for any workfile-driven run, so the protection that makes `-f 16 -fftlen 4` work does not apply.

**Part 3 — the remedial self-test wrote the wrong cfg file, and the retry could not tell it had made no progress.**

`main()`'s `ERR_RUN_SELFTEST_FORLENGTH` handler forced `modType = MODULUS_TYPE_MERSENNE` before `goto TIMING_TEST_LOOP`, so the self-test ran as a *Mersenne* test at 3K and wrote `mlucas.cfg` — while the entry the production run was missing was in `fermat.cfg`. The end of `TIMING_TEST_LOOP` then does `goto ERNST_MAIN`, re-entering the `ernstMain()` call with the state that requested the self-test unchanged. Nothing in the cycle could ever clear it.

## The fix

**Fermat-aware default length** (`get_fft_radices.c`). For `MODULUS_TYPE_FERMAT`, restrict the candidate leading radices from `{8,9,10,11,12,13,14,15}` to `{8,14,15}`.

Why that shape rather than a separate function or a rewritten search: on the existing `lead*twoK` grid the length produced by leading radix `L` has odd part `L/gcd(L,8)`, so the grid can only produce odd parts `{1,9,5,11,3,13,7,15}` — and `{8,14,15}` are *exactly* the three entries whose lengths have odd part 1, 7 and 15. The generated sequence therefore stays strictly ascending (`15*twoK < 8*2*twoK`), the "smallest length with `maxP >= p`" contract is unchanged, and every other line of the routine is untouched. The Mersenne path is a pure `nLeadingRadices = N_LEADING_RADICES` passthrough.

`main()` also sets the `MODULUS_TYPE` global from its local `modType` once the type is known, because `main()` itself calls `get_default_fft_length()` (for `-f <index>` without `-fft`) and that call now needs to know which schedule to use.

New Fermat defaults, all legal, and matching what `config-fermat.sh` generates:

| | F16 | F17 | F18 | F19 | F20 | F21 | F22 | F23–F33 |
|---|---|---|---|---|---|---|---|---|
| new default | 4K | 7K | 14K | 28K | 56K | 112K | 224K | unchanged |
| odd part | 1 | 7 | 7 | 7 | 7 | 7 | 7 | — |

**On `k = 63`:** the `63*2^k` lengths (1008K, 2016K, 4032K, ...) are *not* of the form `{8..15}*2^m` at all, so they never were candidates in this routine. I deliberately did not add them: they beat the adjacent power of two by only 1.6% while forcing the radix-63 family (radix63/1008/4032), which has known Fermat-mod correctness defects. They remain reachable via `-fft`.

**On issue #153 (Fermat-mod leading radix 15 computes wrong residues):** it does not constrain this choice, but not for the reason an earlier revision of this description gave. That revision claimed no candidate length offers a lead-15 or lead-30 radix set; **that is wrong for scalar builds.** Enumerating the radix tables directly, the `{8,14,15}` grid yields 53 candidate lengths, and five of them do offer such sets — but only in the `#else` arm of the `#ifdef USE_SSE2`, i.e. in non-SIMD builds:

| length | leading radix per radix set (scalar build) |
|---|---|
| 15 K | 60, **30**, **15**, **15** |
| 30 K | 60, 60, **30**, **30**, **15**, **15** |
| 60 K | 60, 60, **30**, **15** |
| 120 K | 60, 60, **30**, **15** |
| 240 K | 240, 240, 60, **30**, **15**, **15** |

(Under `USE_SSE2` the lead-15/30 sets are compiled out and only the lead-60/240 ones remain, so the "60, 240 or 960 only" statement does hold for every SIMD build. #153's own repro, `./Mlucas -f 18 -fftlen 15 -radset 2`, is exactly a 15K lead-15 set on a scalar build.)

The conclusion survives for a different reason: **none of those five lengths is ever selected as a Fermat default, because a Fermat-mod exponent is always `p = 2^findex`.** Simulating the patched routine over F13–F33 gives defaults of 1, 1, 2, 4, 7, 14, 28, 56, 112, 224, 448, 896, 1792, 3584, 7168 (7680 on non-FMA builds), 15360, 30720, 61440, 122880, 262144 and 524288 K — and no radix set at any of those lengths has leading radix 15 or 30, in either build arm. 15K/30K/60K/120K/240K are reachable candidates only for non-power-of-two `p`, which Fermat-mod never has. So the default never steers a Fermat user onto the #153 path.

**Remedial self-test honours the actual modulus type** (`Mlucas.c`). The handler now runs with the modulus type the failed production run actually used, taking the reference exponent from `FermVec[]` for Fermat-mod (falling back to the workfile's Fermat index, which `ESTRING` holds, when the length has no `FermVec` entry — e.g. 14K), and restores `modType` before retrying the production run.

**Two guards so an unbounded silent loop is unreachable even if a length case is missed:**
1. A cfg entry once written is permanent, so a *repeat* request for a length already self-tested in this session means no progress — that now fails with an actionable diagnostic naming the length and the cfg file. A legitimate second request always names a different, larger length (roundoff-triggered FFT upsizing via `goto SETUP_FFT`). A counter cap backs this up against any unforeseen multi-length cycle.
2. Reaching the end of `TIMING_TEST_LOOP` with `quick_self_test` still set means the self-test found no usable radix set, so no cfg entry was written and the assignment cannot run. That was previously a fall-through to "Done ..." and a 0 exit status; it is now a hard error.

## Verification

Linux x86_64, gcc 16.1.1, full clean `bash makemake.sh avx2`, no new warnings.

**Mersenne invariance — proved, not sampled.** I compiled the upstream version of the routine into the same binary as `get_default_fft_length_ref()` and A/B-diffed against the patched one. Both are monotone step functions of `p` returning the smallest candidate length with `maxP >= p`, so walking the intervals on which each is constant enumerates the entire domain rather than sampling it:

```
# PMIN=2048 PMAX=9383873021
cell [2048,22788] -> 1 K
cell [22789,44888] -> 2 K
cell [44889,66742] -> 3 K
...
cell [8391341651,8937021925] -> 524288 K
cell [8937021926,9383873021] -> 0 K (above maxP of largest supported length)
# MODULUS_TYPE=1: 137 cells, 200528 probes, 0 differences; cells cover
#   9383870974 of 9383870974 exponents in [PMIN,PMAX] (COMPLETE, no gaps)
```

Both endpoints of every cell are probed for both functions, plus 100k probes across the tail region where both return 0. Repeated with `MODULUS_TYPE` unset (0) and with `MODULUS_TYPE_MERSENNE`: identical, **0 differences**. So the Mersenne return value is unchanged for every input in the supported range.

**Mersenne self-test.** `obj_avx2/Mlucas -s tt` → 13K=`E3BC90B0E652C7C0`, 14K=`DB8E39C67F8CCA0A`, 15K=`B3C5A1C03E26BB17`, matching the pre-change values; the full `Res64` stream is byte-identical between a pre-change and post-change run. (`-s s` was still running when I filed this — clean through 480K, 0 skipped lengths.)

**Livelock gone.**

| scenario | before | after |
|---|---|---|
| F16 cofactor `PRP=`, `fermat.cfg` lacking the length | 5427+ cycles, still spinning; 5427 junk lines in `mlucas.cfg` | **1** remedial self-test, written to `fermat.cfg`; **no** `mlucas.cfg` created; run proceeds |
| `Fermat,Test=16`, ditto | 29 cycles → silent `exit 0` | 1 remedial self-test → full Pépin test completes |
| `Fermat,Test=18`, `fermat.cfg` lacking 14K | same livelock | 1 remedial **Fermat** self-test at the new 14K default |

That F18 case is the most informative: 14K has no `FermVec` entry, so it exercises the new-length consensus path. Both radix sets at 14K agreed, and the `fermat.cfg` line the self-test wrote records

```
14  msec/iter = 1.16  ROE[avg,max] = [0.007128906, 0.008789062]  radices = 28 16 16 ...
    p = 18: 100-iter Res mod 2^64, 2^35-1, 2^36-1 = 7C6B681485EB86DB, 5745147782, 50521157289
```

which is exactly the `FermVec` F18 reference triplet `{0x7C6B681485EB86DB, 5745147782, 50521157289}`.

**End-to-end Pépin run, cross-checked against an independent oracle.** `Fermat,Test=16` from `worktodo.txt` now completes a full Pépin test at the new 4K default:

```
F16 is not prime. Program: E21.0.2. Final residue shift count = 0.
Selfridge-Hurwitz residues Res64,Res35m1,Res36m1 = 40ABB0C5BFF05CB5,  173595305,65390296136.
```

A standalone GMP oracle (65535 mod-squarings of 3 mod 2^65536+1) gives the same three values, `40ABB0C5BFF05CB5 / 173595305 / 65390296136`, as do forced runs at 7K, 8K and 16K.

**All seven newly-selected lengths reproduce the `FermVec` 100-iteration reference residues** (`-f N -fft L -iters 100`): F16@4K `AAE76C15C2B37465`, F17@7K `FFA16CDC8C87483C`, F18@14K `7C6B681485EB86DB`, F19@28K `529E54642A813995`, F20@56K `64629CED6E218018`, F21@112K `1DE0171591038250`, F22@224K `9201143390F3828D`. Roundoff error is also far better than at the old illegal lengths (e.g. F16: AvgMaxErr 0.000065 at 4K vs 0.25 at 3K).

**Both guards exercised** on builds with the length fix temporarily disabled:
- guard 1: the original 5427-cycle livelock becomes 2 cycles then `ERROR: A timing self-test at FFT length 3 K has already been run in this session, yet the production run still finds no entry for that length in fermat.cfg. Refusing to loop.`
- guard 2: a Mersenne run needing 1K, where every radix set is rejected for excessive roundoff, previously printed a warning and exited 0 having silently skipped the assignment; it now errors out with `ERROR: The timing self-test at FFT length 1 K yielded no usable radix set, so no mlucas.cfg entry could be written ...`

**Side benefit:** this also repairs the documented `-f <index> -iters <n>` self-test, which reaches `get_default_fft_length()` directly from `main()`'s argument handling. On unmodified `main`, `-f 16/17/18/19 -iters 100` (no `-fft`) all abort; after the fix they select 4K/7K/14K/28K and print the correct reference residues.

## Not verified / honest caveats

- **Only AVX2 Linux.** I did not run AVX-512, ARM, Windows or macOS. The change is arithmetic-free and build-mode-independent, but I am not claiming runtime results I did not produce.
- **Fermat PRP-CF is still not functional end-to-end, for an unrelated reason.** With the livelock gone the F16-cofactor run gets through the Pépin phase and reaches `Suyama_CF_PRP()`, where it trips `Assertion 'ilo == p-1' failed: Fermat-mod cofactor-PRP test requires p-1 mod-squarings!` — Fermat-mod PRP sets `maxiter = p` rather than `p-1`. That reproduces on unmodified `main` via `-fft 8`, which bypasses the livelock entirely, so it is a separate pre-existing defect and I left it alone.
- The F18 Pépin run above completes but uses a random nonzero residue shift (leading radix 28, so the `radix < 16` shift restriction does not apply). I did **not** cross-check that particular final residue against an oracle, so I am only claiming the 100-iteration triplet for F18, which I did verify.

No existing GitHub issue covers this livelock, so there is no `Resolves #N`.
