### PR TITLE
Fix a cluster of FFT length/table hygiene defects

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -4471,7 +4471,12 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 			for(j = 0; j < numTest; j++) {
 				if(i == MvecPtr[j].fftLength) break;
 			}
-			if(i != MvecPtr[j].fftLength) {
+			// The no-match test must be (j == numTest): on loop fallthrough j indexes the spare user-data slot
+			// at the top of the table, whose fftLength field was just set to i by the -fftlen handling above,
+			// so the old (i != MvecPtr[j].fftLength) test could never be true and this branch was dead code.
+			// That left the test exponent at 0 for any legal FFT length lacking a reference-residue entry, so
+			// Mlucas fell through to the "no worktodo file, no command-line exponent" path and silently exited:
+			if(j == numTest) {
 				hi = (99*given_N_get_maxP(i<<10)/100) | 0x1;	// Make sure starting value is odd. v21: Cut to 99% of pmax_rec
 				lo = hi - 1000;	if(lo < PMIN) lo = PMIN;
 				for(expo = hi; expo >=lo; expo -= 2) {

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -4594,7 +4594,12 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 			for(j = 0; j < numTest; j++) {
 				if(i == MvecPtr[j].fftLength) break;
 			}
-			if(i != MvecPtr[j].fftLength) {
+			// The no-match test must be (j == numTest): on loop fallthrough j indexes the spare user-data slot
+			// at the top of the table, whose fftLength field was just set to i by the -fftlen handling above,
+			// so the old (i != MvecPtr[j].fftLength) test could never be true and this branch was dead code.
+			// That left the test exponent at 0 for any legal FFT length lacking a reference-residue entry, so
+			// Mlucas fell through to the "no worktodo file, no command-line exponent" path and silently exited:
+			if(j == numTest) {
 				hi = (99*given_N_get_maxP(i<<10)/100) | 0x1;	// Make sure starting value is odd. v21: Cut to 99% of pmax_rec
 				lo = hi - 1000;	if(lo < PMIN) lo = PMIN;
 				for(expo = hi; expo >=lo; expo -= 2) {

--- a/src/get_fft_radices.c
+++ b/src/get_fft_radices.c
@@ -2003,10 +2003,8 @@ int	get_fft_radices(uint32 kblocks, int radix_set, uint32 *nradices, uint32 radi
 		switch(radix_set) {
 		case 0 :
 			numrad = 4; rvec[0]= 992; rvec[1] = 16; rvec[2] = 32; rvec[3] = 32; break;
-		case 1 :
-			numrad = 4; rvec[0]= 992; rvec[1] = 16; rvec[2] = 32; rvec[3] = 32; break;
 		default :
-			*nradices = 2;	return ERR_RADIXSET_UNAVAILABLE;
+			*nradices = 1;	return ERR_RADIXSET_UNAVAILABLE;
 		}; break;
 	case 32256 :
 		switch(radix_set) {
@@ -2156,19 +2154,15 @@ int	get_fft_radices(uint32 kblocks, int radix_set, uint32 *nradices, uint32 radi
 		case 3 :
 			numrad = 5; rvec[0] =128; rvec[1] = 16; rvec[2] = 16; rvec[3] = 32; rvec[4] = 32; break;
 		case 4 :
-			numrad = 5; rvec[0] =128; rvec[1] = 16; rvec[2] = 16; rvec[3] = 32; rvec[4] = 32; break;
+			numrad = 5; rvec[0] = 64; rvec[1] = 16; rvec[2] = 32; rvec[3] = 32; rvec[4] = 32; break;
 		case 5 :
-			numrad = 5; rvec[0] = 64; rvec[1] = 16; rvec[2] = 32; rvec[3] = 32; rvec[4] = 32; break;
-		case 6 :
-			numrad = 5; rvec[0] = 64; rvec[1] = 16; rvec[2] = 32; rvec[3] = 32; rvec[4] = 32; break;
-		case 7 :
 			numrad = 5; rvec[0] = 32; rvec[1] = 32; rvec[2] = 32; rvec[3] = 32; rvec[4] = 32; break;
-		case 8 :
+		case 6 :
 			numrad = 6; rvec[0] = 32; rvec[1] = 16; rvec[2] = 16; rvec[3] = 16; rvec[4] = 16; rvec[5] = 16; break;
-		case 9 :
+		case 7 :
 			numrad = 6; rvec[0] = 16; rvec[1] = 16; rvec[2] = 16; rvec[3] = 16; rvec[4] = 16; rvec[5] = 32; break;
 		default :
-			*nradices = 10;	return ERR_RADIXSET_UNAVAILABLE;
+			*nradices = 8;	return ERR_RADIXSET_UNAVAILABLE;
 		}; break;
 	case 73728 :				/* 72M = 73728K */
 		switch(radix_set) {

--- a/src/get_preferred_fft_radix.c
+++ b/src/get_preferred_fft_radix.c
@@ -64,6 +64,12 @@
 				rest for the lg2(pow2(r0)) term. Thus e.g. r0 = 4032 = 63*64 would map to a [63,6] pair,
 				needing just 6+3 = 9 bits to store, as opposed to 11 bits for (r0-1) = 4095 = 0b11111111111 .
 			***>
+			Until that reworking happens, a .cfg-file entry for a *larger-than-requested* FFT length whose
+			leading radix exceeds 1024 - which the 63*2^k lengths 4032K,8064K,...,516096K all use, r0 = 4032 -
+			simply cannot be encoded. Such entries are skipped (with an informational message) rather than
+			encoded incorrectly; worst case we forgo a faster larger-FFT-length option. Note this restriction
+			applies *only* to the encoding of larger lengths: an entry for the requested length itself is
+			written straight into the NRADICES/RADIX_VEC[] globals and so has no leading-radix limit.
 		- Bits <10:13> store (number of FFT radices);
 		- Each successive pair of higher-order bits stores log2[(intermediate FFT radix)/8]: Since
 		  our smallest permitted intermediate FFT radix is 8 and these must be powers of 2, this
@@ -89,7 +95,7 @@
 */
 uint32	get_preferred_fft_radix(uint32 kblocks)
 {
-	uint32 i, j, k, kprod, found, retval = 0;
+	uint32 i, j, k, kprod, found, unencodable, retval = 0;
 	double tbest = 0, tcurr;
 	char *char_addr;
 
@@ -132,6 +138,7 @@ uint32	get_preferred_fft_radix(uint32 kblocks)
 							}
 							char_addr += 9;	// 9 chars in "radices ="
 							kprod = 1;	/* accumulate product of radices */
+							unencodable = FALSE;	/* Set if this entry's leading radix won't fit the compact encoding */
 							for(j = 0; j < 10; j++) {	/* Read in the radices */
 								if(sscanf(char_addr, "%d", &k) != 1) {
 									snprintf(cbuf,STR_MAX_LEN*2,"get_preferred_fft_radix: invalid format for %s file: failed to read %dth element of radix set, offending input line %s", CONFIGFILE, j, g_in_line);
@@ -146,9 +153,7 @@ uint32	get_preferred_fft_radix(uint32 kblocks)
 									// leading to an eventual ASSERT in the kprod-based looping sanity checks.
 									while( isspace(*char_addr)) char_addr++;	// 1. First skip any WS preceding current numeric token
 									while(!isspace(*char_addr)) char_addr++;	// 2. Look for first WS char following current numeric token
-									if(j == 0)
-										ASSERT(k <= 1024, "get_preferred_fft_radix: Leading radix > 1024: out of range!");
-									else if(k) {
+									if(j && k) {
 										ASSERT(k <= 32  , "get_preferred_fft_radix: Intermediate radix > 32: out of range!");
 										ASSERT(isPow2(k), "get_preferred_fft_radix: Intermediate FFT radix not a power of 2!");
 									}
@@ -163,6 +168,14 @@ uint32	get_preferred_fft_radix(uint32 kblocks)
 											RADIX_VEC[j] = k;
 										}
 									} else {	/* Otherwise, store radix-set data into retval in above-described compact form */
+										/* Bits <0:9> hold (leading radix - 1), so a leading radix > 1024 - as used by the
+										63*2^k FFT lengths, all of which lead with radix 4032 - cannot be encoded. Rather
+										than abort the run (which is what the ASSERT that used to live here did, even for
+										a perfectly valid self-test-generated .cfg entry), just decline to offer this
+										longer length as an alternative to the requested one: */
+										if(j == 0 && k > 1024) {
+											unencodable = TRUE;	break;
+										}
 										if(k == 0) {	/* Bits <10:13> store (number of FFT radices): */
 											if(!((retval >> 10) & 0xf))	/* Set based only position of first zero in the list */
 												retval += (j << 10);
@@ -178,6 +191,10 @@ uint32	get_preferred_fft_radix(uint32 kblocks)
 										}
 									}
 								}
+							}
+							if(unencodable) {
+								fprintf(stderr,"INFO: %s entry for FFT length %u K has leading radix %u > 1024, which the compact 32-bit radix encoding cannot represent - ignoring this entry as a longer-but-faster alternative to the requested %u K.\n", CONFIGFILE, i, k, kblocks);
+								continue;
 							}
 							/* Product of real-FFT radices (kblocks) must be divisible by 1K = 1024
 							Since (kprod) here is product of complex radices, first multiply it by 2:

--- a/src/get_preferred_fft_radix.c
+++ b/src/get_preferred_fft_radix.c
@@ -151,8 +151,14 @@ uint32	get_preferred_fft_radix(uint32 kblocks)
 									// we have current radix k = 8, an opening while( isspace(*char_addr++)) increments char_addr to the WS
 									// *following* the 8, and the loop continues, causing us to "lose the current radix",
 									// leading to an eventual ASSERT in the kprod-based looping sanity checks.
+									// The 2nd loop must also stop at the terminating NUL: if the .cfg file's last line
+									// lacks a trailing newline, the final radix token ends at end-of-string and an
+									// unguarded !isspace() scan runs off the end of g_in_line[] (ASan: global-buffer-
+									// overflow). Stopping on '\0' leaves char_addr on the terminator, which the leading
+									// isspace()-skip above then also stops on, so a truncated final line simply parses
+									// as far as its data goes.
 									while( isspace(*char_addr)) char_addr++;	// 1. First skip any WS preceding current numeric token
-									while(!isspace(*char_addr)) char_addr++;	// 2. Look for first WS char following current numeric token
+									while(*char_addr && !isspace(*char_addr)) char_addr++;	// 2. Look for first WS char following current numeric token
 									if(j && k) {
 										ASSERT(k <= 32  , "get_preferred_fft_radix: Intermediate radix > 32: out of range!");
 										ASSERT(isPow2(k), "get_preferred_fft_radix: Intermediate FFT radix not a power of 2!");

--- a/src/get_preferred_fft_radix.c
+++ b/src/get_preferred_fft_radix.c
@@ -64,6 +64,12 @@
 				rest for the lg2(pow2(r0)) term. Thus e.g. r0 = 4032 = 63*64 would map to a [63,6] pair,
 				needing just 6+3 = 9 bits to store, as opposed to 11 bits for (r0-1) = 4095 = 0b11111111111 .
 			***>
+			Until that reworking happens, a .cfg-file entry for a *larger-than-requested* FFT length whose
+			leading radix exceeds 1024 - which the 63*2^k lengths 4032K,8064K,...,516096K all use, r0 = 4032 -
+			simply cannot be encoded. Such entries are skipped (with an informational message) rather than
+			encoded incorrectly; worst case we forgo a faster larger-FFT-length option. Note this restriction
+			applies *only* to the encoding of larger lengths: an entry for the requested length itself is
+			written straight into the NRADICES/RADIX_VEC[] globals and so has no leading-radix limit.
 		- Bits <10:13> store (number of FFT radices);
 		- Each successive pair of higher-order bits stores log2[(intermediate FFT radix)/8]: Since
 		  our smallest permitted intermediate FFT radix is 8 and these must be powers of 2, this
@@ -89,7 +95,7 @@
 */
 uint32	get_preferred_fft_radix(uint32 kblocks)
 {
-	uint32 i, j, k, kprod, found, retval = 0;
+	uint32 i, j, k, kprod, found, unencodable, retval = 0;
 	double tbest = 0, tcurr;
 	char *char_addr;
 
@@ -136,6 +142,7 @@ uint32	get_preferred_fft_radix(uint32 kblocks)
 							}
 							char_addr += 9;	// 9 chars in "radices ="
 							kprod = 1;	/* accumulate product of radices */
+							unencodable = FALSE;	/* Set if this entry's leading radix won't fit the compact encoding */
 							for(j = 0; j < 10; j++) {	/* Read in the radices */
 								if(sscanf(char_addr, "%d", &k) != 1) {
 									snprintf(cbuf, sizeof(cbuf),"get_preferred_fft_radix: invalid format for %s file: failed to read %dth element of radix set, offending input line %s", CONFIGFILE, j, g_in_line);
@@ -150,9 +157,7 @@ uint32	get_preferred_fft_radix(uint32 kblocks)
 									// leading to an eventual ASSERT in the kprod-based looping sanity checks.
 									while( isspace((unsigned char)*char_addr)) char_addr++;	// 1. First skip any WS preceding current numeric token
 									while(!isspace((unsigned char)*char_addr)) char_addr++;	// 2. Look for first WS char following current numeric token
-									if(j == 0)
-										ASSERT(k <= 1024, "get_preferred_fft_radix: Leading radix > 1024: out of range!");
-									else if(k) {
+									if(j && k) {
 										ASSERT(k <= 32  , "get_preferred_fft_radix: Intermediate radix > 32: out of range!");
 										ASSERT(isPow2(k), "get_preferred_fft_radix: Intermediate FFT radix not a power of 2!");
 									}
@@ -167,6 +172,14 @@ uint32	get_preferred_fft_radix(uint32 kblocks)
 											RADIX_VEC[j] = k;
 										}
 									} else {	/* Otherwise, store radix-set data into retval in above-described compact form */
+										/* Bits <0:9> hold (leading radix - 1), so a leading radix > 1024 - as used by the
+										63*2^k FFT lengths, all of which lead with radix 4032 - cannot be encoded. Rather
+										than abort the run (which is what the ASSERT that used to live here did, even for
+										a perfectly valid self-test-generated .cfg entry), just decline to offer this
+										longer length as an alternative to the requested one: */
+										if(j == 0 && k > 1024) {
+											unencodable = TRUE;	break;
+										}
 										if(k == 0) {	/* Bits <10:13> store (number of FFT radices): */
 											if(!((retval >> 10) & 0xf))	/* Set based only position of first zero in the list */
 												retval += (j << 10);
@@ -182,6 +195,10 @@ uint32	get_preferred_fft_radix(uint32 kblocks)
 										}
 									}
 								}
+							}
+							if(unencodable) {
+								fprintf(stderr,"INFO: %s entry for FFT length %u K has leading radix %u > 1024, which the compact 32-bit radix encoding cannot represent - ignoring this entry as a longer-but-faster alternative to the requested %u K.\n", CONFIGFILE, i, k, kblocks);
+								continue;
 							}
 							/* Product of real-FFT radices (kblocks) must be divisible by 1K = 1024
 							Since (kprod) here is product of complex radices, first multiply it by 2:

--- a/src/get_preferred_fft_radix.c
+++ b/src/get_preferred_fft_radix.c
@@ -155,8 +155,14 @@ uint32	get_preferred_fft_radix(uint32 kblocks)
 									// we have current radix k = 8, an opening while( isspace(*char_addr++)) increments char_addr to the WS
 									// *following* the 8, and the loop continues, causing us to "lose the current radix",
 									// leading to an eventual ASSERT in the kprod-based looping sanity checks.
+									// The 2nd loop must also stop at the terminating NUL: if the .cfg file's last line
+									// lacks a trailing newline, the final radix token ends at end-of-string and an
+									// unguarded !isspace() scan runs off the end of g_in_line[] (ASan: global-buffer-
+									// overflow). Stopping on '\0' leaves char_addr on the terminator, which the leading
+									// isspace()-skip above then also stops on, so a truncated final line simply parses
+									// as far as its data goes.
 									while( isspace((unsigned char)*char_addr)) char_addr++;	// 1. First skip any WS preceding current numeric token
-									while(!isspace((unsigned char)*char_addr)) char_addr++;	// 2. Look for first WS char following current numeric token
+									while(*char_addr && !isspace((unsigned char)*char_addr)) char_addr++;	// 2. Look for first WS char following current numeric token
 									if(j && k) {
 										ASSERT(k <= 32  , "get_preferred_fft_radix: Intermediate radix > 32: out of range!");
 										ASSERT(isPow2(k), "get_preferred_fft_radix: Intermediate FFT radix not a power of 2!");


### PR DESCRIPTION
Four related FFT length/table-hygiene defects, one commit each. Each was reproduced on `main` before being fixed; the evidence is below and in the individual commit messages.

Build used for all runs: `makemake.sh avx2 use_hwloc`, gcc 16.1.1, x86-64 AVX2 (no AVX-512 hardware). ASan runs use `CFLAGS="-fdiagnostics-color -Wall -g -Og -fsanitize=address,undefined" makemake.sh nosimd use_hwloc`, matching the CI ASan job (`nosimd` because `-fsanitize=address` plus the SSE2/AVX2 inline asm blows the register allocator: *"'asm' operand has impossible constraints or there are not enough registers"*).

---

## 1. `-fftlen` silently no-ops for 17 legal FFT lengths (`src/Mlucas.c`)

The "`-fftlen` given, no exponent" path searches `MersVec[]`/`MvecPRP[]` for a reference-residue entry at the requested length and, failing that, is meant to pick a prime test exponent just under `0.99*pmax_rec`. The no-match test was:

```c
for(j = 0; j < numTest; j++) { if(i == MvecPtr[j].fftLength) break; }
if(i != MvecPtr[j].fftLength) { ...find a prime... }
```

On loop fallthrough `j == numTest`, which indexes the spare user-data slot at the top of the table — and that slot's `fftLength` was set to the requested length a few dozen lines earlier by the `-fftlen` handling. So the compare always succeeded, the find-a-prime branch was **unreachable dead code**, and the test exponent stayed 0. Mlucas then fell through to the "no worktodo file, nor user-supplied command-line exponent" path and **exited with status 0 having run nothing**, never mentioning the FFT length it had been asked for.

**Which lengths.** I enumerated every legal length by calling `get_fft_radices(k, 0, ...)` for all `k` in `1..MAX_FFT_LENGTH_IN_K` in a harness linked against the real object files (153 legal lengths in this build), and diffed that against the 136 `MersVec[]` entries. Exactly 17 legal lengths have no reference-residue entry:

```
992 1008 1984 2016 3968 4032 7936 8064 15872 16128 31744 32256 63488 64512 129024 258048 516096
```

i.e. every `31*2^k` and `63*2^k` length. (The reverse check is clean: every `MersVec[]` length is legal, including 416K.) Note `get_fft_radices.c` states the invariant explicitly: *"Every legal FFT length ... must have a corresponding set of pretested self-test residues in the MersVec table in Mlucas.c!"* — these 17 violate it, which is why the fallback exists in the first place.

**Before** (`main`):

```
$ Mlucas -fftlen 992 -iters 100 -radset 0 -cpu 0:3
...
 looking for worktodo.txt file...
No worktodo.txt file not found, nor user-supplied command-line exponent.
$ echo $?
0
```

vs. the neighbouring, table-present length:

```
$ Mlucas -fftlen 1024 -iters 100 -radset 0 -cpu 0:3
 worktodo.txt file not found...using user-supplied command-line exponent p = 19800083
M19800083: using FFT length 1024K = 1048576 8-byte floats
Res64: 95AFD7A5269F14F6. AvgMaxErr = 0.202678571. MaxErr = 0.281250000.
```

**After**, the requested length is honoured and an exponent is chosen for it. Verified by execution for all 17 except the top three (`129024`, `258048`, `516096`, skipped only because of the RAM/runtime needed on this box), e.g.:

```
$ Mlucas -fftlen 4032 -iters 100 -radset 0 -cpu 0:0
 worktodo.txt file not found...using user-supplied command-line exponent p = 76056139
M76056139: using FFT length 4032K = 4128768 8-byte floats
Using complex FFT radices      4032        16        32
Res64: 09BD88299D9157AB. AvgMaxErr = 0.246651786. MaxErr = 0.281250000.
```

**Heads-up:** now that these lengths actually run, several of them promptly fail in their radix code — pre-existing bugs this change makes visible rather than causes:

| length | radix set | result on this AVX2 build |
|---|---|---|
| 4032K | `4032 16 32` | passes with `-cpu 0:0`; with 4 threads `radix4032_ditN_cy_dif1.c` warns `n_div_nwt%CY_THREADS != 0 ... likely more threads than this leading radix can handle.` and returns `ERR_ASSERT` |
| 992K, 3968K | `992 16 32` | `nonzero exit carry in radix992_ditN_cy_dif1` → `ERR_CARRY`, at any exponent (also at p/pmax = 0.92) |
| 1008K, 2016K | `1008 …`, `63 …` | roundoff warning `maxerr = 0.486…0.493` on iteration 1 → all radix sets rejected |

Those are separate issues and are out of scope here; the point of this commit is that a silent success-exit is a worse failure mode than a loud one.

## 2. Three byte-identical duplicate radix sets (`src/get_fft_radices.c`)

```
31744K: radix_set 0 == radix_set 1 : 992 16 32 32
65536K: radix_set 3 == radix_set 4 : 128 16 16 32 32
65536K: radix_set 5 == radix_set 6 :  64 16 32 32 32
```

Confirmed identical by exhaustive runtime enumeration (every legal length × every radix-set index, comparing returned radix vectors): **3 duplicate pairs across 153 legal lengths before, 0 after**. None of the three sits inside a build-mode `#if`, so they are duplicates in every build configuration.

Effect: a self-test at those lengths times the same radix set twice for nothing, and `*nradices` overstates the number of distinct options — 31744K advertises 2 radix sets but really has 1, so an ROE/timing failure there has no fallback despite appearances.

**On index stability:** nothing persists a radix-set index. `mlucas.cfg` records the radices themselves; savefiles record neither. The only positional consumer is the transient `-radset [int]` flag, which also accepts an explicit `-radset r0,r1,...` radix list. So the only visible effect is renumbering: at 65536K two sets are removed, so old 6..9 become 4..7 and the highest valid `-radset` index drops from 9 to 7 (`*nradices` 10 → 8); at 31744K the claimed 2 sets become 1, so the highest index drops from 1 to 0. Flagging that explicitly in case you'd rather keep the padding; if so I'll swap this commit for a comment documenting the duplicates instead. (An earlier revision of this description described the 65536K renumbering as "old 5..9 → 4..8", i.e. a single removal — it is two.)

## 3. `get_preferred_fft_radix()` aborts on a leading radix > 1024

The compact 32-bit encoding used to hand a *larger-than-requested* FFT length back to the caller stores `(leading radix - 1)` in bits `<0:9>`, so it cannot hold a leading radix above 1024. That was guarded by

```c
if(j == 0)
    ASSERT(k <= 1024, "get_preferred_fft_radix: Leading radix > 1024: out of range!");
```

placed *ahead* of the "is this entry for the requested length?" branch — so it fired for every `.cfg` entry, including entries for the requested length itself, which go straight into `NRADICES`/`RADIX_VEC[]` and need no encoding at all.

**The consequence is an abort, not a silent mis-encode — and it is reachable.** Leading radix 4032 is `radix_set 0` for the `63*2^k` lengths 4032K, 8064K, 16128K, 32256K, 64512K, 129024K, 258048K, 516096K. Those are reachable only via `-fftlen`, which is exactly what item 1 was silently swallowing — so fixing item 1 un-masks this one. With item 1 fixed and nothing else changed:

```
$ Mlucas -fftlen 4032 -iters 100 -cpu 0:0      # ordinary self-test, writes mlucas.cfg
$ cat mlucas.cfg
21.0.2
      4032  msec/iter =  114.30  ROE[avg,max] = [0.246651786, 0.281250000]  radices = 4032 16 32  0  0  0  0  0  0  0	p = 76056139: ...
$ echo Test=76056139 > worktodo.txt
$ Mlucas -fftlen 4032 -cpu 0:0
 worktodo.txt entry: Test=76056139
ERROR: Function get_preferred_fft_radix, at line 150 of file ../src/get_preferred_fft_radix.c
Assertion 'k <= 1024' failed: get_preferred_fft_radix: Leading radix > 1024: out of range!
Aborted (core dumped)
```

i.e. a valid self-test-generated `.cfg` entry bricks every subsequent production run at the length that produced it.

Fix: drop the leading-radix check from the common path (entries for the requested length have no such limit) and, in the encode branch, skip the offending entry rather than abort — we merely forgo offering that longer length as a faster alternative, and say so. After:

```
$ Mlucas -fftlen 4032 -cpu 0:0                 # same cfg as above
INFO: Maximum recommended exponent for FFT length (4032 Kdbl) = 76824398; p[ = 76056139]/pmax_rec = 0.9899998045
Using 1 threads in carry step                  # runs normally
```

and for the genuinely-unencodable case (`.cfg` holds a faster 4032K entry, run requested at 3840K):

```
INFO: mlucas.cfg entry for FFT length 4032 K has leading radix 4032 > 1024, which the compact
32-bit radix encoding cannot represent - ignoring this entry as a longer-but-faster alternative
to the requested 3840 K.
```

with the run continuing at 3840K. Actually *widening* the encoding needs a format change — bits `<14:31>` are fully consumed by the 9 intermediate-radix pairs — so I left that as the pre-existing to-do in the header comment (which the commit updates to describe the current behaviour). The 1024 leading-radix *limit* is thereby confined to the encode path, where it is a real constraint rather than a spurious one — and there it now skips the entry, so no `ASSERT(k <= 1024)` survives anywhere.

## 4. `isspace()` scan walks past NUL on an unterminated final `.cfg` line

The `.cfg`-line radix-token scan in `get_preferred_fft_radix()`, on `main`:

```c
while( isspace(*char_addr)) char_addr++;	// skip WS before the token
while(!isspace(*char_addr)) char_addr++;	// skip the token itself
```

`'\0'` is not a space, so the second loop reads past the terminator whenever the token being skipped ends at end-of-string — which is what `fgets()` hands back when the `.cfg` file's last line has no trailing newline. A hand-edited or truncated-in-transfer `mlucas.cfg` is enough. (The other `isspace()` scans in `Mlucas.c` are all of the non-negated `while(isspace(*p)) ++p;` form and stop at NUL correctly.)

To make the overrun cross the end of the 1024-byte `g_in_line[]` rather than merely wander into its uninitialised tail, the test `mlucas.cfg` has an unterminated final line of exactly 1023 chars (space-padded between the `ROE[...]` field and `radices =`) plus `worktodo.txt` = `Test=66431`:

```
==1607056==ERROR: AddressSanitizer: global-buffer-overflow on address 0x560bf6554fe0 at pc 0x560bf389908a
READ of size 1 at 0x560bf6554fe0 thread T0
    #0 0x560bf3899089 in get_preferred_fft_radix ../src/get_preferred_fft_radix.c:148
    #1 0x560bf38e779d in ernstMain ../src/Mlucas.c:1312
    #2 0x560bf38f61d5 in main ../src/Mlucas.c:4420
0x560bf6554fe0 is located 32 bytes before global variable 'g_cstr' defined in '../src/Mlucas.c:114:27' (0x560bf6555000) of size 1024
0x560bf6554fe0 is located 0 bytes after global variable 'g_in_line' defined in '../src/Mlucas.c:115:6' (0x560bf6554be0) of size 1024
SUMMARY: AddressSanitizer: global-buffer-overflow ../src/get_preferred_fft_radix.c:148 in get_preferred_fft_radix
```

(that trace is from a build of pristine `main`, to rule out any interaction with commit 3).

Fix is the missing NUL test. `char_addr` then stops on the terminator and the next iteration's leading `isspace()`-skip stops there too, so a truncated final line simply parses as far as its data goes. Same test case after the fix: **ASan clean**, and it produces the same result as the byte-identical but newline-terminated file — `M66431 is not prime`, `res64 DD086E2075368734`, `fft-length 4096`, from both the padded-truncated and the ordinary well-formed `.cfg`.

---

## Verification

Nothing was dropped — all four are real defects.

* Reference residues, `-fftlen {13,14,15} -iters 100 -radset 0`: `E3BC90B0E652C7C0`, `DB8E39C67F8CCA0A`, `B3C5A1C03E26BB17` — all match.
* `-s tt`: exit 0, and the per-length pass/fail summary is **byte-identical** to a build of `main` run side by side. (Both report `0 of 2 radix-sets at FFT length 1 K passed` and the same for 2K — pre-existing on this build, unrelated to these changes.)
* `-s s`: exit 0 on both this branch and `main`, per-length pass/fail summary identical. The *chosen* radix sets differ between the two runs, but that is timing noise — the two runs were raced on disjoint core sets and the winner is picked by measured `msec/iter`.
* `mlucas.cfg` handling: ASan clean on the truncated file, unchanged behaviour on well-formed input (identical residue).
* Radix-table duplicate scan: 3 → 0.

## Not verified

* The three largest affected lengths (129024K, 258048K, 516096K) were not run — 1–4 GB of FFT array and minutes per iteration on this box. Their `-fftlen` dispatch goes through the same length-independent code path as the 14 that were run.
* AVX-512 was not exercised (no AVX-512 hardware here). None of these four changes is SIMD-dependent: two are pure control flow in `.cfg` parsing, one is a scalar table edit, one is a loop-exit condition in argument handling.
* The follow-on radix failures listed under item 1 (radix992 carry, radix1008/63 roundoff, radix4032 thread-count assert) are reported as observations only; I did not diagnose or fix them here.


---

### Relationship to #179 and #175

The 17 unmasked lengths are exactly the `31*2^k` and `63*2^k` families, and the follow-on failures noted under item 1 are already addressed by two open PRs:

* **992K / 3968K** — `ERR_CARRY` in `radix992_ditN_cy_dif1`. #179 restores the missing LL carry injection in radix992 (which was computing `x^2` rather than `x^2-2` in *every* build, including scalar) and rejects the odd-radix case it cannot yet handle.
* **1008K / 2016K / 4032K** — the iteration-1 roundoff and the 4032K thread-count assert. #175 guards the radix-63 family, which is where radix1008 and radix4032 live.

So this PR does not create those failures — it makes them reachable. Landing it alongside or after #179 and #175 means a user who selects one of these lengths gets either a working run or a clean "radix unavailable" rejection. Landing it alone leaves them selectable but failing, which is still an improvement on today's behaviour — a silent no-op that exits with status 0 having computed nothing — but is worth sequencing deliberately.

