### PR TITLE
twopmmodq64/128/192/256: fix the even-modulus p-window underflow (resolves #186)

### DIFF
--- a/src/imul_macro1.h
+++ b/src/imul_macro1.h
@@ -6402,7 +6402,8 @@ On Alpha, this needs a total of 12 MUL instructions and 42 ALU ops.
 		MUL_LOHI64(__x.d0,__x.d2, __e , __f );	/*   x0*x2 */\
 		MUL_LOHI64(__x.d1,__x.d2, __i , __j );	/*   x1*x2 */\
 		/* Add last pair (bottom layer) cross terms: */\
-		__b += __e;	__i += __f + (__b < __e);	/* f is a UMULH output, so f + CY cannot overflow */\
+		__b += __e;	__f += (__b < __e);	/* f is a UMULH output, so f + CY cannot overflow */\
+		__i += __f;	__j += (__i < __f);	/* ...but i + (f + CY) can, so ripple that carry into j */\
 		__hi.d2 = ((int64)__j < 0);\
 		/* Interleave left-shift of the 4-word result with squaring MULs: */\
 		/*** I wish I could say that interleaving the MULs and ALU stuff gives a speedup, but on x86_64 I get same speed if I do */\
@@ -6433,10 +6434,12 @@ On Alpha, this needs a total of 12 MUL instructions and 42 ALU ops.
 		/* Evaluate the cross-terms first, then right-shift those 1 place while we compute the w0-w5 terms: */\
 	"movq	%[__x0],%%rax	\n\t	mulq	%[__x1]	\n\t	movq	%%rax,%%r11	\n\t	movq	%%rdx,%%r12	\n\t"/* _a:_b = x0*x1 */\
 	"movq	%[__x0],%%rax	\n\t	mulq	%[__x2]	\n\t	movq	%%rax,%%rdi	\n\t	movq	%%rdx,%%r13	\n\t"/* _e:_f = x0*x2 */\
-	"movq	%[__x1],%%rax	\n\t	mulq	%[__x2]	\n\t		movq %%rdx,%%r14  \n\t	movq	%%rdx,%%r15	\n\t"/* _i:_j = x1*x2; leave _i in rax, make 2 copies of rdx */\
+	"movq	%[__x1],%%rax	\n\t	mulq	%[__x2]	\n\t		movq %%rdx,%%r14  \n\t"/* _i:_j = x1*x2; leave _i in rax, _j in r14 */\
 		/* Add last pair (bottom layer) cross terms: */\
 		"addq	%%rdi,%%r12		\n\t"/* _b += _e */\
 		"adcq	%%rax,%%r13		\n\t"/*	_i += _f + (_b < _e); _f is a UMULH output, so f + CY cannot overflow */\
+		"adcq	$0,%%r14		\n\t"/*	_j += (_i < _f); ...but _i + (_f + CY) can, so ripple that carry into _j */\
+		"movq	%%r14,%%r15		\n\t"/* copy of the now-final _j, for _w5 */\
 		"shrq	$63,%%r15		\n\t"/* _w5 = (_j >> 63) */\
 		/* Interleave left-shift of the 4-word result with squaring MULs: */\
 	"movq	%[__x0],%%rax	\n\t	mulq	%%rax	\n\t	movq	%%rax,%[__lo0] \n\t	movq	%%rdx,%%r10	\n\t"/* w0:w1 = x0^2 */\

--- a/src/twopmodq.c
+++ b/src/twopmodq.c
@@ -1207,9 +1207,16 @@ uint64 twopmmodq64(uint64 p, uint64 q)
 	// If get here, p > 64: set up for Montgomery-mul-based powering loop:
 	nshift = trailz64(q);
 	if(nshift) {
-		// p >= nshift guaranteed here:
+		// p >= nshift guaranteed here, since p > 64 > nshift:
 		q >>= nshift; p -= nshift;	// Right-shift dividend by (nshift) bits; for 2^p this means subtracting nshift from p
 		if(debug) printf("Removed power-of-2 from q: q' = (q >> %u) = %" PRIu64 "\n",nshift,q);
+		// The (p <= 64) early-out above was taken against the *unshifted* exponent, so for
+		// p in (64, 64+nshift) the subtraction just dropped p below 64 and the (pshift = p - 64)
+		// computed below would wrap. Redo the direct computation, now against the odd part q',
+		// and restore the off-shifted power of 2 on the way out.  p = 64 needs no special case:
+		// it gives pshift = 0, hence leadb = 0 and start_index = 0, which the main path handles.
+		if(p < 64)
+			return ((1ull << p) % q) << nshift;
 	}
 	qhalf  = q>>1;	/* = (q-1)/2, since q odd. */
 	// Extract leftmost 7 bits of (p - 64); if > 64, use leftmost 6 instead:

--- a/src/twopmodq.c
+++ b/src/twopmodq.c
@@ -1214,12 +1214,18 @@ uint64 twopmmodq64(uint64 p, uint64 q)
 	qhalf  = q>>1;	/* = (q-1)/2, since q odd. */
 	// Extract leftmost 7 bits of (p - 64); if > 64, use leftmost 6 instead:
 	pshift = p - 64;	j = leadz64(pshift);
-	leadb = (pshift<<j) >> 57;	// No (pshift = ~pshift) step in positive-power algorithm!
-	if(leadb > 64) {
-		start_index = 58-j;
-		leadb >>= 1;
+	if(j > 57) {	// pshift < 64, i.e. fewer than 7 significant bits: the 7-bit extraction below would
+					// left-pad pshift with zeros (leadb != pshift) and underflow the unsigned start_index,
+					// leaving 0 loop passes and returning the seed. Use all of pshift as the lead chunk:
+		leadb = pshift;	start_index = 0;
 	} else {
-		start_index = 57-j;
+		leadb = (pshift<<j) >> 57;	// No (pshift = ~pshift) step in positive-power algorithm!
+		if(leadb > 64) {
+			start_index = 58-j;
+			leadb >>= 1;
+		} else {
+			start_index = 57-j;
+		}
 	}
 	/* q must be odd for Montgomery-style modmul to work: */
 	ASSERT((q & 0x1) && (q > 1), "q must be odd > 1!");
@@ -1333,8 +1339,14 @@ void twopmmodq64_q4(uint64 p, uint64 *i0, uint64 *i1, uint64 *i2, uint64 *i3, ui
 	uint32 leadb, start_index;
 
 	// Extract leftmost 6 bits of p and subtract from 64:
-	leadb = (p<<j) >> 58;
-	start_index = 58-j;
+	if(j > 58) {	// p < 32, i.e. fewer than 6 significant bits: the 6-bit extraction below would
+					// left-pad p with zeros (leadb != p) and underflow the unsigned start_index,
+					// leaving 0 loop passes and returning the seed. Use all of p as the lead chunk:
+		leadb = p;	start_index = 0;
+	} else {
+		leadb = (p<<j) >> 58;
+		start_index = 58-j;
+	}
 
 	/* q must be odd for Montgomery-style modmul to work: */
 	ASSERT(q1 > 1 && q1 > 1 && q2 > 1 && q3 > 1 , "modulus must be > 1!");

--- a/src/twopmodq128.c
+++ b/src/twopmodq128.c
@@ -93,12 +93,18 @@ uint128 twopmmodq128(uint128 p, uint128 q)
 	}
 	// Extract leftmost 8 bits of (p - 128); if > 128, use leftmost 7 instead:
 	x.d0 = 128ull; x.d1 = 0ull; SUB128(p,x,pshift); j = leadz128(pshift);
-	LSHIFT128(pshift,j,x);	leadb = x.d1 >> 56;	// leadb = (pshift<<j) >> 57; no (pshift = ~pshift) step in positive-power algorithm!
-	if(leadb > 128) {
-		start_index = 128-7-j;
-		leadb >>= 1;
+	if(j > 120) {	// pshift < 128, i.e. fewer than 8 significant bits: the 8-bit extraction below would
+					// left-pad pshift with zeros (leadb != pshift) and underflow the unsigned start_index,
+					// leaving 0 loop passes and returning the seed. Use all of pshift as the lead chunk:
+		leadb = (uint32)pshift.d0;	start_index = 0;
 	} else {
-		start_index = 128-8-j;
+		LSHIFT128(pshift,j,x);	leadb = x.d1 >> 56;	// leadb = (pshift<<j) >> 57; no (pshift = ~pshift) step in positive-power algorithm!
+		if(leadb > 128) {
+			start_index = 128-7-j;
+			leadb >>= 1;
+		} else {
+			start_index = 128-8-j;
+		}
 	}
 #if FAC_DEBUG
 	if(dbg) {
@@ -141,7 +147,8 @@ uint128 twopmmodq128(uint128 p, uint128 q)
 	if(leadb == 128)
 		x = rsqr;
 	else {
-		x.d0 = 1ull; LSHIFT128(x,leadb,x);	// x <<= leadb;
+		// x is reused as scratch above, so must zero its high words before seeding with 2^leadb:
+		x.d0 = 1ull; x.d1 = 0ull;	LSHIFT128(x,leadb,x);	// x <<= leadb;
 		MONT_MUL128(x,rsqr, q,qinv, x);	// x*R (mod q) = MONT_MUL(x,R^2 (mod q),q,qinv)
  	}
 

--- a/src/twopmodq128.c
+++ b/src/twopmodq128.c
@@ -94,12 +94,18 @@ uint128 twopmmodq128(uint128 p, uint128 q)
 	}
 	// Extract leftmost 8 bits of (p - 128); if > 128, use leftmost 7 instead:
 	x.d0 = 128ull; x.d1 = 0ull; SUB128(p,x,pshift); j = leadz128(pshift);
-	LSHIFT128(pshift,j,x);	leadb = x.d1 >> 56;	// leadb = (pshift<<j) >> 57; no (pshift = ~pshift) step in positive-power algorithm!
-	if(leadb > 128) {
-		start_index = 128-7-j;
-		leadb >>= 1;
+	if(j > 120) {	// pshift < 128, i.e. fewer than 8 significant bits: the 8-bit extraction below would
+					// left-pad pshift with zeros (leadb != pshift) and underflow the unsigned start_index,
+					// leaving 0 loop passes and returning the seed. Use all of pshift as the lead chunk:
+		leadb = (uint32)pshift.d0;	start_index = 0;
 	} else {
-		start_index = 128-8-j;
+		LSHIFT128(pshift,j,x);	leadb = x.d1 >> 56;	// leadb = (pshift<<j) >> 57; no (pshift = ~pshift) step in positive-power algorithm!
+		if(leadb > 128) {
+			start_index = 128-7-j;
+			leadb >>= 1;
+		} else {
+			start_index = 128-8-j;
+		}
 	}
 #if FAC_DEBUG
 	if(dbg) {
@@ -142,7 +148,8 @@ uint128 twopmmodq128(uint128 p, uint128 q)
 	if(leadb == 128)
 		x = rsqr;
 	else {
-		x.d0 = 1ull; LSHIFT128(x,leadb,x);	// x <<= leadb;
+		// x is reused as scratch above, so must zero its high words before seeding with 2^leadb:
+		x.d0 = 1ull; x.d1 = 0ull;	LSHIFT128(x,leadb,x);	// x <<= leadb;
 		MONT_MUL128(x,rsqr, q,qinv, x);	// x*R (mod q) = MONT_MUL(x,R^2 (mod q),q,qinv)
  	}
 

--- a/src/twopmodq128.c
+++ b/src/twopmodq128.c
@@ -65,6 +65,23 @@ uint128 twopmmodq128(uint128 p, uint128 q)
 	if(dbg) printf("twopmmodq128: computing 2^%s (mod %s)\n",&char_buf[convert_uint128_base10_char(char_buf,p)],&g_cstr[convert_uint128_base10_char(g_cstr,q)]);
 #endif
 	RSHIFT_FAST128(q, 1, qhalf);	/* = (q-1)/2, since q odd. */
+	/* If p > 128 we need the Montgomery-mul powering loop, which needs an odd modulus, so strip
+	any power of 2 from q *here*, ahead of the (p <= 128) early-out below: the strip lowers p by
+	nshift and can drop it into the early-out range. Doing the early-out first instead leaves
+	p in (128, 128+nshift) falling through to (pshift = p - 128), which wraps. The (p > 128)
+	guard keeps p >= nshift, so the identity 2^p mod q = 2^nshift * (2^(p-nshift) mod q') holds. */
+	nshift = 0;
+	if(!(p.d1 == 0 && p.d0 <= 128)) {
+		nshift = trailz128(q);
+		if(nshift) {
+			x.d0 = (uint64)nshift; x.d1 = 0ull; SUB128(p,x,p);	// p >= nshift guaranteed here:
+			RSHIFT128(q,nshift,q);	// Right-shift dividend by (nshift) bits; for 2^p this means subtracting nshift from p
+			RSHIFT_FAST128(q, 1, qhalf);	// Must recompute (q-1)/2: the mod-doublings in the powering loop reduce (mod q'), not (mod q)
+		#if FAC_DEBUG
+			if(dbg) printf("Removed power-of-2 from q: q' = (q >> %u) = %s\n",nshift,&char_buf[convert_uint128_base10_char(char_buf,q)]);
+		#endif
+		}
+	}
 	// If p <= 128, directly compute 2^p (mod q):
 	if(p.d1 == 0 && p.d0 <= 128) {
 		// Lshift (1 << j) to align with leading bit of q, then do (p - j) repeated mod-doublings:
@@ -80,18 +97,13 @@ uint128 twopmmodq128(uint128 p, uint128 q)
 			/* Combines overflow-on-add and need-to-subtract-q-from-sum checks */
 			if(CMPUGT128(x, qhalf)){ ADD128(x, x, x); SUB128(x, q, x); }else{ ADD128(x, x, x); }
 		}
+		// Restore any power of 2 stripped from the modulus above:
+		if(nshift) {
+			LSHIFT128(x,nshift,x);
+		}
 		return x;
 	}
-	// If get here, p > 128: set up for Montgomery-mul-based powering loop:
-	nshift = trailz128(q);
-	if(nshift) {
-		x.d0 = (uint64)nshift; x.d1 = 0ull; SUB128(p,x,p);	// p >= nshift guaranteed here:
-		RSHIFT128(q,nshift,q);	// Right-shift dividend by (nshift) bits; for 2^p this means subtracting nshift from p
-		RSHIFT_FAST128(q, 1, qhalf);	// Must recompute (q-1)/2: the mod-doublings in the powering loop reduce (mod q'), not (mod q)
-	#if FAC_DEBUG
-		if(dbg) printf("Removed power-of-2 from q: q' = (q >> %u) = %s\n",nshift,&char_buf[convert_uint128_base10_char(char_buf,q)]);
-	#endif
-	}
+	// If get here, p > 128 and q is odd: set up for Montgomery-mul-based powering loop.
 	// Extract leftmost 8 bits of (p - 128); if > 128, use leftmost 7 instead:
 	x.d0 = 128ull; x.d1 = 0ull; SUB128(p,x,pshift); j = leadz128(pshift);
 	if(j > 120) {	// pshift < 128, i.e. fewer than 8 significant bits: the 8-bit extraction below would

--- a/src/twopmodq128.c
+++ b/src/twopmodq128.c
@@ -92,6 +92,10 @@ uint128 twopmmodq128(uint128 p, uint128 q)
 			LSHIFT128(x,(uint32)p.d0,x);
 		} else {
 			LSHIFT128(x,j,x);
+			// 2^j <= q < 2^(j+1), so the aligned seed is < q *except* when q is an exact power
+			// of 2, where 2^j == q and the seed needs reducing to 0 - the doublings below never
+			// reduce it otherwise, and the routine would return q (or 2^nshift) in place of 0:
+			if(CMPEQ128(x, q)) { x.d0 = x.d1 = 0ull; }
 		}
 		for( ; j < p.d0; j++) {
 			/* Combines overflow-on-add and need-to-subtract-q-from-sum checks */

--- a/src/twopmodq128.c
+++ b/src/twopmodq128.c
@@ -87,6 +87,7 @@ uint128 twopmmodq128(uint128 p, uint128 q)
 	if(nshift) {
 		x.d0 = (uint64)nshift; x.d1 = 0ull; SUB128(p,x,p);	// p >= nshift guaranteed here:
 		RSHIFT128(q,nshift,q);	// Right-shift dividend by (nshift) bits; for 2^p this means subtracting nshift from p
+		RSHIFT_FAST128(q, 1, qhalf);	// Must recompute (q-1)/2: the mod-doublings in the powering loop reduce (mod q'), not (mod q)
 	#if FAC_DEBUG
 		if(dbg) printf("Removed power-of-2 from q: q' = (q >> %u) = %s\n",nshift,&char_buf[convert_uint128_base10_char(char_buf,q)]);
 	#endif

--- a/src/twopmodq192.c
+++ b/src/twopmodq192.c
@@ -87,6 +87,7 @@ uint192 twopmmodq192(uint192 p, uint192 q)
 	if(nshift) {
 		x.d0 = (uint64)nshift; x.d1 = x.d2 = 0ull; SUB192(p,x,p);	// p >= nshift guaranteed here:
 		RSHIFT192(q,nshift,q);	// Right-shift dividend by (nshift) bits; for 2^p this means subtracting nshift from p
+		RSHIFT_FAST192(q, 1, qhalf);	// Must recompute (q-1)/2: the mod-doublings in the powering loop reduce (mod q'), not (mod q)
 	#if FAC_DEBUG
 		if(dbg) printf("Removed power-of-2 from q: q' = (q >> %u) = %s\n",nshift,&char_buf[convert_uint192_base10_char(char_buf,q)]);
 	#endif

--- a/src/twopmodq192.c
+++ b/src/twopmodq192.c
@@ -94,12 +94,18 @@ uint192 twopmmodq192(uint192 p, uint192 q)
 	}
 	// Extract leftmost 8 bits of (p - 192); if > 192, use leftmost 7 instead:
 	x.d0 = 192ull; x.d1 = x.d2 = 0ull; SUB192(p,x,pshift); j = leadz192(pshift);
-	LSHIFT192(pshift,j,x);	leadb = x.d2 >> 56;	// leadb = (pshift<<j) >> 57; no (pshift = ~pshift) step in positive-power algorithm!
-	if(leadb > 192) {
-		start_index = 192-7-j;
-		leadb >>= 1;
+	if(j > 184) {	// pshift < 128, i.e. fewer than 8 significant bits: the 8-bit extraction below would
+					// left-pad pshift with zeros (leadb != pshift) and underflow the unsigned start_index,
+					// leaving 0 loop passes and returning the seed. Use all of pshift as the lead chunk:
+		leadb = (uint32)pshift.d0;	start_index = 0;
 	} else {
-		start_index = 192-8-j;
+		LSHIFT192(pshift,j,x);	leadb = x.d2 >> 56;	// leadb = (pshift<<j) >> 57; no (pshift = ~pshift) step in positive-power algorithm!
+		if(leadb > 192) {
+			start_index = 192-7-j;
+			leadb >>= 1;
+		} else {
+			start_index = 192-8-j;
+		}
 	}
 #if FAC_DEBUG
 	if(dbg) {
@@ -137,7 +143,9 @@ uint192 twopmmodq192(uint192 p, uint192 q)
 	if(leadb == 192)
 		x = rsqr;
 	else {
-		x.d0 = 1ull; LSHIFT192(x,leadb,x);	// x <<= leadb;
+		// x holds (2 - q*qinv) scratch from the Newton iteration above, whose high words are
+		// nonzero; must zero them before seeding with 2^leadb, else leadb < 64 shifts in garbage:
+		x.d0 = 1ull; x.d1 = x.d2 = 0ull;	LSHIFT192(x,leadb,x);	// x <<= leadb;
 		MONT_MUL192(x,rsqr, q,qinv, x);	// x*R (mod q) = MONT_MUL(x,R^2 (mod q),q,qinv)
  	}
 

--- a/src/twopmodq192.c
+++ b/src/twopmodq192.c
@@ -92,6 +92,10 @@ uint192 twopmmodq192(uint192 p, uint192 q)
 			LSHIFT192(x,(uint32)p.d0,x);
 		} else {
 			LSHIFT192(x,j,x);
+			// 2^j <= q < 2^(j+1), so the aligned seed is < q *except* when q is an exact power
+			// of 2, where 2^j == q and the seed needs reducing to 0 - the doublings below never
+			// reduce it otherwise, and the routine would return q (or 2^nshift) in place of 0:
+			if(CMPEQ192(x, q)) { x.d0 = x.d1 = x.d2 = 0ull; }
 		}
 		for( ; j < p.d0; j++) {
 			/* Combines overflow-on-add and need-to-subtract-q-from-sum checks */

--- a/src/twopmodq192.c
+++ b/src/twopmodq192.c
@@ -65,6 +65,23 @@ uint192 twopmmodq192(uint192 p, uint192 q)
 	if(dbg) printf("twopmmodq192: computing 2^%s (mod %s)\n",&char_buf[convert_uint192_base10_char(char_buf,p)],&g_cstr[convert_uint192_base10_char(g_cstr,q)]);
 #endif
 	RSHIFT_FAST192(q, 1, qhalf);	/* = (q-1)/2, since q odd. */
+	/* If p > 192 we need the Montgomery-mul powering loop, which needs an odd modulus, so strip
+	any power of 2 from q *here*, ahead of the (p <= 192) early-out below: the strip lowers p by
+	nshift and can drop it into the early-out range. Doing the early-out first instead leaves
+	p in (192, 192+nshift) falling through to (pshift = p - 192), which wraps. The (p > 192)
+	guard keeps p >= nshift, so the identity 2^p mod q = 2^nshift * (2^(p-nshift) mod q') holds. */
+	nshift = 0;
+	if(!(p.d2 == 0 && p.d1 == 0 && p.d0 <= 192)) {
+		nshift = trailz192(q);
+		if(nshift) {
+			x.d0 = (uint64)nshift; x.d1 = x.d2 = 0ull; SUB192(p,x,p);	// p >= nshift guaranteed here:
+			RSHIFT192(q,nshift,q);	// Right-shift dividend by (nshift) bits; for 2^p this means subtracting nshift from p
+			RSHIFT_FAST192(q, 1, qhalf);	// Must recompute (q-1)/2: the mod-doublings in the powering loop reduce (mod q'), not (mod q)
+		#if FAC_DEBUG
+			if(dbg) printf("Removed power-of-2 from q: q' = (q >> %u) = %s\n",nshift,&char_buf[convert_uint192_base10_char(char_buf,q)]);
+		#endif
+		}
+	}
 	// If p <= 192, directly compute 2^p (mod q):
 	if(p.d2 == 0 && p.d1 == 0 && p.d0 <= 192) {
 		// Lshift (1 << j) to align with leading bit of q, then do (p - j) repeated mod-doublings:
@@ -80,18 +97,13 @@ uint192 twopmmodq192(uint192 p, uint192 q)
 			/* Combines overflow-on-add and need-to-subtract-q-from-sum checks */
 			if(CMPUGT192(x, qhalf)){ ADD192(x, x, x); SUB192(x, q, x); }else{ ADD192(x, x, x); }
 		}
+		// Restore any power of 2 stripped from the modulus above:
+		if(nshift) {
+			LSHIFT192(x,nshift,x);
+		}
 		return x;
 	}
-	// If get here, p > 192: set up for Montgomery-mul-based powering loop:
-	nshift = trailz192(q);
-	if(nshift) {
-		x.d0 = (uint64)nshift; x.d1 = x.d2 = 0ull; SUB192(p,x,p);	// p >= nshift guaranteed here:
-		RSHIFT192(q,nshift,q);	// Right-shift dividend by (nshift) bits; for 2^p this means subtracting nshift from p
-		RSHIFT_FAST192(q, 1, qhalf);	// Must recompute (q-1)/2: the mod-doublings in the powering loop reduce (mod q'), not (mod q)
-	#if FAC_DEBUG
-		if(dbg) printf("Removed power-of-2 from q: q' = (q >> %u) = %s\n",nshift,&char_buf[convert_uint192_base10_char(char_buf,q)]);
-	#endif
-	}
+	// If get here, p > 192 and q is odd: set up for Montgomery-mul-based powering loop.
 	// Extract leftmost 8 bits of (p - 192); if > 192, use leftmost 7 instead:
 	x.d0 = 192ull; x.d1 = x.d2 = 0ull; SUB192(p,x,pshift); j = leadz192(pshift);
 	if(j > 184) {	// pshift < 128, i.e. fewer than 8 significant bits: the 8-bit extraction below would

--- a/src/twopmodq192.c
+++ b/src/twopmodq192.c
@@ -93,12 +93,18 @@ uint192 twopmmodq192(uint192 p, uint192 q)
 	}
 	// Extract leftmost 8 bits of (p - 192); if > 192, use leftmost 7 instead:
 	x.d0 = 192ull; x.d1 = x.d2 = 0ull; SUB192(p,x,pshift); j = leadz192(pshift);
-	LSHIFT192(pshift,j,x);	leadb = x.d2 >> 56;	// leadb = (pshift<<j) >> 57; no (pshift = ~pshift) step in positive-power algorithm!
-	if(leadb > 192) {
-		start_index = 192-7-j;
-		leadb >>= 1;
+	if(j > 184) {	// pshift < 128, i.e. fewer than 8 significant bits: the 8-bit extraction below would
+					// left-pad pshift with zeros (leadb != pshift) and underflow the unsigned start_index,
+					// leaving 0 loop passes and returning the seed. Use all of pshift as the lead chunk:
+		leadb = (uint32)pshift.d0;	start_index = 0;
 	} else {
-		start_index = 192-8-j;
+		LSHIFT192(pshift,j,x);	leadb = x.d2 >> 56;	// leadb = (pshift<<j) >> 57; no (pshift = ~pshift) step in positive-power algorithm!
+		if(leadb > 192) {
+			start_index = 192-7-j;
+			leadb >>= 1;
+		} else {
+			start_index = 192-8-j;
+		}
 	}
 #if FAC_DEBUG
 	if(dbg) {
@@ -136,7 +142,9 @@ uint192 twopmmodq192(uint192 p, uint192 q)
 	if(leadb == 192)
 		x = rsqr;
 	else {
-		x.d0 = 1ull; LSHIFT192(x,leadb,x);	// x <<= leadb;
+		// x holds (2 - q*qinv) scratch from the Newton iteration above, whose high words are
+		// nonzero; must zero them before seeding with 2^leadb, else leadb < 64 shifts in garbage:
+		x.d0 = 1ull; x.d1 = x.d2 = 0ull;	LSHIFT192(x,leadb,x);	// x <<= leadb;
 		MONT_MUL192(x,rsqr, q,qinv, x);	// x*R (mod q) = MONT_MUL(x,R^2 (mod q),q,qinv)
  	}
 

--- a/src/twopmodq256.c
+++ b/src/twopmodq256.c
@@ -122,6 +122,7 @@ uint256 twopmmodq256(uint256 p, uint256 q)
 	if(nshift) {
 		x.d0 = (uint64)nshift; x.d1 = x.d2 = x.d3 = 0ull; SUB256(p,x,p);	// p >= nshift guaranteed here:
 		RSHIFT256(q,nshift,q);	// Right-shift dividend by (nshift) bits; for 2^p this means subtracting nshift from p
+		RSHIFT_FAST256(q, 1, qhalf);	// Must recompute (q-1)/2: the mod-doublings in the powering loop reduce (mod q'), not (mod q)
 	#if FAC_DEBUG
 		if(dbg) printf("Removed power-of-2 from q: q' = (q >> %u) = %s\n",nshift,&char_buf[convert_uint256_base10_char(char_buf,q)]);
 	#endif

--- a/src/twopmodq256.c
+++ b/src/twopmodq256.c
@@ -128,8 +128,14 @@ uint256 twopmmodq256(uint256 p, uint256 q)
 	}
 	// Extract leftmost 8 bits of (p - 256):
 	x.d0 = 256ull; x.d1 = x.d2 = x.d3 = 0ull; SUB256(p,x,pshift); j = leadz256(pshift);
-	LSHIFT256(pshift,j,x);	leadb = x.d3 >> 56;	// leadb = (pshift<<j) >> 57; no (pshift = ~pshift) step in positive-power algorithm!
-	start_index = 256-8-j;
+	if(j > 248) {	// pshift < 128, i.e. fewer than 8 significant bits: the 8-bit extraction below would
+					// left-pad pshift with zeros (leadb != pshift) and underflow the unsigned start_index,
+					// leaving 0 loop passes and returning the seed. Use all of pshift as the lead chunk:
+		leadb = (uint32)pshift.d0;	start_index = 0;
+	} else {
+		LSHIFT256(pshift,j,x);	leadb = x.d3 >> 56;	// leadb = (pshift<<j) >> 57; no (pshift = ~pshift) step in positive-power algorithm!
+		start_index = 256-8-j;
+	}
 #if FAC_DEBUG
 	if(dbg) {
 		printf("leadb = %u\n",j);
@@ -166,7 +172,9 @@ uint256 twopmmodq256(uint256 p, uint256 q)
 	if(leadb == 256)
 		x = rsqr;
 	else {
-		x.d0 = 1ull; LSHIFT256(x,leadb,x);	// x <<= leadb;
+		// x holds (2 - q*qinv) scratch from the Newton iteration above, whose high words are
+		// nonzero; must zero them before seeding with 2^leadb, else leadb < 192 shifts in garbage:
+		x.d0 = 1ull; x.d1 = x.d2 = x.d3 = 0ull;	LSHIFT256(x,leadb,x);	// x <<= leadb;
 		MONT_MUL256(x,rsqr, q,qinv, x);	// x*R (mod q) = MONT_MUL(x,R^2 (mod q),q,qinv)
  	}
 

--- a/src/twopmodq256.c
+++ b/src/twopmodq256.c
@@ -129,8 +129,14 @@ uint256 twopmmodq256(uint256 p, uint256 q)
 	}
 	// Extract leftmost 8 bits of (p - 256):
 	x.d0 = 256ull; x.d1 = x.d2 = x.d3 = 0ull; SUB256(p,x,pshift); j = leadz256(pshift);
-	LSHIFT256(pshift,j,x);	leadb = x.d3 >> 56;	// leadb = (pshift<<j) >> 57; no (pshift = ~pshift) step in positive-power algorithm!
-	start_index = 256-8-j;
+	if(j > 248) {	// pshift < 128, i.e. fewer than 8 significant bits: the 8-bit extraction below would
+					// left-pad pshift with zeros (leadb != pshift) and underflow the unsigned start_index,
+					// leaving 0 loop passes and returning the seed. Use all of pshift as the lead chunk:
+		leadb = (uint32)pshift.d0;	start_index = 0;
+	} else {
+		LSHIFT256(pshift,j,x);	leadb = x.d3 >> 56;	// leadb = (pshift<<j) >> 57; no (pshift = ~pshift) step in positive-power algorithm!
+		start_index = 256-8-j;
+	}
 #if FAC_DEBUG
 	if(dbg) {
 		printf("leadb = %u\n",j);
@@ -167,7 +173,9 @@ uint256 twopmmodq256(uint256 p, uint256 q)
 	if(leadb == 256)
 		x = rsqr;
 	else {
-		x.d0 = 1ull; LSHIFT256(x,leadb,x);	// x <<= leadb;
+		// x holds (2 - q*qinv) scratch from the Newton iteration above, whose high words are
+		// nonzero; must zero them before seeding with 2^leadb, else leadb < 192 shifts in garbage:
+		x.d0 = 1ull; x.d1 = x.d2 = x.d3 = 0ull;	LSHIFT256(x,leadb,x);	// x <<= leadb;
 		MONT_MUL256(x,rsqr, q,qinv, x);	// x*R (mod q) = MONT_MUL(x,R^2 (mod q),q,qinv)
  	}
 

--- a/src/twopmodq256.c
+++ b/src/twopmodq256.c
@@ -100,6 +100,23 @@ uint256 twopmmodq256(uint256 p, uint256 q)
 	if(dbg) printf("twopmmodq256: computing 2^%s (mod %s)\n",&char_buf[convert_uint256_base10_char(char_buf,p)],&g_cstr[convert_uint256_base10_char(g_cstr,q)]);
 #endif
 	RSHIFT_FAST256(q, 1, qhalf);	/* = (q-1)/2, since q odd. */
+	/* If p > 256 we need the Montgomery-mul powering loop, which needs an odd modulus, so strip
+	any power of 2 from q *here*, ahead of the (p <= 256) early-out below: the strip lowers p by
+	nshift and can drop it into the early-out range. Doing the early-out first instead leaves
+	p in (256, 256+nshift) falling through to (pshift = p - 256), which wraps. The (p > 256)
+	guard keeps p >= nshift, so the identity 2^p mod q = 2^nshift * (2^(p-nshift) mod q') holds. */
+	nshift = 0;
+	if(!(p.d3 == 0 && p.d2 == 0 && p.d1 == 0 && p.d0 <= 256)) {
+		nshift = trailz256(q);
+		if(nshift) {
+			x.d0 = (uint64)nshift; x.d1 = x.d2 = x.d3 = 0ull; SUB256(p,x,p);	// p >= nshift guaranteed here:
+			RSHIFT256(q,nshift,q);	// Right-shift dividend by (nshift) bits; for 2^p this means subtracting nshift from p
+			RSHIFT_FAST256(q, 1, qhalf);	// Must recompute (q-1)/2: the mod-doublings in the powering loop reduce (mod q'), not (mod q)
+		#if FAC_DEBUG
+			if(dbg) printf("Removed power-of-2 from q: q' = (q >> %u) = %s\n",nshift,&char_buf[convert_uint256_base10_char(char_buf,q)]);
+		#endif
+		}
+	}
 	// If p <= 256, directly compute 2^p (mod q):
 	if(p.d3 == 0 && p.d2 == 0 && p.d1 == 0 && p.d0 <= 256) {
 		// Lshift (1 << j) to align with leading bit of q, then do (p - j) repeated mod-doublings:
@@ -115,18 +132,13 @@ uint256 twopmmodq256(uint256 p, uint256 q)
 			/* Combines overflow-on-add and need-to-subtract-q-from-sum checks */
 			if(CMPUGT256(x, qhalf)){ ADD256(x, x, x); SUB256(x, q, x); }else{ ADD256(x, x, x); }
 		}
+		// Restore any power of 2 stripped from the modulus above:
+		if(nshift) {
+			LSHIFT256(x,nshift,x);
+		}
 		return x;
 	}
-	// If get here, p > 256: set up for Montgomery-mul-based powering loop:
-	nshift = trailz256(q);
-	if(nshift) {
-		x.d0 = (uint64)nshift; x.d1 = x.d2 = x.d3 = 0ull; SUB256(p,x,p);	// p >= nshift guaranteed here:
-		RSHIFT256(q,nshift,q);	// Right-shift dividend by (nshift) bits; for 2^p this means subtracting nshift from p
-		RSHIFT_FAST256(q, 1, qhalf);	// Must recompute (q-1)/2: the mod-doublings in the powering loop reduce (mod q'), not (mod q)
-	#if FAC_DEBUG
-		if(dbg) printf("Removed power-of-2 from q: q' = (q >> %u) = %s\n",nshift,&char_buf[convert_uint256_base10_char(char_buf,q)]);
-	#endif
-	}
+	// If get here, p > 256 and q is odd: set up for Montgomery-mul-based powering loop.
 	// Extract leftmost 8 bits of (p - 256):
 	x.d0 = 256ull; x.d1 = x.d2 = x.d3 = 0ull; SUB256(p,x,pshift); j = leadz256(pshift);
 	if(j > 248) {	// pshift < 128, i.e. fewer than 8 significant bits: the 8-bit extraction below would

--- a/src/twopmodq256.c
+++ b/src/twopmodq256.c
@@ -127,6 +127,10 @@ uint256 twopmmodq256(uint256 p, uint256 q)
 			LSHIFT256(x,(uint32)p.d0,x);
 		} else {
 			LSHIFT256(x,j,x);
+			// 2^j <= q < 2^(j+1), so the aligned seed is < q *except* when q is an exact power
+			// of 2, where 2^j == q and the seed needs reducing to 0 - the doublings below never
+			// reduce it otherwise, and the routine would return q (or 2^nshift) in place of 0:
+			if(CMPEQ256(x, q)) { x.d0 = x.d1 = x.d2 = x.d3 = 0ull; }
 		}
 		for( ; j < p.d0; j++) {
 			/* Combines overflow-on-add and need-to-subtract-q-from-sum checks */


### PR DESCRIPTION
Resolves #186.

## ⚠ This PR is stacked — the first three commits belong to #167, #185 and #172

| commit | PR | what |
|---|---|---|
| `SQR_LOHI192: propagate the dropped cross-term carry into word 4` | **#167** | `src/imul_macro1.h` |
| `twopmmodq64/128/192/256: fix start_index underflow …` | **#185** | |
| `twopmmodq128/192/256: recompute qhalf after the even-modulus right-justify shift` | **#172** | |
| **`… fix pshift underflow for even moduli with p just above the routine width`** | **this PR** | the #186 fix |
| **`… reduce the aligned seed when the modulus is an exact power of 2`** | **this PR** | |

**Only the last two commits are new here.** The other three are carried because this fix cannot be
expressed without them: the block it relocates *is* #172's fix, so the patch does not apply to a tree
without it. Merge #167, #185, #172 first (in that order) and rebasing this branch will drop them
automatically — they are the same patches, not copies.

`#167` is independent of the other two and may land at any point before this.

## The defect

`twopmmodq64/128/192/256` (`twopmodq.c:1192`, `twopmodq128.c:53`, `twopmodq192.c:53`,
`twopmodq256.c:88`) all share this shape, with W = 64/128/192/256:

```c
    if(p <= W) { ...direct computation...; return x; }   // early-out, tested against UNSHIFTED p
    nshift = trailz(q);
    if(nshift) { q >>= nshift;  p -= nshift; }           // strip 2^nshift from even q
    pshift = p - W;                                      // <-- wraps if p < W here
```

The early-out is tested before the power of 2 is stripped. So for

```
    W < p < W + trailz(q)        (which requires trailz(q) >= 2)
```

`p -= nshift` drops `p` below `W`, `pshift = p - W` wraps to a value near 2^W, and `leadb` and
`start_index` are extracted from that garbage — the powering loop then runs on the wrong exponent.

`p == W + nshift` is *not* affected: `pshift = 0`, so `leadb = 0` and `start_index = 0`, which the
powering loop handles correctly. That is why #186 sees p=67 and p=131 as "ok" sitting between two wrong
values.

**This is reachable from ordinary use, not just from a unit test.** At `Mlucas.c:5286-5300` (PRP-CF) the
modulus is `KNOWN_FACTORS[i] - 1`, which is **always even** because factors are odd, and the exponent is
the iteration count. `Mlucas.c:2424`, `Mlucas.c:6397` and `factor.c:1234` are further even/small-p call
sites.

## Why a uniform sweep will not find this

Two independent rare events have to coincide: `trailz(q) >= 2` (probability 1/4 for random q), and `p`
landing in a window of `trailz(q) - 1` consecutive values immediately above W (for p drawn from any
realistic range, essentially never). The harness therefore enumerates the window directly rather than
sampling it — `p` over `[W-4, W+40]`, `q = odd_part * 2^t` with `t` over `[0,40]`, N random odd parts per
cell.

That predicts a failure fraction of `sum_{t=2..40}(t-1) / (41*45) = 780/1845 = 42.28%`, and the unfixed
code measures **42.28%** — the sweep hits exactly the predicted cells and nothing else, which is what
makes it evidence rather than noise.

## Verification

Oracle is GMP `mpz_powm(2, p, q)`. "before" = the three dependency commits only.

| sweep | cases | before | after |
|---|---|---|---|
| targeted, `q = …F8` (trailz 3), p ∈ [W−2, W+5] | 32 | **8** | 0 |
| biased, p ∈ [W−4,W+40] × trailz ∈ [0,40], 200/cell | 1,476,000 | **624,000** (42.28%) | 0 |
| same, 1500/cell | 11,070,000 | **4,679,998** (42.28%) | 0 |
| broad, p ∈ [1,4W], random trailz ∈ [0,12) | 800,000 | **758** | 0 |
| degenerate, `q = 2^k` ∀k ∈ [1,W), p ∈ [1,W+8] | 122,792 | **59,677** | 0 |
| large p (up to 2^32), trailz ∈ [0,W−2] | 80,000 | 0 | 0 |

The last row is a pure regression check — with p ≫ W it structurally cannot reach the window, and
correctly reports 0 on both. Recorded so it is not mistaken for evidence.

The targeted sweep reproduces #186's table exactly, including both literal values quoted there
(`twopmmodq64(65, 0x7FFFFFFFFFFFFFF8)` → `0x200000` for a correct `0x20`; `twopmmodq128(129, ·)` →
`0x2000` for `0x20`), and confirms by measurement the p ∈ {193,194} and {257,258} windows that #186 had
only inferred. The p=68/132 rows from #186 are absent because #185 is in the base.

Per-width, on the 11.07M biased sweep: `twopmmodq64` 1,169,998 → 0; `128` 1,170,000 → 0;
`192` 1,170,000 → 0; `256` 1,170,000 → 0.

## Why there are two commits, and why both are needed

**Commit 1** is the #186 fix. For 128/192/256 it hoists the even-modulus right-justify shift **above** the
`p <= W` early-out, guarded by `p > W` so that `p >= nshift` still holds and the identity
`2^p mod q = 2^nshift * (2^(p-nshift) mod q')` remains valid, then restores the off-shifted power of 2 on
the early-out's return path. The guard is essential: hoisting unconditionally would underflow `p -= nshift`
for small p with a large `trailz(q)` (e.g. p=5, q=2^100). The 64-bit routine's direct path is a single
`(1 << p) % q`, so its early-out stays put and `p` is simply re-tested after the shift.

**Commit 2** fixes a second, adjacent defect, found while checking for regressions and not part of #186.
The `p <= W` direct path seeds `x = 2^j` with `j = W - leadz(q) - 1`, the largest power of 2 that is
`<= q`. That seed is strictly `< q` for every q **except an exact power of 2**, where `2^j == q`: the seed
is congruent to 0 but unreduced, and the doubling step only subtracts q when `x > qhalf`, so `x == q` is a
fixed point and the routine returns `q` where `0` is correct. One line per file:

```c
    if(CMPEQ128(x, q)) { x.d0 = x.d1 = 0ull; }
```

This is pre-existing — 59,677 of 122,792 `q = 2^k` cases are already wrong without either commit. **But
commit 1 routes `p ∈ (W, W+nshift)` into that path**, where the old `q' = 1` powering-loop route happened
to return the correct 0. Measured on the `q = 2^k` sweep:

| tree | wrong |
|---|---|
| dependencies only | 59,677 |
| **+ commit 1 only** | **64,177** — commit 1 newly breaks 4,500 cases |
| + both commits | **0** |

So commit 1 must not be merged without commit 2. In the other direction they are independent: commit 2
alone is a valid standalone fix for the pre-existing 59,677.

`twopmmodq64` is unaffected by commit 2 — `(1 << p) % q` is exact for any q. For p > 64 with `q = 2^k` it
trips its own `ASSERT(q > 1)` after the strip; that pre-existing hard abort is left alone.

## Other checks

* Full `makemake.sh avx2` build of the tree: clean, 0 errors.
* `./Mlucas -fft 1024 -iters 100 -radset 0` → `Res64: 95AFD7A5269F14F6`, and the built-in IMUL self-test
  (which exercises `imul_macro1.h`, i.e. #167) passes. Smoke test only — the changed routines are not on
  the FFT path.
* `twopmmodq64_q4` (`twopmodq.c:1339`) is **not** affected: it `ASSERT`s an odd modulus and has no nshift
  path at all.

Verified against a GMP oracle across 5 sweep modes.
