### PR TITLE
Fix two Fermat-mod diagnostic defects, and the same radix-report bug in pairFFT_mul

### DIFF
--- a/src/fermat_mod_square.c
+++ b/src/fermat_mod_square.c
@@ -613,7 +613,7 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 		{
 			/* If power-of-2 runlength, no IBDWT gets done, make bases the same: */
 			base   [0] = (double)(1 << bits_small);	base   [1] = base[0]	;
-			baseinv[0] = 1.0/base[0];				baseinv[1] = baseinv[1]	;	/* don't need extended precision for this since both bases are powers of 2.	*/
+			baseinv[0] = 1.0/base[0];				baseinv[1] = baseinv[0]	;	/* don't need extended precision for this since both bases are powers of 2.	*/
 		}
 		else
 		{

--- a/src/fermat_mod_square.c
+++ b/src/fermat_mod_square.c
@@ -535,7 +535,7 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 //			nradices_radix0 = 12;
 			radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		default:
-			sprintf(cbuf  ,"ERROR: radix %d not available for Fermat-mod transform. Halting...\n",RADIX_VEC[i]);
+			sprintf(cbuf  ,"ERROR: radix %d not available for Fermat-mod transform. Halting...\n",radix0);
 			fprintf(stderr,"%s", cbuf);
 			ASSERT(0,cbuf);
 		}

--- a/src/fermat_mod_square.c
+++ b/src/fermat_mod_square.c
@@ -1704,7 +1704,7 @@ undo_initial_ffft_pass:
 
 			atmp  = a[j2]*radix_inv;
 			a[j2] = DNINT(atmp);
-			k += (fabs(2*a[j1]) > base[ii]);
+			k += (fabs(2*a[j2]) > base[ii]);
 			frac_fp = fabs(a[j2]-atmp);
 			if(frac_fp > max_fp)
 				max_fp = frac_fp;

--- a/src/fermat_mod_square.c
+++ b/src/fermat_mod_square.c
@@ -638,7 +638,7 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 		{
 			/* If power-of-2 runlength, no IBDWT gets done, make bases the same: */
 			base   [0] = (double)(1 << bits_small);	base   [1] = base[0]	;
-			baseinv[0] = 1.0/base[0];				baseinv[1] = baseinv[1]	;	/* don't need extended precision for this since both bases are powers of 2.	*/
+			baseinv[0] = 1.0/base[0];				baseinv[1] = baseinv[0]	;	/* don't need extended precision for this since both bases are powers of 2.	*/
 		}
 		else
 		{

--- a/src/fermat_mod_square.c
+++ b/src/fermat_mod_square.c
@@ -1708,7 +1708,7 @@ undo_initial_ffft_pass:
 
 			atmp  = a[j2]*radix_inv;
 			a[j2] = DNINT(atmp);
-			k += (fabs(2*a[j1]) > base[ii]);
+			k += (fabs(2*a[j2]) > base[ii]);
 			frac_fp = fabs(a[j2]-atmp);
 			if(frac_fp > max_fp)
 				max_fp = frac_fp;

--- a/src/pairFFT_mul.c
+++ b/src/pairFFT_mul.c
@@ -235,7 +235,7 @@ void pairFFT_mul(double x[], double y[], double z[], int n, int INIT_ARRAYS, int
 			nradices_radix0 = 5;
 			radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		default :
-			sprintf(char_str, "radix[0] = %d not available.\n",RADIX_VEC[i]);
+			sprintf(char_str, "radix[0] = %d not available.\n",radix_vec0);
 			ASSERT(0, char_str);
 		}
 


### PR DESCRIPTION
Independent one-line defects on the Fermat-mod diagnostic paths. One commit each. No change to any healthy code path — all of them touch only reporting/redundant code.

**Rebased 2026-09-09.** Defect 3 below (the `default:`-arm radix message in `fermat_mod_square.c`) landed separately in the meantime via #146, commit `7189795` — main already prints `radix0` there. That commit has been dropped from this branch, which resolves the merge conflict. The remaining three commits are unchanged, and the `pairFFT_mul.c` instance of the same defect is still live on main. Section 3 is kept below for the record.

## 1. Out-of-range-digit check never looked at the imaginary part

The final acyclic-untwisting/unweighting loop in `fermat_mod_square()` rounds the real digit `a[j1]` and the imaginary digit `a[j2]` of each complex element and bumps the out-of-range counter `k` after each. The second bump tested `a[j1]` again:

```c
	atmp  = a[j2]*radix_inv;
	a[j2] = DNINT(atmp);
-	k += (fabs(2*a[j1]) > base[ii]);
+	k += (fabs(2*a[j2]) > base[ii]);
```

So `Warning: %u of %u out-of-range output digits detected.` double-counted every out-of-range **real** digit and never examined a single **imaginary** digit — half the output words were unchecked by that diagnostic.

**Demonstrated.** Injected one deliberately out-of-range digit at `j == 0` immediately before the two rounding blocks (throwaway `#ifdef` hook, not part of this PR), Pépin test on F16 at 4K, radix set 0, AVX2 build:

| injected digit | before | after |
| --- | --- | --- |
| imaginary | *(no warning at all)* | `Warning: 1 of 4096 out-of-range output digits detected.` |
| real | `Warning: 2 of 4096 out-of-range output digits detected.` | `Warning: 1 of 4096 out-of-range output digits detected.` |

`k` is a diagnostic counter only; it does not feed the transform, so residues are unchanged.

## 2. `baseinv[1] = baseinv[1]` self-assignment — redundant, not a live miscomputation

The power-of-2 branch of `fermat_mod_square()`'s base setup sets `base[1] = base[0]` ("*If power-of-2 runlength, no IBDWT gets done, make bases the same*") but its companion line self-assigned:

```c
	base   [0] = (double)(1 << bits_small);	base   [1] = base[0]	;
-	baseinv[0] = 1.0/base[0];				baseinv[1] = baseinv[1]	;
+	baseinv[0] = 1.0/base[0];				baseinv[1] = baseinv[0]	;
```

Since `base[0] == base[1]` here, `baseinv[0]` is plainly the intended value, and the array does **not** already hold it: `base[]`/`baseinv[]` are function-scope statics, so `baseinv[1]` is 0.0 on the first power-of-2 Fermat run and stale (`1/(2*base[0])` from an earlier length) afterwards.

**But it is dead redundancy, not a bug.** Verified by poisoning the slot — substituting `baseinv[1] = -1.0e300;` in that branch — and re-running:

* AVX2: Pépin F16@4K, F17@8K, F18@16K (power-of-2) and F17@7K, F18@15K (non-power-of-2) — all Res64 bit-identical to the unpoisoned build.
* AVX-512 under Intel SDE (`sde64 -skx`): F16@4K (radices 16,8,16), F17@8K (32,8,16 and 16,16,16), F20@64K (64,32,16) — all Res64 bit-identical.

That matches the code: `fermat_carry_norm_pow2_errcheck()` in `carry.h` uses only `base[0]`/`baseinv[0]`, and the SIMD Fermat carry macros read base and 1/base out of `half_arr[0..1]`, initialized from `base[0]`/`baseinv[0]`. The one other reader — the AVX-512 hijacked rounding slot `sse2_rnd->d1 = baseinv[1]` — is consumed only by the Mersenne AVX-512 carry macros (the Fermat macros are handed `half_arr` instead), and its thread-local memcheck ASSERT compares the slot against the same variable it was stored from.

Fixed anyway: it is a latent trap for any future reader of `baseinv[1]` on the power-of-2 path, and it defeats self-assignment diagnostics for the surrounding block.

## 3. Error message named the final radix, not the offending leading radix — *landed separately via #146, dropped from this branch*

The `default:` arm of the `radix_prim`-building `switch(radix0)` printed `RADIX_VEC[i]`. At that point `i` is left over from the preceding `for(i = 1; i < NRADICES-1; i++)` loop, so it equals `NRADICES-1` (or 1 for a two-pass transform) — never 0.

```c
	default:
-		sprintf(cbuf  ,"ERROR: radix %d not available for Fermat-mod transform. Halting...\n",RADIX_VEC[i]);
+		sprintf(cbuf  ,"ERROR: radix %d not available for Fermat-mod transform. Halting...\n",radix0);
```

**Demonstrated.** Pépin test on F19 at 44K, radix set 0 (`Using complex FFT radices  44  32  16`):

```
before:  ERROR: radix 16 not available for Fermat-mod transform. Halting...
after:   ERROR: radix 44 not available for Fermat-mod transform. Halting...
```

44 is the unsupported leading radix. 16 is supported, and is the final radix of most *working* radix sets — so the old message pointed the reader at the wrong radix entirely.

## Recurrence check

* The Mersenne analogue of (1) — the corresponding final unweighting loop in `mers_mod_square()` — uses a real-only representation with a single index `j`, and is correct as written.
* The Mersenne analogue of (3) — the `default:` arm of the `radix_prim`-building `switch(radix0)` in `mers_mod_square()` — already prints `radix0`.

Scanned the rest of `fermat_mod_square.c` and the whole of `src/` for all three shapes:

**Pattern 1 (`j1` where `j2` was meant).** No other instances. Every `j1`/`j2` complex-pair block in `fermat_mod_square()` — the forward-weighting block and the inverse-weighting/unweighting block — is symmetric; `mers_mod_square.c`, `pairFFT_mul.c` and `pm1.c` have no `a[j1]`/`a[j2]` pair loops at all, and the `Mlucas.c` `shift_word()` pairs are correct for both the Re and Im branches. An "odd one out" detector (flag a `[j1]`-only line whose neighbours are `[j2]`-only, and the mirror) reproduces this bug against the pre-fix blob and finds nothing else in the current tree; re-run for the `jt`/`jp`, `j`/`j+1` and `.re`/`.im` pairings, it is also clean.

**Pattern 2 (self-assignment).** No other instances. Textual scan of all 101 `src/*.c` plus all `src/*.h` (comment-stripped, statement-split, LHS == RHS) is clean, and the same scanner correctly flags the pre-fix `baseinv[1] = baseinv[1]` line. Note that `clang -Wself-assign` does *not* catch array-subscript self-assignment — `int a[4]; a[0]=a[0];` warns about nothing, and clang was silent on the pre-fix file in all five SIMD build modes — so the compiler would not have found this one.

**Pattern 3 (wrong radix in a `default:` arm).** One recurrence, same defect class, in a different file — `pairFFT_mul()`'s own `radix_prim`-building switch, on `radix_vec0` (`= RADIX_VEC[0]`, set earlier in the same init block):

```c
	switch(radix_vec0){
	...
	default :
		sprintf(char_str, "radix[0] = %d not available.\n",RADIX_VEC[i]);
```

Wrong on two counts: the message text itself says `radix[0]`, and `i` is left over from the `for(i = 1; i < NRADICES-1; i++)` loop immediately above the switch, so it is `NRADICES-1` (or 1), never 0. Folded in below rather than sent separately.

Every other radix `default:` arm checks out — I paired each `switch(...)` subject with its printed expression across all of `src/*.c`. That is 25 further sites: 6 in `fermat_mod_square.c`, 8 in `mers_mod_square.c`, 9 in `pairFFT_mul.c`, and one each in `Mlucas.c` and `test_fft_radix.c`. Subjects match in every one, and every `RADIX_VEC[i]` site sits inside a live `i`-loop.

## Regression testing (AVX2, gcc 16.1.1, `-D_GNU_SOURCE`)

Self-test residues unchanged:

| test | Res64 |
| --- | --- |
| 13K | `E3BC90B0E652C7C0` |
| 14K | `DB8E39C67F8CCA0A` |
| 15K | `B3C5A1C03E26BB17` |

Fermat runs unchanged (100 iters, all radix sets, before == after):

| test | Res64 |
| --- | --- |
| Pépin F16 @ 4K | `AAE76C15C2B37465` |
| Pépin F17 @ 7K, 8K | `FFA16CDC8C87483C` |
| Pépin F18 @ 15K, 16K | `7C6B681485EB86DB` |
| Pépin F20 @ 64K (AVX-512/SDE) | `64629CED6E218018` |


---

### Added: the same defect in `pairFFT_mul.c`

Folding in the recurrence noted above rather than sending it separately, since it is the same bug in the other file that carries the pattern. In `pairFFT_mul()`, the `switch(radix_vec0)` default arm:

```c
sprintf(char_str, "radix[0] = %d not available.\n",RADIX_VEC[i]);
```

`i` is left over from the preceding `for(i = 1; i < NRADICES-1; i++)` loop, so it holds `NRADICES-1` and can never be 0 — the message says `radix[0]` while printing a different radix from the set. Now prints `radix_vec0`, the value actually being switched on, matching how `mers_mod_square.c` and (as of this PR) `fermat_mod_square.c` report the same condition.

Diagnostic-path only, no computed result changes; `pairFFT_mul.c` compiles clean under nosimd and `-DUSE_THREADS` with `-Wall -Wextra`.

