### PR TITLE
curr_fac[] is half the size legal input needs, and the bounds check runs after the write (2 sites)

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -3360,15 +3360,23 @@ uint32 Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[
 	BASE_MULTIPLIER_BITS[0] = 1ull;	lenf = 1;
 	// Multiply each known-factor with current partial product of factors.
 	// Use BASE_MULTIPLIER_BITS to store factor product here, but need curr_fac[] for intermediate partial products:
-	uint64 curr_fac[20];
-	for(i = 0; KNOWN_FACTORS[i] != 0ull; i += 4) {
+	// curr_fac[] must hold the full product of the known factors: KNOWN_FACTORS[] is dimensioned for at most
+	// 10 factors of at most 4 limbs each, so that product needs up to 40 limbs, not 20. (curr_fac[] is also
+	// reused further down to hold the (A - B)/C quotient, which is < F and thus also fits in 40 limbs.)
+	const uint32 nlimb_kf = sizeof(KNOWN_FACTORS)/sizeof(KNOWN_FACTORS[0]);	// = 40
+	uint64 curr_fac[sizeof(KNOWN_FACTORS)/sizeof(KNOWN_FACTORS[0])];
+	// The i < nlimb_kf clause is needed because KNOWN_FACTORS[] has exactly nlimb_kf elts and thus no
+	// 0-sentinel past the last one: with all 10 factor-slots filled, the old loop read KNOWN_FACTORS[40]:
+	for(i = 0; i < nlimb_kf && KNOWN_FACTORS[i] != 0ull; i += 4) {
 		k = mi64_getlen(KNOWN_FACTORS+i,4);	// k = number of nonzero limbs in curr_fac (alloc 4 limbs per in KNOWN_FACTORS[])
+		// mi64_mul_vector writes (lenf + k) limbs of curr_fac[], so bounds-check the write *before* it happens:
+		ASSERT(lenf+k <= nlimb_kf, "Product of known-factors too large to fit into curr_fac[]!");
 		// Multiply factor into current partial product of factors; use curr_fac[] array to store product to work around none-of-3-input-pointers-may-coincide restriction in mi64_mul_vector:
 		mi64_mul_vector(BASE_MULTIPLIER_BITS,lenf, KNOWN_FACTORS+i,k, curr_fac,&lenf);
 		mi64_set_eq(BASE_MULTIPLIER_BITS,curr_fac,lenf);
 	}
 	ASSERT((i>>2) == nfac, "Number of known-factors mismatch!");
-	ASSERT(lenf <= 20, "Product of known-factors too large to fit into curr_fac[]!");
+	ASSERT(lenf <= nlimb_kf, "Product of known-factors too large to fit into curr_fac[]!");
 	for(i = 0; i < lenf; i++) { curr_fac[i] = 0ull; }	// Re-zero the elts of curr_fac[] used as tmps in above loop
 	fbits = (lenf<<6) - mi64_leadz(BASE_MULTIPLIER_BITS, lenf);
 	// Now that have F stored in BASE_MULTIPLIER_BITS array, do powmod to get B = base^(F-1) (mod N):
@@ -3427,6 +3435,9 @@ uint32 Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[
 // R = (A - B) mod C in B-array (bi[]); store Q = (A - B)/C in curr_fac[] in case want to remultiply and verify Q*C + R = (A - B):
 	sprintf(cbuf,"(A - B) Res64 = %#016" PRIX64 ", C Res64 = %#016" PRIX64 "\n",ai[0],ci[0]);
 	mlucas_fprint(cbuf,1);
+	// mi64_div_binary writes at most (i - j + 1) limbs of quotient into curr_fac[]; bound that write before it happens.
+	// [(A - B) < N and C = N/F, so the quotient is < F and hence fits in nlimb_kf limbs, but check rather than assume:]
+	ASSERT(i < j || (i-j+1) <= nlimb_kf, "Quotient (A - B)/C too large to fit into curr_fac[]!");
 	mi64_div_binary(ai,ci, i,j, curr_fac,(uint32 *)&k, bi);	// On return, k has quotient length; curr_fac[] = quo, bi[] = rem
 	snprintf(cbuf,sizeof(cbuf),"(A - B)/C: Quotient = %s, Remainder Res64 = %#016" PRIX64 "\n",&g_cstr[convert_mi64_base10_char(g_cstr,curr_fac,k,0)],bi[0]);
 	mlucas_fprint(cbuf,1);
@@ -3440,7 +3451,7 @@ uint32 Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[
 	snprintf(cbuf,sizeof(cbuf),"Suyama Cofactor-PRP test of %s",PSTRING);
 	// Base-2 log of cofactor = lg(Fm/F) = lg(Fm) - lg(F) ~= 2^m - lg(F). 2^m stored in p, sub lg(F) in loop below:
 	double lg_cof = p,lg_fac,log10_2 = 0.30102999566398119521;	// Use lg_fac to store log2 of each factor as we recompute it
-	for(i = 0; KNOWN_FACTORS[i] != 0ull; i += 4) {
+	for(i = 0; i < nlimb_kf && KNOWN_FACTORS[i] != 0ull; i += 4) {	// i-bound: cf. the factor-product loop above
 		k = mi64_getlen(KNOWN_FACTORS+i,4);	// k = number of nonzero limbs in curr_fac (alloc 4 limbs per in KNOWN_FACTORS[])
 		strcat( cbuf, " / " );
 		strcat( cbuf, &g_cstr[convert_mi64_base10_char(g_cstr, KNOWN_FACTORS+i, k, 0)] );

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -3446,15 +3446,23 @@ uint32 Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[
 	BASE_MULTIPLIER_BITS[0] = 1ull;	lenf = 1;
 	// Multiply each known-factor with current partial product of factors.
 	// Use BASE_MULTIPLIER_BITS to store factor product here, but need curr_fac[] for intermediate partial products:
-	uint64 curr_fac[20];
-	for(i = 0; KNOWN_FACTORS[i] != 0ull; i += 4) {
+	// curr_fac[] must hold the full product of the known factors: KNOWN_FACTORS[] is dimensioned for at most
+	// 10 factors of at most 4 limbs each, so that product needs up to 40 limbs, not 20. (curr_fac[] is also
+	// reused further down to hold the (A - B)/C quotient, which is < F and thus also fits in 40 limbs.)
+	const uint32 nlimb_kf = sizeof(KNOWN_FACTORS)/sizeof(KNOWN_FACTORS[0]);	// = 40
+	uint64 curr_fac[sizeof(KNOWN_FACTORS)/sizeof(KNOWN_FACTORS[0])];
+	// The i < nlimb_kf clause is needed because KNOWN_FACTORS[] has exactly nlimb_kf elts and thus no
+	// 0-sentinel past the last one: with all 10 factor-slots filled, the old loop read KNOWN_FACTORS[40]:
+	for(i = 0; i < nlimb_kf && KNOWN_FACTORS[i] != 0ull; i += 4) {
 		k = mi64_getlen(KNOWN_FACTORS+i,4);	// k = number of nonzero limbs in curr_fac (alloc 4 limbs per in KNOWN_FACTORS[])
+		// mi64_mul_vector writes (lenf + k) limbs of curr_fac[], so bounds-check the write *before* it happens:
+		ASSERT(lenf+k <= nlimb_kf, "Product of known-factors too large to fit into curr_fac[]!");
 		// Multiply factor into current partial product of factors; use curr_fac[] array to store product to work around none-of-3-input-pointers-may-coincide restriction in mi64_mul_vector:
 		mi64_mul_vector(BASE_MULTIPLIER_BITS,lenf, KNOWN_FACTORS+i,k, curr_fac,&lenf);
 		mi64_set_eq(BASE_MULTIPLIER_BITS,curr_fac,lenf);
 	}
 	ASSERT((i>>2) == nfac, "Number of known-factors mismatch!");
-	ASSERT(lenf <= 20, "Product of known-factors too large to fit into curr_fac[]!");
+	ASSERT(lenf <= nlimb_kf, "Product of known-factors too large to fit into curr_fac[]!");
 	for(i = 0; i < lenf; i++) { curr_fac[i] = 0ull; }	// Re-zero the elts of curr_fac[] used as tmps in above loop
 	fbits = (lenf<<6) - mi64_leadz(BASE_MULTIPLIER_BITS, lenf);
 	// Now that have F stored in BASE_MULTIPLIER_BITS array, do powmod to get B = base^(F-1) (mod N):
@@ -3513,6 +3521,9 @@ uint32 Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[
 // R = (A - B) mod C in B-array (bi[]); store Q = (A - B)/C in curr_fac[] in case want to remultiply and verify Q*C + R = (A - B):
 	sprintf(cbuf,"(A - B) Res64 = %#016" PRIX64 ", C Res64 = %#016" PRIX64 "\n",ai[0],ci[0]);
 	mlucas_fprint(cbuf,1);
+	// mi64_div_binary writes at most (i - j + 1) limbs of quotient into curr_fac[]; bound that write before it happens.
+	// [(A - B) < N and C = N/F, so the quotient is < F and hence fits in nlimb_kf limbs, but check rather than assume:]
+	ASSERT(i < j || (i-j+1) <= nlimb_kf, "Quotient (A - B)/C too large to fit into curr_fac[]!");
 	mi64_div_binary(ai,ci, i,j, curr_fac,(uint32 *)&k, bi);	// On return, k has quotient length; curr_fac[] = quo, bi[] = rem
 	snprintf(cbuf,sizeof(cbuf),"(A - B)/C: Quotient = %s, Remainder Res64 = %#016" PRIX64 "\n",&g_cstr[convert_mi64_base10_char(g_cstr,curr_fac,k,0)],bi[0]);
 	mlucas_fprint(cbuf,1);
@@ -3526,7 +3537,7 @@ uint32 Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[
 	snprintf(cbuf,sizeof(cbuf),"Suyama Cofactor-PRP test of %s",PSTRING);
 	// Base-2 log of cofactor = lg(Fm/F) = lg(Fm) - lg(F) ~= 2^m - lg(F). 2^m stored in p, sub lg(F) in loop below:
 	double lg_cof = p,lg_fac,log10_2 = 0.30102999566398119521;	// Use lg_fac to store log2 of each factor as we recompute it
-	for(i = 0; KNOWN_FACTORS[i] != 0ull; i += 4) {
+	for(i = 0; i < nlimb_kf && KNOWN_FACTORS[i] != 0ull; i += 4) {	// i-bound: cf. the factor-product loop above
 		k = mi64_getlen(KNOWN_FACTORS+i,4);	// k = number of nonzero limbs in curr_fac (alloc 4 limbs per in KNOWN_FACTORS[])
 		strcat( cbuf, " / " );
 		strcat( cbuf, &g_cstr[convert_mi64_base10_char(g_cstr, KNOWN_FACTORS+i, k, 0)] );

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -6602,14 +6602,21 @@ uint32 extract_known_factors(uint64 p, char *fac_start) {
 	// Multiply each known-factor with current partial product of factors.
 	// Use BASE_MULTIPLIER_BITS to store factor product here, but need curr_fac[] for intermediate partial products:
 	BASE_MULTIPLIER_BITS[0] = 1ull;	lenf = 1;
-	uint64 curr_fac[20];
-	for(i = 0; KNOWN_FACTORS[i] != 0ull; i += 4) {
+	// Same three defects as the factor-product loop in Suyama_CF_PRP(), in the same shape - see the comments
+	// there. KNOWN_FACTORS[] holds up to 10 factors of up to 4 limbs each, so their product needs up to 40
+	// limbs, not 20; the loop needs an explicit i-bound because KNOWN_FACTORS[] has exactly that many elts
+	// and so carries no 0-sentinel past the last one; and the size check has to precede the write it guards:
+	const uint32 nlimb_kf = sizeof(KNOWN_FACTORS)/sizeof(KNOWN_FACTORS[0]);	// = 40
+	uint64 curr_fac[sizeof(KNOWN_FACTORS)/sizeof(KNOWN_FACTORS[0])];
+	for(i = 0; i < nlimb_kf && KNOWN_FACTORS[i] != 0ull; i += 4) {
 		k = mi64_getlen(KNOWN_FACTORS+i,4);	// k = number of nonzero limbs in curr_fac (alloc 4 limbs per in KNOWN_FACTORS[])
+		// mi64_mul_vector writes (lenf + k) limbs of curr_fac[], so bounds-check the write *before* it happens:
+		ASSERT(lenf+k <= nlimb_kf, "Product of factors too large to fit into curr_fac[]!");
 		// Multiply factor into current partial product of factors; use curr_fac[] array to store product to work around none-of-3-input-pointers-may-coincide restriction in mi64_mul_vector:
 		mi64_mul_vector(BASE_MULTIPLIER_BITS,lenf, KNOWN_FACTORS+i,k, curr_fac,&lenf);
 		mi64_set_eq(BASE_MULTIPLIER_BITS,curr_fac,lenf);
 	}
-	ASSERT(lenf <= 20, "Product of factors too large to fit into curr_fac[]!");
+	ASSERT(lenf <= nlimb_kf, "Product of factors too large to fit into curr_fac[]!");
 
 	// Since F << N, use Mont-mul-div for C - quotient overwrites N, no rem-vec needed, just verify that F is in fact a divisor:
 	ASSERT(1 == mi64_div(mvec,BASE_MULTIPLIER_BITS, j,lenf, qvec,0x0), "C = N/F should have 0 remainder!");


### PR DESCRIPTION
`Suyama_CF_PRP()` accumulates the product F of the known factors in a fixed 20-limb stack array:

```c
	uint64 curr_fac[20];
	for(i = 0; KNOWN_FACTORS[i] != 0ull; i += 4) {
		k = mi64_getlen(KNOWN_FACTORS+i,4);
		mi64_mul_vector(BASE_MULTIPLIER_BITS,lenf, KNOWN_FACTORS+i,k, curr_fac,&lenf);
		mi64_set_eq(BASE_MULTIPLIER_BITS,curr_fac,lenf);
	}
	ASSERT((i>>2) == nfac, "Number of known-factors mismatch!");
	ASSERT(lenf <= 20, "Product of known-factors too large to fit into curr_fac[]!");
```

The `lenf <= 20` check runs **after** the loop that does the writing, so it is a post-mortem, not a
guard. `mi64_mul_vector(x,lenX, y,lenY, z,&lenZ)` writes `lenX + lenY` limbs of `z[]` — it zero-fills
that many on entry (`for(i = 0; i < lenX + lenY; i++) { z[i] = 0; }`, first statement of
`mi64_mul_vector()`) before doing anything else — so the loop stores up to `lenf + k` limbs into a
20-limb buffer on every iteration.

Two OOB accesses in the same three lines:

1. **Stack write** past `curr_fac[20]` once the running product reaches 17 limbs (1024+ bits) and the
   next factor is 4 limbs.
2. **Global read** of `KNOWN_FACTORS[40]`: the loop terminates on a 0 limb, but `KNOWN_FACTORS[]` is
   dimensioned `[40]` with no sentinel past the end, so an assignment that uses all 10 factor slots
   reads one element past the array.

## Real maximum lenf = 40

Set by `extract_known_factors()`'s own validation, and by the declaration it fills:

- `Mdata.h` — `extern uint64 KNOWN_FACTORS[40];  // ... for now limit to 10 factors, each < 2^256`
- `extract_known_factors()` — `ASSERT(lenf < 5, "known-factor out of range, must be < 2^256!");`
- `extract_known_factors()` — `ASSERT(nfac < 10, "Limit of 10 known factors!");` (evaluated *before*
  the `nfac++` on the next line, so 10 factors are admissible)

10 factors x 4 limbs = **40 limbs**, i.e. the buffer is exactly half the size it needs to be. The
first out-of-bounds *write* happens well before that, at ~1024 bits of accumulated factor product.

## ASan evidence (before)

`upstream/main` @ 47d75d3, x86-64, gcc 16.1.1, `CFLAGS="-Wall -g -Og -fsanitize=address
-fsanitize-recover=address"`, `makemake.sh nosimd`, run with `ASAN_OPTIONS=halt_on_error=0` so one run
shows every site instead of stopping at the first.

`worktodo.txt`: `PRP=1,2,8111,-1,75,0,3,5,"<10 factors>"` — factor 1 is `16223 = 2*8111+1`, a genuine
factor of M8111; factors 2-10 are primes = 1 (mod 2p) of 251-252 bits each, i.e. the largest shape the
parser accepts. Product = 2276 bits = **36 limbs**.

```
Suyama-PRP on cofactors of M8111: using FFT length 1K = 1024 8-byte floats.
...
==1569204==ERROR: AddressSanitizer: stack-buffer-overflow ...
WRITE of size 8 at 0x7b5ce95f0540 thread T0
    #0 mi64_mul_vector ../src/mi64.c:2940
    #1 Suyama_CF_PRP ../src/Mlucas.c:3367
    #2 ernstMain ../src/Mlucas.c:2487
    #3 main ../src/Mlucas.c:4420

Address 0x7b5ce95f0540 is located in stack of thread T0 at offset 320 in frame
    #0 Suyama_CF_PRP ../src/Mlucas.c:3317
  This frame has 6 object(s):
    ...
    [160, 320) 'curr_fac' (line 3363) <== Memory access at offset 320 overflows this variable
```

```
==1569204==ERROR: AddressSanitizer: global-buffer-overflow ...
READ of size 8 at 0x558673947c00 thread T0
    #0 Suyama_CF_PRP ../src/Mlucas.c:3364
0x558673947c00 is located 0 bytes after global variable 'KNOWN_FACTORS'
    defined in '../src/Mlucas.c:212:8' (0x558673947ac0) of size 320
0x558673947c00 is located 32 bytes before global variable 'RADIX_VEC' ...
```

(Those frames are against merge-base `47d75d3`.)

Six ASan reports in that one run: the `curr_fac` write (twice inside `mi64_mul_vector`, then in
`mi64_getlen` and `mi64_set_eq` reading it back), the `KNOWN_FACTORS[40]` read, and one pre-existing
unrelated over-read (`res_SH`, see below). Only *after* all of that does the existing check fire:

```
ERROR: Function Suyama_CF_PRP, at line 3371 of file ../src/Mlucas.c
Assertion 'lenf <= 20' failed: Product of known-factors too large to fit into curr_fac[]!
```

Note what the ASan frame layout means without a sanitizer: `curr_fac` sits at the top of the frame, so
the 16 limbs written past it land in the saved registers / return address region. In a plain -O3 build
this is a stack smash, not an assertion failure.

## The fix

- Size `curr_fac[]` from `sizeof(KNOWN_FACTORS)` (40 limbs) instead of a hardcoded 20, so it can hold
  the largest product the parser can produce.
- Move the bound *in front of* the write: `ASSERT(lenf+k <= nlimb_kf, ...)` inside the loop, before
  `mi64_mul_vector`. With the buffer correctly sized this is now unreachable for any input
  `extract_known_factors()` accepts (worst case 36+4 = 40) — which is what an assertion should be —
  but it fails loudly rather than silently corrupting the stack if either limit ever changes.
- Keep the original post-loop `lenf <= ...` assertion.
- Bound the loop index by the array size, fixing the `KNOWN_FACTORS[40]` read. Same one-line change
  applied to the second `KNOWN_FACTORS[]` walk in this function (the `lg_cof` loop), which has the
  identical unbounded termination test.
- `curr_fac[]` is reused ~70 lines down to receive the `(A - B)/C` quotient from `mi64_div_binary()`
  with no size check at all; that quotient is `< F` so 40 limbs covers it, and a pre-call
  `ASSERT(i < j || (i-j+1) <= nlimb_kf, ...)` now states the bound instead of assuming it. (I have no
  input that overflows *that* write on its own — it needs the same >1280-bit F — so that part is
  reasoned, not measured.)

## After

Same binary/flags, same input:

- Both the `curr_fac` stack-buffer-overflow and the `KNOWN_FACTORS` global-buffer-overflow are gone.
- Normal input unchanged: `PRP=1,2,8111,-1,75,0,3,5,"16223"` (a real cofactor-PRP test of M8111)
  produces byte-identical output before and after — `(A - B) Res64 = 0X5757A093B1DCAAE1`,
  `C Res64 = 0XDD9161B9D7822361`, `Quotient = 2988`, `Remainder Res64 = 0X3A76FB744EE7BAB5`,
  `COMPOSITE [C2438]`, and an identical JSON result line including `res64` and `res2048`.
  The only differing character anywhere in the output is the 9th decimal of the modpow roundoff
  monitor (`MaxErr = 0.000000001` vs `0.000000002`). That is codegen noise, not behaviour: rebuilding
  both revisions with `-fno-lto` *swaps* which side prints which, and the 1K self-test's
  `AvgMaxErr`/`MaxErr` are bit-identical across all four binaries.
- 100-iteration self-test Res64 at FFT 13K/14K/15K (AVX2 build): `E3BC90B0E652C7C0` /
  `DB8E39C67F8CCA0A` / `B3C5A1C03E26BB17`, all matching reference.

## Two other things this input turns up (not fixed here)

Neither is caused by this change; both are pre-existing on `upstream/main`.

1. **`res_SH(ci,n,...)` heap over-read** in `Suyama_CF_PRP()`'s Mersenne branch — already fixed by
   #183, which is where the sixth ASan report in the run above comes from.

2. **`mi64_div_binary()` under-allocates its own scratch** — with `curr_fac[]` fixed, the run proceeds
   to `Suyama_CF_PRP()`'s `mi64_div(bi,BASE_MULTIPLIER_BITS, j,lenf, ci,0x0)` and ASan fires *inside
   mi64.c*: `mi64_div_binary()` sizes its scratch `lens = lenX + lenY + 16` but then does
   `yloc = scratch + lenX; mi64_clear(yloc+lenY, lenX-lenY)`, which needs `2*lenX` limbs. It overflows
   whenever `lenX > lenY + 16`. Standalone repro, no Mlucas.c involved — 127-limb numerator, 36-limb
   odd divisor, the exact shapes this call site produces for a 2276-bit F:

   ```
   ERROR: AddressSanitizer: heap-buffer-overflow
   WRITE of size 8
       #0 mi64_clear ../src/mi64.c:300
       #1 mi64_div_binary ../src/mi64.c:5712
       #2 mi64_div_mont ../src/mi64.c:5437
       #3 mi64_div ../src/mi64.c:5052
       #4 main t.c:24
   0x... is located 0 bytes after 992-byte region   [992 = 8*(127+36+16) ... needs 8*(2*127)]
   allocated by thread T0 here:
       #1 mi64_div_binary ../src/mi64.c:5688
   ```

   With a local `lens = lenX + MAX(lenX,lenY) + 16` patch applied on top of this PR, the PRP-CF run is
   ASan-clean apart from the #183 over-read, and ends where it should for a synthetic factor list:
   `Assertion '1 == mi64_div(...)' failed: C = N/F should have 0 remainder!`. That mi64.c fix is not
   part of this PR.

## Reachability caveat, stated plainly

Factors 2-10 of the repro input are primes of the right form (`q = 2kp+1`, base-3 PRP) but are not
actual factors of M8111. `extract_known_factors()` accepts them today only because its
divides-the-modulus check tests `KNOWN_FACTORS[0..3]` — the *first* factor — on every iteration; that
is the bug #168 fixes. With #168 applied, this exact input is rejected at parse time and reproducing
the overflow requires a genuine 10-factor list whose product exceeds ~1024 bits. I did not assemble
one, so I have not shown that any published Mersenne/Fermat factor list reaches that today. The
40-limb bound is not affected by #168 either way: it is what the parser's own `nfac < 10` and
`lenf < 5` limits permit, and it is what `curr_fac[]` has to be sized for.

## Other fixed-size buffers in this function, audited

- `BASE_MULTIPLIER_BITS[]` holds the same product F — allocated `((ITERS_BETWEEN_CHECKPOINTS+63)>>6)+1`
  limbs in `ernstMain()`, **158** limbs at the default interval of 10000, so 40 limbs fits with room
  to spare.
- `g_cstr[STR_MAX_LEN]` (1024) receives `convert_mi64_base10_char(g_cstr, curr_fac, k, 0)` for the
  quotient — 40 limbs is at most 771 decimal digits, fits.
- `cbuf[STR_MAX_LEN*3]` (3072) accumulates `"Suyama Cofactor-PRP test of M<p>"` plus `" / <factor>"`
  for each factor — at most ~800 chars for 10 x 78-digit factors, fits.
- `ci[]`/`ai[]`/`bi[]` are the caller's arrays, sized from the FFT length; the only problem there is
  the `res_SH` limb-count bug already covered by #183.

## Remaining walks, not fixed here

The tree has five `for(i = 0; KNOWN_FACTORS[i] != 0ull; i += 4)` walks. This PR bounds the two in
`Suyama_CF_PRP()`; the other three all have the same `KNOWN_FACTORS[40]` read-past-the-end on a
10-factor assignment:

- `read_ppm1_savefiles()` (`Mlucas.c`) — live.
- `generate_JSON_report()` (`Mlucas.c`) — live.
- a dead `#if 0` block near the end of `extract_known_factors()` (`Mlucas.c`) — a verbatim second copy
  of the very bug fixed here, `uint64 curr_fac[20];` and post-mortem `ASSERT(lenf <= 20, ...)`
  included. If that block is ever re-enabled it needs the same fix.

Left alone to keep this diff to one function; worth a follow-up sweep. (An earlier revision of this
description said there were only two remaining walks.)


---

### Added: the same defect in `extract_known_factors()`

`extract_known_factors()` (`src/Mlucas.c`) carries a byte-identical copy of the factor-product loop fixed above, with the same three defects:

```c
	uint64 curr_fac[20];
	for(i = 0; KNOWN_FACTORS[i] != 0ull; i += 4) {
		k = mi64_getlen(KNOWN_FACTORS+i,4);
		mi64_mul_vector(BASE_MULTIPLIER_BITS,lenf, KNOWN_FACTORS+i,k, curr_fac,&lenf);
		mi64_set_eq(BASE_MULTIPLIER_BITS,curr_fac,lenf);
	}
	ASSERT(lenf <= 20, "Product of factors too large to fit into curr_fac[]!");
```

`KNOWN_FACTORS[40]` is documented in `Mdata.h` as "limit to 10 factors, each < 2^256", i.e. 10 x 4 limbs, so their product needs up to 40 limbs and `curr_fac[20]` is again half of what a legal input can produce. The loop again has no `i` bound, and since `KNOWN_FACTORS[]` has exactly 40 elements there is no 0-sentinel past the last one, so a worktodo line with all 10 slots filled reads `KNOWN_FACTORS[40]`. And the `ASSERT` again runs after the writes it is meant to guard.

Two differences from the Suyama copy:

* `curr_fac[]` is **not** reused further down here, so there is no quotient write to bound - only the product-loop fix applies.
* This one is on the **worktodo-parsing** path: `extract_known_factors()` is called from three sites in the worktodo reader, so it is reachable by any assignment carrying a known-factors list, not only by cofactor-PRP runs.

Fixed the same way, sharing the same `nlimb_kf` idiom.

**On demonstration:** unlike the Suyama-side defects above, I have not produced a runtime repro for this one. Every factor is validated as a genuine divisor via `twopmmodq256` before it is stored, so triggering the overflow needs a real exponent with enough large known factors for their product to exceed 1280 bits - six 256-bit factors, or ten averaging over 128 bits. I could not construct that from known factorisations in reasonable time. The bound itself is arithmetic and not in doubt, and the fix is the same one already argued above; I am flagging the absence of a live repro rather than implying one.

`src/Mlucas.c` compiles with no new warnings - the warning set is identical to unpatched `main` under `-Wall`.
