### PR TITLE
mi64_div_binary: size the scratch for the left-justified y-copy (heap buffer overflow)

### DIFF
--- a/src/mi64.c
+++ b/src/mi64.c
@@ -5685,7 +5685,12 @@ int mi64_div_binary(const uint64 x[], const uint64 y[], uint32 lenX, uint32 lenY
 	allow for left-justification of y-copy"); the sizing that replaced it did not: */
 	if(lens < (lenX + MAX(lenX,lenY))) {
 		// lens = MAX(1024,lenX + lenY);	// Alloc yloc same as x to allow for left-justification of y-copy
-		lens = lenX + MAX(lenX,lenY) + 16;        // GG: bug fix: Always add some extra buffer length. 16 is arbitrary and conservative.
+		/* Exactly the requirement, no fudge. The '+ 16' this replaces came from #14's conservative
+		padding, added while the sizing itself was wrong; with the sizing correct it buys nothing and
+		costs detection - the overflow fixed here only bit when lenX > lenY + 16, i.e. those 16 spare
+		limbs are precisely what hid it until the gap grew past them. Sizing exactly means the next
+		undersizing mistake trips ASan on the first limb rather than the seventeenth: */
+		lens = lenX + MAX(lenX,lenY);
 		/*** May 2022: In preparing for the cofactor-is-prime-power GCD on F25/[known factors], build on Linux
 		with GCC 9.2.1, hit SIGABRT 		here with 'realloc(): invalid next size'. Step-thru debug showed
 		the #limbs-allocated counter lens increasing from 0 to 4 to 9, next jump from 9 to 1048574 triggered

--- a/src/mi64.c
+++ b/src/mi64.c
@@ -5676,10 +5676,16 @@ int mi64_div_binary(const uint64 x[], const uint64 y[], uint32 lenX, uint32 lenY
 	ylen = mi64_getlen(y, lenY);
 	ASSERT(ylen != 0, "divide by 0!");
 
-	// Allocate the needed auxiliary storage - the 2 yloc = ... / mi64_set_eq calls below copy (lenX + lenY) limbs into scratch, so alloc at least that much:
-	if(lens < (lenX + lenY)) {
+	/* Allocate the needed auxiliary storage. NOTE the requirement is 2*lenX limbs, not (lenX + lenY):
+	the y-copy below is *left-justified to lenX limbs* -
+		xloc = scratch       ; mi64_set_eq(xloc, x, lenX);
+		yloc = scratch + lenX; mi64_set_eq(yloc, y, lenY); mi64_clear(yloc+lenY, lenX-lenY);
+	- so yloc spans scratch[lenX, 2*lenX), and the mi64_clear() runs off the end of the allocation
+	whenever lenX > lenY + 16. The commented-out line below had this right ("Alloc yloc same as x to
+	allow for left-justification of y-copy"); the sizing that replaced it did not: */
+	if(lens < (lenX + MAX(lenX,lenY))) {
 		// lens = MAX(1024,lenX + lenY);	// Alloc yloc same as x to allow for left-justification of y-copy
-		lens = lenX + lenY + 16;        // GG: bug fix: Always add some extra buffer length. 16 is arbitrary and conservative.
+		lens = lenX + MAX(lenX,lenY) + 16;        // GG: bug fix: Always add some extra buffer length. 16 is arbitrary and conservative.
 		/*** May 2022: In preparing for the cofactor-is-prime-power GCD on F25/[known factors], build on Linux
 		with GCC 9.2.1, hit SIGABRT 		here with 'realloc(): invalid next size'. Step-thru debug showed
 		the #limbs-allocated counter lens increasing from 0 to 4 to 9, next jump from 9 to 1048574 triggered


### PR DESCRIPTION
### The bug

`mi64_div_binary()` sets up its scratch space as

```c
xloc = scratch       ; mi64_set_eq(xloc, x, lenX);
yloc = scratch + lenX; mi64_set_eq(yloc, y, lenY); mi64_clear(yloc+lenY, lenX-lenY);
```

The y-copy is **left-justified to `lenX` limbs**, so `yloc` spans `scratch[lenX, 2*lenX)` and the routine needs **`2*lenX`** limbs. The allocation asks for `lenX + lenY + 16`, which is short whenever `lenX > lenY + 16` — and the trailing `mi64_clear()` then writes past the end of the buffer.

The commented-out sizing immediately above had it right — *"Alloc yloc same as x to allow for left-justification of y-copy"* — and the line that replaced it did not.

### Probably the cause of the corruption already recorded here

The comments in this same block document two heap-corruption incidents:

> May 2022: … hit SIGABRT here with `realloc(): invalid next size` …
> Jun 2022: Again hit error … `incorrect checksum for freed object - object was probably modified after being freed.`

Those are the classic signatures of a write just past a heap block, and they were hit on exactly this code path (the cofactor-is-prime-power GCD on F25 with known factors). Both were worked around — switching `realloc`→`malloc`, then adding a slack term — rather than by correcting the size.

### Evidence

Standalone probe: `mi64_div()` with a 127-limb numerator and a 36-limb odd divisor — the shape `Suyama_CF_PRP` feeds it for a 2276-bit factor product. Built `-Og -fsanitize=address -DUSE_THREADS` against each revision:

| revision | result |
| --- | --- |
| `upstream/main` @47d75d3 | `AddressSanitizer: heap-buffer-overflow`, `WRITE of size 8`, `0 bytes after 992-byte region`, in `mi64_clear` (`mi64.c:300`) |
| with this fix | no ASan report; returns `0`, `q[0] = 4934415073450713659` |

### Why this cannot change any result

The change only ever *enlarges* the allocation: `MAX(lenX,lenY) >= lenY`, so both the threshold test and the new size are `>=` their previous values. No arithmetic is touched.

### Not verified here

- I did not reproduce the multi-exponent production symptom end to end. It was observed independently while preparing #183: four multi-exponent PRP-CF sweeps aborted with `_int_malloc assertion failed` / `realloc(): invalid pointer` immediately after the `Checking prime-power-ness via GCD(A - B,C) ...` line, on the **pre-fix** binary. Re-running the single failing exponent alone completes cleanly, so triggering it needs several assignments in one process.
- Only the `static` scratch's *size* is corrected here. Whether that scratch should be `static` at all (it is not thread-safe, and it is what makes the corruption span calls) is a separate question I have not addressed.
