### PR TITLE
imul_macro1.h: MULH128x96 and MULH128 drop a real carry out of __b

### DIFF
--- a/src/imul_macro1.h
+++ b/src/imul_macro1.h
@@ -3679,8 +3679,13 @@ MUL64x32s, i.e. are significantly cheaper than full-blown MUL_LOHIs on
 		MUL64x32(  __x.d1,__y.d1,&__w2,&__w3);\
 		/* First add [a,b] + [c,d] : since b and d <= 2^64 - 2, can add carryout of a+c sans ripple-carry check: */\
 		__a  += __c;\
-		__b  += __d + (__a < __c);\
-		DBG_ASSERT((__b >= __d),"MULH128x96: unexpected carryout of __b");\
+		/* (__a,__b) is a 96-bit product so __b < 2^32, but (__c,__d) is a FULL 128-bit one with
+		__d up to 2^64-2, so this 128-bit sum genuinely carries out of __b - the old code dropped
+		that carry, and the DBG_ASSERT below it expands to nothing unless FAC_DEBUG. The carry has
+		weight 2^128 here, i.e. it belongs in __w3. Add __d and the carry-in separately so the
+		carry test cannot itself be fooled when __d = 2^64-1 and there is a carry in: */\
+		__b  += __d;			__w3 += (__b < __d);\
+		__cy  = (__a < __c);	__b += __cy;	__w3 += (__b < __cy);\
 		/* Now add [w1,w2,w3] + [a,b,0]: */\
 		__w1 += __a;\
 		__cy  = (__w1 < __a);\
@@ -3739,8 +3744,13 @@ MUL64x32s, i.e. are significantly cheaper than full-blown MUL_LOHIs on
 		MUL64x32(  __x.d1,__y.d1, __w2, __w3);\
 		/* First add [a,b] + [c,d] : since b and d <= 2^64 - 2, can add carryout of a+c sans ripple-carry check: */\
 		__a  += __c;\
-		__b  += __d + (__a < __c);\
-		DBG_ASSERT((__b >= __d),"MULH128x96: unexpected carryout of __b");\
+		/* (__a,__b) is a 96-bit product so __b < 2^32, but (__c,__d) is a FULL 128-bit one with
+		__d up to 2^64-2, so this 128-bit sum genuinely carries out of __b - the old code dropped
+		that carry, and the DBG_ASSERT below it expands to nothing unless FAC_DEBUG. The carry has
+		weight 2^128 here, i.e. it belongs in __w3. Add __d and the carry-in separately so the
+		carry test cannot itself be fooled when __d = 2^64-1 and there is a carry in: */\
+		__b  += __d;			__w3 += (__b < __d);\
+		__cy  = (__a < __c);	__b += __cy;	__w3 += (__b < __cy);\
 		/* Now add [w1,w2,w3] + [a,b,0]: */\
 		__w1 += __a;\
 		__cy  = (__w1 < __a);\
@@ -3794,10 +3804,14 @@ MUL64x32s, i.e. are significantly cheaper than full-blown MUL_LOHIs on
 		__a2 += __c2;\
 		__a3 += __c3;\
 		\
-		__b0 += __d0 + (__a0 < __c0);\
-		__b1 += __d1 + (__a1 < __c1);\
-		__b2 += __d2 + (__a2 < __c2);\
-		__b3 += __d3 + (__a3 < __c3);\
+		__b0 += __d0;			__hi0.d1 += (__b0 < __d0);\
+		__cy0 = (__a0 < __c0);	__b0 += __cy0;	__hi0.d1 += (__b0 < __cy0);\
+		__b1 += __d1;			__hi1.d1 += (__b1 < __d1);\
+		__cy1 = (__a1 < __c1);	__b1 += __cy1;	__hi1.d1 += (__b1 < __cy1);\
+		__b2 += __d2;			__hi2.d1 += (__b2 < __d2);\
+		__cy2 = (__a2 < __c2);	__b2 += __cy2;	__hi2.d1 += (__b2 < __cy2);\
+		__b3 += __d3;			__hi3.d1 += (__b3 < __d3);\
+		__cy3 = (__a3 < __c3);	__b3 += __cy3;	__hi3.d1 += (__b3 < __cy3);\
 		\
 		/* Now add [w1,w2,w3] + [a,b,0]: */\
 		__t0 += __a0;\
@@ -3906,14 +3920,22 @@ MUL64x32s, i.e. are significantly cheaper than full-blown MUL_LOHIs on
 		__a6 += __c6;\
 		__a7 += __c7;\
 		\
-		__b0 += __d0 + (__a0 < __c0);\
-		__b1 += __d1 + (__a1 < __c1);\
-		__b2 += __d2 + (__a2 < __c2);\
-		__b3 += __d3 + (__a3 < __c3);\
-		__b4 += __d4 + (__a4 < __c4);\
-		__b5 += __d5 + (__a5 < __c5);\
-		__b6 += __d6 + (__a6 < __c6);\
-		__b7 += __d7 + (__a7 < __c7);\
+		__b0 += __d0;			__hi0.d1 += (__b0 < __d0);\
+		__cy0 = (__a0 < __c0);	__b0 += __cy0;	__hi0.d1 += (__b0 < __cy0);\
+		__b1 += __d1;			__hi1.d1 += (__b1 < __d1);\
+		__cy1 = (__a1 < __c1);	__b1 += __cy1;	__hi1.d1 += (__b1 < __cy1);\
+		__b2 += __d2;			__hi2.d1 += (__b2 < __d2);\
+		__cy2 = (__a2 < __c2);	__b2 += __cy2;	__hi2.d1 += (__b2 < __cy2);\
+		__b3 += __d3;			__hi3.d1 += (__b3 < __d3);\
+		__cy3 = (__a3 < __c3);	__b3 += __cy3;	__hi3.d1 += (__b3 < __cy3);\
+		__b4 += __d4;			__hi4.d1 += (__b4 < __d4);\
+		__cy4 = (__a4 < __c4);	__b4 += __cy4;	__hi4.d1 += (__b4 < __cy4);\
+		__b5 += __d5;			__hi5.d1 += (__b5 < __d5);\
+		__cy5 = (__a5 < __c5);	__b5 += __cy5;	__hi5.d1 += (__b5 < __cy5);\
+		__b6 += __d6;			__hi6.d1 += (__b6 < __d6);\
+		__cy6 = (__a6 < __c6);	__b6 += __cy6;	__hi6.d1 += (__b6 < __cy6);\
+		__b7 += __d7;			__hi7.d1 += (__b7 < __d7);\
+		__cy7 = (__a7 < __c7);	__b7 += __cy7;	__hi7.d1 += (__b7 < __cy7);\
 		\
 		/* Now add [w1,w2,w3] + [a,b,0]: */\
 		__t0 += __a0;\
@@ -4358,8 +4380,13 @@ On Alpha, this needs a total of 7 MUL instructions and 12 ALU ops.
 	MUL_LOHI64(__x.d1,__y.d1,&__w2,&__w3);\
 	/* First add [a,b] + [c,d] : since b and d <= 2^64 - 2, can add carryout of a+c sans ripple-carry check: */\
 	__a  += __c;\
-	__b  += __d + (__a < __c);\
-	DBG_ASSERT((__b >= __d),"MULH128: unexpected carryout of __b");\
+	/* Same dropped carry as in MULH128x96, and here it is far likelier: BOTH (__a,__b) and
+	(__c,__d) are full 128-bit products, so their sum overflows 128 bits for roughly half of all
+	operand pairs rather than only when __d is within 2^32 of the top. The carry has weight 2^128,
+	i.e. it belongs in __w3. Add __d and the carry-in separately so the carry test is not fooled
+	when __d = 2^64-1 and there is a carry in: */\
+	__b  += __d;			__w3 += (__b < __d);\
+	__cy  = (__a < __c);	__b += __cy;	__w3 += (__b < __cy);\
 	/* Now add [w1,w2,w3] + [a,b,0]: */\
 	__w1 += __a;\
 	__cy  = (__w1 < __a);\


### PR DESCRIPTION
Fifteen copies of this construct discard a real carry:

```c
__a  += __c;
__b  += __d + (__a < __c);
DBG_ASSERT((__b >= __d),"...: unexpected carryout of __b");
```

The comment above them claims *"since b and d <= 2^64 - 2, can add carryout of a+c sans ripple-carry check"* — but that is not the shape of the operands. In `MULH128x96`, `(__a,__b)` is the 96-bit product `x.d0*y.d1`, so `__b < 2^32`; `(__c,__d)` is the **full 128-bit** product `y.d0*x.d1`, with `__d` up to `2^64-2`. Their 128-bit sum reaches `2^128 + 2^96`, so `__b` genuinely carries out.

The `DBG_ASSERT` is not a guard — `masterdefs.h` defines it away to nothing unless `FAC_DEBUG`, so production silently returns `hi.d1` one too small.

### The fix

`(__a,__b)` is added at the `[__w1,__w2]` positions, so a carry out of `__b` has weight 2^128 — it belongs in `__w3` (or `__hiN.d1` in the pipelined variants).

`__d` and the carry-in are now added **separately** rather than as `__d + (__a < __c)`, so the carry test cannot itself be fooled: when `__d = 2^64-1` and there is a carry in, that inner sum wraps to 0 and a naive `(__b < __d)` test would miss the carry entirely.

**Sites:** `MULH128x96` (both the `MUL_LOHI64_SUBROUTINE` and portable bodies), all 4 lanes of `MULH128x96_q4`, all 8 of `MULH128x96_q8`, and the same construct in `MULH128`'s `MUL_LOHI64_SUBROUTINE` body — where **both** `(__a,__b)` and `(__c,__d)` are full 128-bit products, so it overflows far more often than the `x96` case rather than only when `__d` is within 2^32 of the top — measured at **7.2% of uniform-random operand pairs** (see the driver results in the comments; an earlier estimate of "roughly half" in this description was wrong). The three no-op `DBG_ASSERT`s go with the code they purported to check.

### Verification

Against an exact `__int128` reference.

A uniform-random sweep finds **nothing** — the defect needs `__d >= 2^64 - 2^32`, i.e. both `y.d0` and `x.d1` near 2^64, which is ~2^-32 of the space. (My first sweep did exactly this and returned 0 wrong on *both* builds, which is why the base run matters as a control.) Biasing those two operands to within 2^24 of 2^64:

| | witness `hi.d1` | biased sweep |
| --- | --- | --- |
| pristine `main` | `0x00000000FFFFDA20` (exact: `…DA21`) — **mismatch** | **389844 / 400000 wrong** |
| with this fix | `0x00000000FFFFDA21` — matches | **0 / 400000 wrong** |

The witness is the one recorded in the original audit. `imul_macro.c` compiles clean with and without `-DMUL_LOHI64_SUBROUTINE`.

### Reachability

`MULH128x96_q4`/`_q8` are called from `twopmodq128_96.c`, reached from `factor.c` only under `-DUSE_128x96=2`; the x86_64/GCC default is `1`. So this is **live but configuration-gated**, and at that setting it produces rare silently-wrong residues — missed factors, not a crash. The `MULH128` copy is on the `MUL_LOHI64_SUBROUTINE` path, which the default x86-64/GCC build never compiles. It is now demonstrated directly rather than by inspection: a standalone driver compiling only `imul_macro.c` and `types.c` with `-DMUL_LOHI64_SUBROUTINE` shows 14403/200000 uniform-random pairs wrong on `main` and 0/200000 with this fix.

Companion to #167, which fixed a different dropped cross-term carry in `SQR_LOHI192`. Several further defects from the same audit remain unfixed and are not included here.

