### PR TITLE
Fix P-1 stage 2 silently skipping primes on restart and just above B1

### DIFF
--- a/src/pm1.c
+++ b/src/pm1.c
@@ -1079,8 +1079,10 @@ based on iteration count versus PM1_S1_PROD_BITS as computed from the B1 bound, 
 	each corresponding semiprime q*psmall is hit in the remapped stage 2 interval:
 	*/
 	pm1_check_bounds();	// This sanity-checks the bounds and sets B2_start = B1 if unset.
-	if(B2_start == B1 && B2 >= B1*psmall) {	// It's possible user running a S2 with B2/psmall < B1, hence the 2nd clause
-		reloc_start = psmall*B1;				// Start including relocation-semiprimes once S2 passes this point, and
+	// Note the (uint64) casts: B1 and psmall are both 32-bit, so their product must be widened before
+	// multiplying, else it wraps for B1 > 2^32/psmall, silently corrupting reloc_start and B2_start:
+	if(B2_start == B1 && B2 >= (uint64)B1*psmall) {	// It's possible user running a S2 with B2/psmall < B1, hence the 2nd clause
+		reloc_start = (uint64)psmall*B1;		// Relocation-semiprimes start appearing at this point, and
 		B2_start = MIN(reloc_start, B2/psmall);	// shift B2_start upward to reflect the fact that primes in [B1,B2/psmall]
 												// will be relocated to [B1*psmall,B2].
 	} else {	// In the case of a standalone S2 interval (B2_small > B1), set psmall = 0 and reloc_start = UINT64_MAX:
@@ -1088,7 +1090,20 @@ based on iteration count versus PM1_S1_PROD_BITS as computed from the B1 bound, 
 	}
 	sprintf(cbuf,"Using B2_start = %" PRIu64 ", B2 = %" PRIu64 ", Bigstep = %u, M = %u\n",B2_start,B2,bigstep,m);
 	mlucas_fprint(cbuf,pm1_standlone+1);
-	uint32 reloc_on = FALSE;	// Gets switched to TRUE (= start using semiprimes which are multiples of psmall) when q > reloc_start
+	/* Whether to include relocation-semiprimes (multiples of psmall whose cofactor is prime) when tagging
+	the primes of each new D-interval entering the pairing bitmap. This must be enabled for the very first
+	interval tagged, rather than switched on partway through the q-loop: intervals are tagged (m2+1) passes
+	before they get processed, the interval tagged on pass q being the one centered on q + (m2+1)*D, so a
+	gate based on the loop variable q engages relocation (m2+1) intervals (plus a further D/2 due to the
+	interval's own width) too late, silently skipping the first ((m2+1)*D + D/2)/psmall primes above B1.
+	Tagging relocation-semiprimes psmall*p with p < B1 is harmless - such p are already in the stage 1
+	prime-product, and psmall*p is composite so nothing is lost by testing p in its place - so simply
+	enable relocation for the whole sweep whenever we are doing relocation at all: */
+	uint32 reloc_on = (psmall != 0);
+	if(reloc_on) {
+		sprintf(cbuf,"Small-prime relocation enabled: semiprimes %u*p start appearing at q = %" PRIu64 "\n",psmall,reloc_start);
+		mlucas_fprint(cbuf,pm1_standlone+1);
+	}
 
 	// Oct 2021: For small q0 and large #bufs, qlo can underflow, so check!
 	q0 = B2_start + bigstep - B2_start%bigstep;
@@ -1110,6 +1125,7 @@ based on iteration count versus PM1_S1_PROD_BITS as computed from the B1 bound, 
 	// May 2021: Added support for M even:
 	m_is_odd = IS_ODD(m);
 	m_is_even = !m_is_odd;
+	m2 = m/2;	// If m odd, m2 = (m-1)/2 = # of D-interval on either side of the central 0-interval
 	ASSERT(RES_SHIFT == 0ull, "Shifted residues unsupported for p-1!\n");	// Need BASE_MULTIPLIER_BITS array = 0 for modmuls below!
 	// Alloc the needed memory:
   #ifndef PM1_STANDALONE
@@ -1765,6 +1781,26 @@ MME = 0;
 			mlucas_fprint(cbuf,pm1_standlone+1);
 		}
 	}
+	/* The prime-pairing bitmap map[] is stateful across passes of the q-loop below: a D-interval's primes
+	are tagged in the bitmap when the interval enters at the top of the extended-match window, but any of
+	them left unpaired are only processed (and the interval retired) once it has shifted m2 slots down the
+	map, m2 passes later. map[] is *not* part of the .s2 savefile, so on a restart the m2 D-intervals just
+	below the resume point would never be re-tagged, and their as-yet-unprocessed unpaired primes would be
+	skipped by the pre-interrupt and the post-restart run alike - a silent hole ~m2*D/ln(B2) primes wide,
+	fresh with each restart, and stage 2 gets restarted from its savefile not only by the user but also by
+	the roundoff-error FFT-length bump and the carry-error retry. Rather than grow the savefile format,
+	simply redo those m2 intervals, backing the resume point up by m2*D but no further than the original
+	stage 2 starting point. Redoing already-accumulated prime pairs is harmless: it only multiplies the
+	stage 2 accumulator by terms it already contains, which cannot remove a prime factor from the product,
+	hence cannot lose a factor. Cost is m2 extra D-blocks per restart. */
+	if(qlo > B2_start) {	// True only on a savefile-restart; a fresh stage 2 has qlo == B2_start
+		if(qlo > B2_start + (uint64)m2*bigstep)
+			qlo -= (uint64)m2*bigstep;
+		else
+			qlo = B2_start;
+		sprintf(cbuf,"Stage 2 restart: backing resume point up to q = %" PRIu64 " to re-cover the %u D-intervals whose pairing-bitmap state the savefile does not preserve.\n",qlo,m2);
+		mlucas_fprint(cbuf,pm1_standlone+1);
+	}
 	/* [b] Stage 2 starts at q0, the smallest multiple of D nearest but not exceeding qlo + D/2;
 	once have that, compute k0 = q0/D: */
 	q0 = qlo + bigstep - qlo%bigstep;
@@ -1800,7 +1836,6 @@ MME = 0;
 	of each word correspond to singleton (in the sense that the corr. q2 is composite) q1 = (q - b[i])'s relative
 	to the center of each of the M D-intervals, the hi bits to the q2 = (q + b[i])'s.
 	*/
-	m2 = m/2;	// If m odd, m2 = (m-1)/2 = # of D-interval on either side of the central 0-interval
 	/*
 	We save ourselves some awkward preprocessing by starting the stage 2 loop such that at end of the first loop pass,
 	the D-interval centered on q0 (M odd) or just left of q0 (M even) enters the as the new upper-interval.
@@ -2051,11 +2086,6 @@ MME = 0;
 	qhi = (B2 + m*bigstep);
 	for(q = qlo; q < qhi; q += bigstep)
 	{
-		if(!reloc_on && q >= reloc_start) {	// Start including relocation-semiprimes once S@ passes this point
-			reloc_on = TRUE;
-			sprintf(cbuf,"Hit q = %" PRIu64 " >= reloc_start[%" PRIu64 "] ... enabling small-prime relocation.\n",q,reloc_start);
-			mlucas_fprint(cbuf,pm1_standlone+1);
-		}
 		// Only start actual 0-interval and extended-window pairing when q hits q0:
 		if(q >= q0) {
 		  if(m_is_odd) {	// prime-pairing between lo|hi halves of 0-interval only done if M odd


### PR DESCRIPTION
Three defects in the P-1 stage 2 prime-pairing sweep caused primes in `[B1,B2]` to be silently
omitted — the run completes, prints `Stage 2: No factor found.`, emits a `"factors":[]` JSON line
still advertising the full `"B1"`/`"B2"` interval, and retires the assignment. No warning, no count
of skipped primes. A factor whose single large prime lands in one of the holes is missed.

`src/pm1.c` builds standalone via `-DPM1_STANDALONE` (which currently requires #197's `cbuf` fix — on `main` the standalone build stops at `pm1.c:46` with a conflicting `cbuf` declaration) as a pure prime-pairing simulator (all
FFT/modmul work `#ifndef`-ed out, but the entire bitmap / pairing / relocation / interval-shift
machinery runs unmodified), so prime coverage is directly measurable. All coverage numbers below
come from that build, instrumented with a recorder at the three accumulator-modmul sites; the
end-to-end numbers come from the real AVX2 build.

---

## Defect 1 — stage-2 restart drops the trailing `m2` D-intervals' unpaired primes

**Severity: high** — silent loss of primes on *every* stage 2 restart, and it compounds: a job
stopped/started daily loses a fresh window each time.

### Mechanism

The extended-window pairing bitmap `map[]` is **stateful across passes of the q-loop**. A D-interval
is only fully drained `m2 = M/2` passes after it is tagged:

- The interval's primes are tagged when it enters at the top of the match window
  (`pm1.c:2244` onward, for the interval centred on `q + (m2+1)*D`).
- On the pass where it becomes the 0-interval, only *both-endpoints-prime* pairs are processed;
  singletons are deliberately left in the bitmap (`pm1.c:2086`, `if(j < m) continue;`) in the hope
  of matching them against a distant interval later.
- Only once the interval has shifted down to `map[0]`, `m2` passes later, are its remaining set bits
  processed unconditionally (`pm1.c:2184-2221`) and the interval retired.

So when the loop is left after pass `q_last`, the `m2` intervals with midpoints in
`[q_last-(m2-1)*D, q_last]` still hold unprocessed singleton primes.

The checkpoint (`pm1.c:2439-2468`) saves the accumulator residue and the scalar `q + bigstep`;
**`map[]` is not in the savefile**. On restart, `pm1.c:1811` sets `qlo = q0 - (m2+1)*D`, so the first
interval tagged is the one centred on `q0 == q_save` — no interval to the left of the resume point is
ever re-tagged, and `map[]` starts all-zero. Those primes are processed by neither the pre-interrupt
nor the post-restart run. The hole is a contiguous window of about `m2*D/ln(B2)` primes ending just
below the resume point.

`M == 1` is immune (`if(j < m)` degenerates to `if(j < 1)`, so singletons are processed immediately);
every larger buffer count is affected.

This is not only a user Ctrl-C / kill / power loss — the driver re-enters stage 2 from the `.s2`
savefile in normal operation: a stage-2 roundoff error bumps the FFT length and `goto SETUP_FFT`
(`Mlucas.c:2686`), and a stage-2 carry error does `goto READ_RESTART_FILE` (`Mlucas.c:2694`).

### Fix chosen, and why

Two candidates were considered:

1. **Persist `map[]` in the `.s2` savefile.** Correct, but it changes the savefile format — existing
   `.s2` files would need a compatibility path, and #170 is concurrently hardening savefile
   read/write. Too much risk for the benefit.
2. **Conservatively redo the trailing window** — back the resume point up by `m2*D` (clamped to the
   original stage 2 start) so those intervals are re-tagged and re-drained. No format change, ~10
   lines, and the savefile stays byte-compatible in both directions.

This PR takes (2).

**Harmlessness of re-processing primes.** Each accumulator modmul multiplies `pow` by
`A^((kD)^2) - A^(b^2)`; since `(kD)^2 - b^2 = (kD-b)(kD+b)`, the exponent of the accumulated product
gains the factors `q1 = kD-b` and `q2 = kD+b`. Redoing a pass therefore only multiplies `pow` by a
term it already contains. The final answer is `gcd(pow, N)`, whose value is determined by which
primes of `N` divide `pow` — and raising the multiplicity of a term cannot *remove* a prime from
`pow`, so the set of detectable factors can only stay the same or grow, never shrink. (The one
theoretical difference is that if `p_i^2 | N` the gcd could report `p_i^2` instead of `p_i` — still a
valid factor, and no Mersenne/Fermat number is known to have a square factor.) Cost is `m2` extra
D-blocks per restart. Verified empirically below, including the case where the redone window
re-multiplies the known factor's own prime pair into the accumulator a second time.

---

## Defect 2 — small-prime relocation switched on `(m2+1)` intervals plus `D/2` too late

**Severity: medium** — silent, always-on hole just above `B1` in **every default-bounds run**,
uninterrupted ones included.

`pm1.c:2054` gated `reloc_on` on the loop variable `q`:

```c
if(!reloc_on && q >= reloc_start) { reloc_on = TRUE; ... }
```

but the interval actually being tagged on pass `q` is the one centred on `tmp = q + (m2+1)*bigstep`
(`pm1.c:2244`), and the relocation bitmap `rmap` is built for `tmp` (`pm1.c:2275-2302`). So
relocation tagging only became active for intervals with `tmp >= reloc_start + (m2+1)*D`, and every
interval below that was tagged with relocation off. The relocation-semiprimes `psmall*p` it contains
are never tagged, so the corresponding primes `p` just above `B1` are covered by neither stage.
A second, smaller off-by-one of the same kind: an interval spans `tmp ± D/2`, so even comparing `tmp`
would leave a `D/2`-wide residue.

Trigger: any contiguous run with `B2 >= psmall*B1`, which is the normal case — `pm1_set_bounds`
picks `B2 ≈ 30..55 × B1`, comfortably above `psmall*B1` for `psmall ∈ {7,11}`.

**Fix:** enable relocation for the whole sweep whenever relocation is being done at all
(`reloc_on = (psmall != 0)`). Tagging `psmall*p` with `p < B1` is harmless: such `p` are already in
the stage 1 prime-product, and `psmall*p` is composite either way (`psmall | psmall*p` and
`psmall*p > psmall`), so testing `p` in its place loses nothing. Extra set bits can only add
accumulator terms, and every set bit is eventually processed (paired, or drained at `map[0]`), so no
pairing partner is "stolen". The in-loop gate and its info-print are replaced by a one-time
setup-time print.

Both `reloc_on = (psmall != 0)` and the narrower `tmp + D/2 >= reloc_start` gate were measured; the
former gives zero missed primes in all 13 configs and is simpler, so that is what landed.

---

## Defect 3 — `B1*psmall` evaluated in 32-bit (latent)

`pm1.c:1082-1083` computes `B1*psmall` with both operands `uint32`, so the product wraps for
`B1 > 2^32/11 ≈ 390e6`, making `reloc_start` small and `B2_start = MIN(reloc_start, B2/psmall)`
nonsense. `pm1_set_bounds` only asserts `B1 <= 2863311530` (`pm1.c:205`) and `-b1` can be set
directly, so nothing excludes the range. Far outside any realistic GIMPS assignment (defaults are
`B1 ≈ p/128`), so **latent, not reachable in practice** — but a one-cast fix, so it is included.

The sibling `psmall * B1` in the restart-parameter ASSERT at `Mlucas.c:2661` has the same defect.
**This PR does not touch `Mlucas.c`** — that cast is carried by #165, which restructures the
enclosing block.

---

## Verification

### Coverage harness

Instrumented the `-DPM1_STANDALONE` build with a recorder at the three sites where the real code
issues an accumulator modmul (`pm1.c:2099`, `:2155`, `:2195` on the pre-fix tree), plus `-qstop q`
(break out of the loop at pass `q`, i.e. emulate an interrupt immediately after the checkpoint that
recorded `q`) and `-qlo q` (pre-set `qlo` exactly as `read_ppm1_savefiles()` would, i.e. emulate the
restart). One modmul covers both `q1 = q-b` and `q2 = q+b`, so both are logged; a logged value `v`
is credited as covering prime `v`, else prime `v/psmall` if `psmall | v` and `v/psmall` is prime
(exactly the relocation semantics). Required set = all primes in `(B1,B2]` from an independent
sieve. The instrumentation is not part of this PR — it is generated by a script against both the
pre- and post-fix `pm1.c`, so both columns come from the same recorder.

Sanity check on the harness: for `psmall == 0` configs (relocation inactive) the baseline covers
every prime with zero misses, for `M` odd and even and all five `D`, i.e. the core pairing algorithm
is sound and the two defects are localized.

### 1. Completeness — uninterrupted sweep, primes in `(B1,B2]` not covered

| D | M | B1 | B2 | psmall | m2 | primes required | **missed before** | **missed after** | dup before | dup after |
|---|---|---|---|---|---|---|---|---|---|---|
| 210 | 9 | 100000 | 500000 | 0 | 4 | 31946 | 0 | 0 | 0 | 0 |
| 210 | 8 | 100000 | 500000 | 0 | 4 | 31946 | 0 | 0 | 0 | 0 |
| 210 | 9 | 100000 | 30000000 | 11 | 4 | 1848267 | **7** | 0 | 112784 | 112784 |
| 330 | 15 | 1000000 | 30000000 | 7 | 7 | 1779361 | **31** | 0 | 54 | 54 |
| 330 | 6 | 100000 | 10000000 | 7 | 3 | 654987 | **12** | 0 | 52591 | 52591 |
| 420 | 5 | 100000 | 20000000 | 11 | 2 | 1261015 | **9** | 0 | 50643 | 50643 |
| 420 | 10 | 100000 | 5000000 | 11 | 5 | 338921 | **16** | 0 | 64 | 64 |
| 660 | 4 | 200000 | 20000000 | 7 | 2 | 1252623 | **19** | 0 | 100223 | 100223 |
| 660 | 9 | 200000 | 10000000 | 7 | 4 | 646595 | **41** | 0 | 2057 | 2057 |
| 840 | 8 | 200000 | 20000000 | 11 | 4 | 1252623 | **31** | 0 | 64 | 64 |
| 840 | 25 | 200000 | 20000000 | 11 | 12 | 1252623 | **78** | 0 | 110 | 110 |
| 210 | 1 | 100000 | 1200000 | 11 | 0 | 83346 | 0 | 0 | 23 | 23 |
| 840 | 13 | 50000 | 2000000 | 11 | 6 | 143800 | **46** | 0 | 138 | 138 |
| 840 | 104 | 10000 | 2000000 | 11 | 52 | 147704 | **421** | 0 | 6674 | 6675 |

**10 of the 13 primary configs missed primes before (290 total), 0 after.** The missed set always
starts at the very first prime above `B1` and its width matches the predicted
`((m2+1)*D + D/2)/psmall`, e.g. `D=210, M=9`: relocation actually engaged at interval midpoint
1101240, so the hole is `p <= 1101240/11 = 100112` ⇒ last missed prime 100103 — exact match with the
measured `100003 100019 100043 100049 100057 100069 100103`.

Note the `dup` column (primes covered more than once — harmless, just extra modmuls) is essentially
**unchanged** by the fix: these are the pre-existing relocation double-covers of
`p ∈ [B2_start, B2/psmall]`, not something the fix introduces. The last row is the exact config used
for the end-to-end test below.

### 2. Restart invariance

For each config, five resume points spread over the sweep. Run A = interrupted at `q`
(`-qstop q`), run B = resumed from `q` (`-qlo q`). **LOST** = primes in `(B1,B2]` covered by
*neither* half, i.e. dropped by the restart relative to an uninterrupted run. This is a mechanical
test over all configs × resume points, not a one-off.

| config | LOST before (5 resume points) | LOST after |
|---|---|---|
| D=210 M=9 B1=100000 B2=500000 psm=0 m2=4 | 28, 27, 25, 18, 23 | 0, 0, 0, 0, 0 |
| D=210 M=8 B1=100000 B2=500000 psm=0 m2=4 | 20, 17, 19, 10, 17 | 0, 0, 0, 0, 0 |
| D=210 M=9 B1=100000 B2=30000000 psm=11 m2=4 | 26, 33, 27, 35, 30 | 0, 0, 0, 0, 0 |
| D=330 M=15 B1=1000000 B2=30000000 psm=7 m2=7 | 70, 84, 81, 97, 84 | 0, 0, 0, 0, 0 |
| D=330 M=6 B1=100000 B2=10000000 psm=7 m2=3 | 35, 35, 36, 37, 34 | 0, 0, 0, 0, 0 |
| D=420 M=5 B1=100000 B2=20000000 psm=11 m2=2 | 42, 40, 36, 36, 43 | 0, 0, 0, 0, 0 |
| D=420 M=10 B1=100000 B2=5000000 psm=11 m2=5 | 61, 54, 75, 56, 60 | 0, 0, 0, 0, 0 |
| D=660 M=4 B1=200000 B2=20000000 psm=7 m2=2 | 47, 35, 38, 45, 39 | 0, 0, 0, 0, 0 |
| D=660 M=9 B1=200000 B2=10000000 psm=7 m2=4 | 125, 129, 121, 130, 130 | 0, 0, 0, 0, 0 |
| D=840 M=8 B1=200000 B2=20000000 psm=11 m2=4 | 91, 92, 102, 97, 106 | 0, 0, 0, 0, 0 |
| D=840 M=25 B1=200000 B2=20000000 psm=11 m2=12 | 295, 282, 281, 295, 276 | 0, 0, 0, 0, 0 |
| D=210 M=1 B1=100000 B2=1200000 psm=11 m2=0 | 0, 0, 0, 0, 0 | 0, 0, 0, 0, 0 |
| D=840 M=13 B1=50000 B2=2000000 psm=11 m2=6 | 173, 187, 170, 178, 171 | 0, 0, 0, 0, 0 |

**60 of 65 restart cases lost primes before (5086 total), 0 after.** `M == 1` loses nothing, as
predicted. As a spot check of mechanism, `D=210 B1=100000 B2=500000 M=9` resuming at
`q_save = 299880` loses exactly the 25-prime window `[298999, 299743]`, which is the `m2 = 4`
intervals immediately left of the resume point — prediction and measurement agree.

### 3. End-to-end, on a real factor

`M(250013)` has the prime factor `30586418411057 = 2*k*p + 1` with `k = 2^3 * 241 * 31727`; its only
prime `> B1 = 10000` is 31727, so it is a stage-2 find. Worktodo
`Pminus1=1,2,250013,-1,10000,2000000` (FFT 15K, `D = 840, M = 104, psmall = 11, B2_start = 110000`),
`obj_avx2` build with GMP:

| run | result |
|---|---|
| uninterrupted | `Found 14-digit factor in Stage 2: 30586418411057`, `"status":"F"` |
| resumed from a genuine mid-stage-2 checkpoint at `q = 504000` | backs up to `q = 472080`, `Found 14-digit factor in Stage 2: 30586418411057` |
| same checkpoint, baseline binary | also finds it (i.e. no regression either way) |
| resumed from `q = 368760`, redone window `[325080, 368760]` | `Found 14-digit factor in Stage 2: 30586418411057` |

The checkpoints are real ones captured by snapshotting `p250013.s2` during a live run, then restored
along with the primary savefile and `.stat` log.

The last row is the direct test of the harmlessness argument: the factor's relevant relocated
semiprime `11*31727 = 348997` sits in the D-interval centred on 348600, so the redone window
`[325080, 368760]` re-executes the pass that contributed its prime pair — that term is multiplied
into the accumulator a **second** time. The factor is still found. (In the `q = 504000` row the
redone window `[472080, 504000]` lies entirely above that interval, so there the factor comes purely
from the savefile accumulator while 38 D-blocks of already-accumulated pairs are re-applied on top of
it — also still found.)

### 4. No-factor controls

`M(250051)` and `M(250109)`, same bounds — both still report `"status":"NF"`:

| | #pairs | #single | %paired | #blocks | #modmul |
|---|---|---|---|---|---|
| before | 79736 | 794 | 99.50 | 2354 | 85238 |
| after | 79966 | 774 | 99.52 | 2354 | 85448 |

Identical for both exponents (the pairing schedule depends only on `D,M,B1,B2`). The block count is
unchanged — the sweep range is identical — and modmuls rise by 210 (+0.25%), which is the cost of
covering the 421 primes above `B1` that were previously skipped for this config (bottom row of
Table 1). The stage-2 residue necessarily changes, since it now includes those primes; that is the
point of the fix, not a regression.

### 5. Build / self-test

Full clean `bash makemake.sh avx2`, no errors. `obj_avx2/Mlucas -s tt` residues unchanged:
`13K = E3BC90B0E652C7C0`, `14K = DB8E39C67F8CCA0A`, `15K = B3C5A1C03E26BB17`.

**Not tested:** AVX-512, Windows, ARM, macOS, and Fermat-mod P-1. The changed code is
architecture- and modulus-independent integer bookkeeping in `pm1.c`, and the `-DPM1_STANDALONE`
coverage results are by construction independent of the FFT backend, but I have not run those
configurations.

---

## Relationship to #165 and #170

**Logically independent of #165.** #165 fixes the `Mlucas.c` shortcut that jumps to
`PM1_STAGE2_GCD` with the *stage-1* residue in `arrtmp[]` (and the truncated-`.s2` variant of it) —
a wrong-input-to-GCD bug. This PR fixes which primes the stage-2 sweep *processes*. Neither depends
on the other and merge order does not matter for correctness.

**No conflict.** This PR changes only `src/pm1.c`; #165 changes `src/Mlucas.c` and `src/pm1.c`
in disjoint regions. An earlier revision of this description said this PR added a `(uint64)` cast
to the `B2_start == psmall * B1` ASSERT in `Mlucas.c` and described the resulting conflict — it
does not, and there is none. #165 now carries that cast in its own restructured block:

```c
ASSERT(psmall == psmall_log && (B2_start == (uint64)psmall * B1 || B2_start == B2 / psmall), ...);
```

**No conflict with #170**, whose `pm1.c` changes are the two `fclose` → `close_savefile` call sites,
nowhere near these hunks. This PR deliberately does not change the savefile format, so it does not
interact with #170's read/write hardening.

## Still outstanding (not fixed here)

Persisting `map[]` in the savefile would let a restart resume *exactly* where it left off rather than
redoing `m2` D-blocks. That is a savefile-format change and is deliberately left out; the cost of the
approach taken here is `m2` extra D-blocks per restart (about 1.5% of a 2354-block sweep at
`M = 104`), which is cheap insurance against silently skipping primes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

