### PR TITLE
KNL build mode: produce a binary that runs on a Xeon Phi, or refuse to build; test it under SDE in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,12 @@ jobs:
     # in GCC 15. The build degrades gracefully without them (see makemake.sh), but 24.04's GCC 13 is
     # the last stock toolchain that can target Knights Landing properly, so test with it while it lasts.
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        cc: [gcc, clang]
+      fail-fast: false
+    env:
+      CC: ${{ matrix.cc }}
     steps:
     - uses: actions/checkout@v7
     - name: Install
@@ -223,15 +229,13 @@ jobs:
         tar -xf sde-external-8.69.1-2021-07-18-lin.tar.bz2
     - name: Before script
       run: |
-        gcc --version
+        $CC --version
         ./sde-external-8.69.1-2021-07-18-lin/sde64 --version
     - name: Build
       run: |
-        set -o pipefail
         bash -e -o pipefail -- makemake.sh avx512_knl
     - name: Self-test under emulated Knights Landing
       run: |
-        set -o pipefail
         # -knl sets both CPUID and SDE's chip check, so any instruction outside the KNL ISA aborts
         # the run rather than silently working on the AVX-512 host. That is the point of this job:
         # an 'avx512' (Skylake-SP) build dies here on kmovd, which is exactly the regression to catch.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,46 @@ jobs:
             done
         done
 
+  Linux-KNL:
+    name: Mlucas KNL
+
+    # Pinned, not 'latest': -march=knl and the ER/PF extensions were deprecated in GCC 14 and removed
+    # in GCC 15. The build degrades gracefully without them (see makemake.sh), but 24.04's GCC 13 is
+    # the last stock toolchain that can target Knights Landing properly, so test with it while it lasts.
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v7
+    - name: Install
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y libgmp-dev
+    - name: Install Intel SDE
+      run: |
+        # Intel SDE 9.38 and later removed the -knl/-knm knobs, and Intel does not host archived
+        # releases, so pin an older kit. This is the mirror the xsimd project uses for its own CI.
+        wget -nv 'https://github.com/xtensor-stack/xsimd-testing-resources/releases/download/1.0.0/sde-external-8.69.1-2021-07-18-lin.tar.bz2'
+        tar -xf sde-external-8.69.1-2021-07-18-lin.tar.bz2
+    - name: Before script
+      run: |
+        gcc --version
+        ./sde-external-8.69.1-2021-07-18-lin/sde64 --version
+    - name: Build
+      run: |
+        set -o pipefail
+        bash -e -o pipefail -- makemake.sh avx512_knl
+    - name: Self-test under emulated Knights Landing
+      run: |
+        set -o pipefail
+        # -knl sets both CPUID and SDE's chip check, so any instruction outside the KNL ISA aborts
+        # the run rather than silently working on the AVX-512 host. That is the point of this job:
+        # an 'avx512' (Skylake-SP) build dies here on kmovd, which is exactly the regression to catch.
+        cd obj_avx512_knl
+        ../sde-external-8.69.1-2021-07-18-lin/sde64 -knl -- ./Mlucas -s tt 2>&1 | tee knl.log
+        st=${PIPESTATUS[0]}
+        echo "Self-test exit status: $st"
+        # 0 = ok, 2 = too few usable radix sets at some length (informational). Anything else fails.
+        if (( st != 0 && st != 2 )); then exit "$st"; fi
+
   ASan-Linux:
     name: AddressSanitizer Linux
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,6 +314,12 @@ jobs:
     # in GCC 15. The build degrades gracefully without them (see makemake.sh), but 24.04's GCC 13 is
     # the last stock toolchain that can target Knights Landing properly, so test with it while it lasts.
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        cc: [gcc, clang]
+      fail-fast: false
+    env:
+      CC: ${{ matrix.cc }}
     steps:
     - uses: actions/checkout@v7
     - name: Install
@@ -328,15 +334,13 @@ jobs:
         tar -xf sde-external-8.69.1-2021-07-18-lin.tar.bz2
     - name: Before script
       run: |
-        gcc --version
+        $CC --version
         ./sde-external-8.69.1-2021-07-18-lin/sde64 --version
     - name: Build
       run: |
-        set -o pipefail
         bash -e -o pipefail -- makemake.sh avx512_knl
     - name: Self-test under emulated Knights Landing
       run: |
-        set -o pipefail
         # -knl sets both CPUID and SDE's chip check, so any instruction outside the KNL ISA aborts
         # the run rather than silently working on the AVX-512 host. That is the point of this job:
         # an 'avx512' (Skylake-SP) build dies here on kmovd, which is exactly the regression to catch.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,6 +307,46 @@ jobs:
           ${{ github.workspace }}
           !mpss-*
 
+  Linux-KNL:
+    name: Mlucas KNL
+
+    # Pinned, not 'latest': -march=knl and the ER/PF extensions were deprecated in GCC 14 and removed
+    # in GCC 15. The build degrades gracefully without them (see makemake.sh), but 24.04's GCC 13 is
+    # the last stock toolchain that can target Knights Landing properly, so test with it while it lasts.
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v7
+    - name: Install
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y libgmp-dev
+    - name: Install Intel SDE
+      run: |
+        # Intel SDE 9.38 and later removed the -knl/-knm knobs, and Intel does not host archived
+        # releases, so pin an older kit. This is the mirror the xsimd project uses for its own CI.
+        wget -nv 'https://github.com/xtensor-stack/xsimd-testing-resources/releases/download/1.0.0/sde-external-8.69.1-2021-07-18-lin.tar.bz2'
+        tar -xf sde-external-8.69.1-2021-07-18-lin.tar.bz2
+    - name: Before script
+      run: |
+        gcc --version
+        ./sde-external-8.69.1-2021-07-18-lin/sde64 --version
+    - name: Build
+      run: |
+        set -o pipefail
+        bash -e -o pipefail -- makemake.sh avx512_knl
+    - name: Self-test under emulated Knights Landing
+      run: |
+        set -o pipefail
+        # -knl sets both CPUID and SDE's chip check, so any instruction outside the KNL ISA aborts
+        # the run rather than silently working on the AVX-512 host. That is the point of this job:
+        # an 'avx512' (Skylake-SP) build dies here on kmovd, which is exactly the regression to catch.
+        cd obj_avx512_knl
+        ../sde-external-8.69.1-2021-07-18-lin/sde64 -knl -- ./Mlucas -s tt 2>&1 | tee knl.log
+        st=${PIPESTATUS[0]}
+        echo "Self-test exit status: $st"
+        # 0 = ok, 2 = too few usable radix sets at some length (informational). Anything else fails.
+        if (( st != 0 && st != 2 )); then exit "$st"; fi
+
   ASan-Linux:
     name: AddressSanitizer Linux
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,9 +310,11 @@ jobs:
   Linux-KNL:
     name: Mlucas KNL
 
-    # Pinned, not 'latest': -march=knl and the ER/PF extensions were deprecated in GCC 14 and removed
-    # in GCC 15. The build degrades gracefully without them (see makemake.sh), but 24.04's GCC 13 is
-    # the last stock toolchain that can target Knights Landing properly, so test with it while it lasts.
+    # Pinned, not 'latest': GCC 13 is the last GCC that can target Knights Landing at all. GCC 14
+    # accepts -march=knl but generates AVX512VL anyway, and GCC 15 removed the flag; makemake.sh
+    # refuses both rather than emit a binary that dies on the first illegal instruction (see the
+    # measured table there). 24.04 ships GCC 13 and Clang 18, both of which pass, so pin to it -
+    # on a newer image this job would correctly but unhelpfully refuse to build.
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,14 @@ jobs:
       fail-fast: false
     env:
       CC: ${{ matrix.cc }}
+      # Intel SDE 9.38 and later removed the -knl/-knm knobs, and Intel no longer serves any
+      # pre-9.38 build -- downloadmirror.intel.com returns 403 for 9.24, 9.27 and 9.33 alike.
+      # 9.24.0 is therefore hosted as a release asset on this repository, byte-identical to
+      # Intel's original and redistributed under the Intel Simplified Software License, which
+      # permits redistribution without modification. See the ci-intel-sde-9.24.0 release.
+      SDE_URL: https://github.com/primesearch/Mlucas/releases/download/ci-intel-sde-9.24.0/sde-external-9.24.0-2023-07-13-lin.tar.xz
+      SDE_SHA256: 87a36b821d0fb8cbcbfeffa359753445f951b225b5f4747689ae16417c4f04ac
+      SDE_DIR: sde-external-9.24.0-2023-07-13-lin
     steps:
     - uses: actions/checkout@v7
     - name: Install
@@ -328,14 +336,16 @@ jobs:
         sudo apt-get install -y libgmp-dev
     - name: Install Intel SDE
       run: |
-        # Intel SDE 9.38 and later removed the -knl/-knm knobs, and Intel does not host archived
-        # releases, so pin an older kit. This is the mirror the xsimd project uses for its own CI.
-        wget -nv 'https://github.com/xtensor-stack/xsimd-testing-resources/releases/download/1.0.0/sde-external-8.69.1-2021-07-18-lin.tar.bz2'
-        tar -xf sde-external-8.69.1-2021-07-18-lin.tar.bz2
+        curl -fsSL -o sde.tar.xz "$SDE_URL"
+        # Verify before unpacking: the pin is what makes a hosted binary trustworthy.
+        echo "$SDE_SHA256  sde.tar.xz" | sha256sum -c -
+        mkdir -p "$SDE_DIR"
+        tar -xf sde.tar.xz -C "$SDE_DIR" --strip-components=1
+        rm -f sde.tar.xz
     - name: Before script
       run: |
         $CC --version
-        ./sde-external-8.69.1-2021-07-18-lin/sde64 --version
+        "./$SDE_DIR/sde64" --version
     - name: Build
       run: |
         bash -e -o pipefail -- makemake.sh avx512_knl
@@ -345,7 +355,7 @@ jobs:
         # the run rather than silently working on the AVX-512 host. That is the point of this job:
         # an 'avx512' (Skylake-SP) build dies here on kmovd, which is exactly the regression to catch.
         cd obj_avx512_knl
-        ../sde-external-8.69.1-2021-07-18-lin/sde64 -knl -- ./Mlucas -s tt 2>&1 | tee knl.log
+        "../$SDE_DIR/sde64" -knl -- ./Mlucas -s tt 2>&1 | tee knl.log
         st=${PIPESTATUS[0]}
         echo "Self-test exit status: $st"
         # 0 = ok, 2 = too few usable radix sets at some length (informational). Anything else fails.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,10 +332,6 @@ jobs:
       SDE_DIR: sde-external-9.24.0-2023-07-13-lin
     steps:
     - uses: actions/checkout@v7
-    - name: Install
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y libgmp-dev
     - name: Install Intel SDE
       run: |
         curl -fsSL -o sde.tar.xz "$SDE_URL"
@@ -351,17 +347,33 @@ jobs:
     - name: Build
       run: |
         bash -e -o pipefail -- makemake.sh avx512_knl
+        # Build Mfactor for KNL too - it has its own AVX-512 sieve, a distinct body of code from
+        # Mlucas, so it is worth compile-covering here. Not run yet: under SDE it segfaults on a
+        # tiny exponent because of the AVX-512 small-p sieve bug that #114 fixes. With #114 merged
+        # in locally the same binary completes '-m 521 -bmax 20' cleanly, so the run step can be
+        # added once that lands.
+        bash -e -o pipefail -- makemake.sh mfac avx512_knl
     - name: Self-test under emulated Knights Landing
       run: |
         # -knl sets both CPUID and SDE's chip check, so any instruction outside the KNL ISA aborts
         # the run rather than silently working on the AVX-512 host. That is the point of this job:
         # an 'avx512' (Skylake-SP) build dies here on kmovd, which is exactly the regression to catch.
+        #
+        # Threads are worth using despite the emulator: measured under 'sde64 -knl', '-s t' takes
+        # 810s on one core against 351s on four, a 2.3x speedup. ('-s tt' on its own shows almost
+        # none, but it is short enough to be dominated by startup.) That is what makes 'tiny'
+        # affordable here, and it roughly triples the FFT lengths covered: 16K-240K atop 2K-15K.
         cd obj_avx512_knl
-        "../$SDE_DIR/sde64" -knl -- ./Mlucas -s tt 2>&1 | tee knl.log
-        st=${PIPESTATUS[0]}
-        echo "Self-test exit status: $st"
-        # 0 = ok, 2 = too few usable radix sets at some length (informational). Anything else fails.
-        if (( st != 0 && st != 2 )); then exit "$st"; fi
+        CPUS="0:$(( $(nproc --all) - 1 ))"
+        # No pipe, so no pipefail needed and no knl.log: this job uploads no artifacts, and the
+        # run's output goes to the workflow log either way.
+        for s in tt t; do
+          st=0
+          "../$SDE_DIR/sde64" -knl -- ./Mlucas -s $s -cpu "$CPUS" || st=$?
+          echo "Self-test -s $s exit status: $st"
+          # 0 = ok, 2 = too few usable radix sets at some length (informational). Else fail.
+          if (( st != 0 && st != 2 )); then exit "$st"; fi
+        done
 
   ASan-Linux:
     name: AddressSanitizer Linux

--- a/makemake.sh
+++ b/makemake.sh
@@ -255,9 +255,22 @@ if [[ ${#MODES[*]} -eq 1 ]]; then
 			ARGS+=(-DUSE_AVX512 -march=skylake-avx512 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mavx512vl -mfma)
 			;;
 		avx512_knl)
-			echo "Building for avx512_knl SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
-			echo "Warning: The 'avx512_knl' option is deprecated, use 'avx512' instead."
-			ARGS+=(-DUSE_AVX512 -march=knl -mavx512f -mavx512cd -mavx512er -mfma)
+			echo "Building for AVX-512 on Knights Landing / Knights Mill in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
+			# NOT interchangeable with the 'avx512' mode: KNL/KNM implement only AVX512F + CD (+ ER/PF),
+			# with no DQ, BW or VL. An 'avx512' build targets Skylake-SP and will SIGILL on a Xeon Phi -
+			# the first thing it hits is 'kmovd' (BW; KNL has only the 16-bit 'kmovw'), and any
+			# EVEX-encoded 256-bit op would need VL. So keep this mode, and keep it free of dq/bw/vl.
+			ARGS+=(-DUSE_AVX512 -mavx512f -mavx512cd -mfma)
+			# -march=knl and the ER/PF extensions were deprecated in GCC 14, removed in GCC 15, and are
+			# gone from recent Clang too. The build does not need them - it compiles and links with
+			# just f/cd/fma - so probe for each and carry on without whichever the toolchain has
+			# dropped, rather than failing outright on a modern compiler:
+			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
+			try_flag -march=knl && ARGS+=(-march=knl)
+			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
+			try_flag -mavx512er && ARGS+=(-mavx512er)
+			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
+			try_flag -mavx512pf && ARGS+=(-mavx512pf)
 			;;
 		avx512)
 			echo "Building for AVX512 SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"

--- a/makemake.sh
+++ b/makemake.sh
@@ -265,12 +265,17 @@ if [[ ${#MODES[*]} -eq 1 ]]; then
 			# gone from recent Clang too. The build does not need them - it compiles and links with
 			# just f/cd/fma - so probe for each and carry on without whichever the toolchain has
 			# dropped, rather than failing outright on a modern compiler:
-			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
-			try_flag -march=knl && ARGS+=(-march=knl)
-			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
-			try_flag -mavx512er && ARGS+=(-mavx512er)
-			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
-			try_flag -mavx512pf && ARGS+=(-mavx512pf)
+			# Warn per dropped flag: the build still runs on KNL/KNM without them, but it is
+			# tuned for a generic AVX-512 target and ER/PF-backed reciprocal and prefetch
+			# sequences are unavailable, so it will be slower than the user is expecting.
+			for knl_flag in -march=knl -mavx512er -mavx512pf; do
+				# shellcheck disable=SC2310 # a failed probe is an answer, not an error
+				if try_flag "$knl_flag"; then
+					ARGS+=("$knl_flag")
+				else
+					echo "Warning: ${CC:-gcc} does not support $knl_flag - building without it. The result will still run on Knights Landing/Mill, but slower than a toolchain retaining Knights support would produce." >&2
+				fi
+			done
 			;;
 		avx512)
 			echo "Building for AVX512 SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"

--- a/makemake.sh
+++ b/makemake.sh
@@ -152,6 +152,29 @@ try_lto() {
 	) >/dev/null 2>&1
 }
 
+# Returns success iff $CC, given the KNL flag set passed as arguments, generates no AVX512VL
+# instructions for a real Mlucas translation unit; 1 if it emits some; 2 if the check could not be
+# run (no objdump, or the compile failed). Probing the generated code is the only reliable test:
+# accepting -march=knl is necessary but NOT sufficient, since GCC 14 takes the flag and still emits
+# 256-bit EVEX ops, which Knights Landing cannot execute. radix48_ditN_cy_dif1.c is used because it
+# is one of the smaller translation units that still reproduces this (~1s to compile).
+knl_vl_clean() {
+	local cc=${CC:-gcc} od tmpdir n src
+	src=$(dirname -- "$0")/src
+	od=$(command -v objdump || command -v llvm-objdump) || return 2
+	[[ -r $src/radix48_ditN_cy_dif1.c ]] || return 2
+	tmpdir=$(mktemp -d) || return 2
+	trap 'rm -rf "$tmpdir"' RETURN
+	# -DINCLUDE_GMP=0 so the probe does not need the GMP headers installed; it only inspects
+	# vector codegen in an FFT kernel, which GMP has no bearing on.
+	"$cc" -c -O3 -w -D_GNU_SOURCE -DUSE_THREADS -DUSE_AVX512 -DINCLUDE_GMP=0 "$@" \
+		-I "$src" -o "$tmpdir/probe.o" "$src/radix48_ditN_cy_dif1.c" >/dev/null 2>&1 || return 2
+	# 256-bit EVEX inserts/extracts (no zmm operand) need AVX512VL; the 512-bit forms do not.
+	n=$("$od" -d "$tmpdir/probe.o" 2>/dev/null \
+		| grep -E 'vinsert[fi]32x4|vextract[fi]32x4' | grep -cv zmm) || n=0
+	[[ $n -eq 0 ]]
+}
+
 if [[ ! $OSTYPE == darwin* ]]; then
 	LD_ARGS+=(-lm -lpthread)
 fi
@@ -321,33 +344,53 @@ if [[ ${#MODES[*]} -eq 1 ]]; then
 			# the first thing it hits is 'kmovd' (BW; KNL has only the 16-bit 'kmovw'), and any
 			# EVEX-encoded 256-bit op would need VL. So keep this mode, and keep it free of dq/bw/vl.
 			ARGS+=(-DUSE_AVX512 -mavx512f -mavx512cd -mfma)
-			# -march=knl was deprecated in GCC 14 and removed in GCC 15, and is gone from recent
-			# Clang too. Without it the build still compiles and links against f/cd/fma alone, but
-			# the result is NOT KNL-safe: GCC 15 and 16 then emit AVX512VL encodings, which Knights
-			# Landing does not implement. Measured by compiling Mlucas.c with -mavx512f -mavx512cd
-			# -mfma and counting EVEX-256 ops with a ymm destination (vinserti32x4), which need VL:
-			#     gcc 13.3 -> 0     gcc 15.3 -> 19     gcc 16.2 -> 3
-			# and gcc 13 emits none whether or not -march=knl is passed, so this is a property of
-			# the newer compilers rather than of the missing flag. -mno-avx512vl does not suppress
-			# them. Under SDE the gcc-16 build dies on the first one:
+			# Targeting KNL needs -march=knl, but that flag is not sufficient on its own, so the real
+			# test is the generated code. Counting 256-bit EVEX inserts/extracts (AVX512VL, which KNL does
+			# not implement) over a representative set of translation units:
+			#
+			#   compiler          -march=knl   -mavx512er   VL ops base / with -march=knl
+			#   gcc 11.4 - 13.3       yes          yes            0    /   0
+			#   gcc 14.4              yes          yes          463    / 149   <-- flag accepted, still unsafe
+			#   gcc 15.3              no           no           202    / n/a
+			#   gcc 16.2              no           no           186    / n/a
+			#   clang 14 - 18         yes          yes            0    /   0
+			#   clang 19.1, 22.1      yes          no             0    /   0
+			#
+			# GCC 14 is why this probes the codegen rather than the flag: it accepts -march=knl and still
+			# emits AVX512VL, and -march=knl actually increases the count rather than suppressing it
+			# (a GCC bug in its own right - -mno-avx512vl does not suppress them either, and
+			# __AVX512VL__ is not even defined). Confirmed end to end under Intel SDE: a gcc-14 build that
+			# passes the flag check dies on the first one,
 			#     SDE-ERROR: Executed instruction not valid for specified chip (KNL):
-			#       vinserti32x4 ymm5, ymm1, xmm0, 0x1     ernstMain, Mlucas.c:378
-			# So refuse the build rather than hand back a binary that cannot run on the target it
-			# names. A toolchain that still has -march=knl is exactly one old enough to be safe:
+			#       vinsertf32x4 ymm0, ymm0, xmm1, 0x1     radix40_ditN_cy_dif1
+			# while a clang-built one runs to a correct residue on an emulated KNL.
 			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 			if ! try_flag -march=knl; then
-				echo "Error: ${CC:-gcc} does not support -march=knl, so it cannot target Knights Landing/Mill. Compilers that dropped the flag (GCC >= 15, recent Clang) also emit AVX512VL instructions that KNL cannot execute, so the resulting binary would build and then die on the first one. Use GCC <= 14 for this build mode, or build with 'avx512' instead if you are targeting Skylake-SP or later." >&2
+				echo "Error: ${CC:-gcc} does not support -march=knl, so it cannot target Knights Landing/Mill. GCC removed the flag in 15. Use GCC <= 13 or Clang for this build mode, or build with 'avx512' instead if you are targeting Skylake-SP or later." >&2
 				exit 1
 			fi
 			ARGS+=(-march=knl)
-			# ER/PF are performance-only - reciprocal and prefetch sequences - so a toolchain that
-			# has -march=knl but has dropped these is still correct, just slower. Warn and continue:
+			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
+			# 'set -e' is in force, so capture the status via '||' rather than a bare call:
+			knl_vl_status=0
+			knl_vl_clean -mavx512f -mavx512cd -mfma -march=knl || knl_vl_status=$?
+			if [[ $knl_vl_status -eq 1 ]]; then
+				echo "Error: ${CC:-gcc} accepts -march=knl but still generates AVX512VL instructions, which Knights Landing/Mill cannot execute - the binary would build and then die on the first one. GCC 14 is known to do this. Use GCC <= 13 or Clang for this build mode." >&2
+				exit 1
+			elif [[ $knl_vl_status -eq 2 ]]; then
+				echo "Warning: could not verify that ${CC:-gcc} avoids AVX512VL for this target (no objdump, or the probe failed to compile). Proceeding on the strength of -march=knl alone; if the resulting binary dies on a Xeon Phi with an illegal-instruction fault, this is why." >&2
+			fi
+			# ER/PF are a separate axis from -march=knl, not implied by it: Clang 19 and later still accept
+			# -march=knl but have dropped -mavx512er/-mavx512pf and do not define __AVX512ER__. That is safe
+			# here because the only ER code in the tree - the VRCP28PD block in mi64_modmul53_batch(), gated
+			# on __AVX512ER__ - is unreachable: its sole caller sits inside a commented-out test harness. So
+			# a toolchain without ER/PF builds a functionally identical binary. Warn rather than refuse:
 			for knl_flag in -mavx512er -mavx512pf; do
 				# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 				if try_flag "$knl_flag"; then
 					ARGS+=("$knl_flag")
 				else
-					echo "Warning: ${CC:-gcc} does not support $knl_flag - building without it. The result still runs on Knights Landing/Mill, but the ER/PF-backed reciprocal and prefetch sequences are unavailable, so it will be slower." >&2
+					echo "Warning: ${CC:-gcc} does not support $knl_flag - building without it. The result still runs on Knights Landing/Mill; the only code this gates is currently unreachable, so the binary is functionally the same." >&2
 				fi
 			done
 			;;

--- a/makemake.sh
+++ b/makemake.sh
@@ -321,19 +321,33 @@ if [[ ${#MODES[*]} -eq 1 ]]; then
 			# the first thing it hits is 'kmovd' (BW; KNL has only the 16-bit 'kmovw'), and any
 			# EVEX-encoded 256-bit op would need VL. So keep this mode, and keep it free of dq/bw/vl.
 			ARGS+=(-DUSE_AVX512 -mavx512f -mavx512cd -mfma)
-			# -march=knl and the ER/PF extensions were deprecated in GCC 14, removed in GCC 15, and are
-			# gone from recent Clang too. The build does not need them - it compiles and links with
-			# just f/cd/fma - so probe for each and carry on without whichever the toolchain has
-			# dropped, rather than failing outright on a modern compiler:
-			# Warn per dropped flag: the build still runs on KNL/KNM without them, but it is
-			# tuned for a generic AVX-512 target and ER/PF-backed reciprocal and prefetch
-			# sequences are unavailable, so it will be slower than the user is expecting.
-			for knl_flag in -march=knl -mavx512er -mavx512pf; do
+			# -march=knl was deprecated in GCC 14 and removed in GCC 15, and is gone from recent
+			# Clang too. Without it the build still compiles and links against f/cd/fma alone, but
+			# the result is NOT KNL-safe: GCC 15 and 16 then emit AVX512VL encodings, which Knights
+			# Landing does not implement. Measured by compiling Mlucas.c with -mavx512f -mavx512cd
+			# -mfma and counting EVEX-256 ops with a ymm destination (vinserti32x4), which need VL:
+			#     gcc 13.3 -> 0     gcc 15.3 -> 19     gcc 16.2 -> 3
+			# and gcc 13 emits none whether or not -march=knl is passed, so this is a property of
+			# the newer compilers rather than of the missing flag. -mno-avx512vl does not suppress
+			# them. Under SDE the gcc-16 build dies on the first one:
+			#     SDE-ERROR: Executed instruction not valid for specified chip (KNL):
+			#       vinserti32x4 ymm5, ymm1, xmm0, 0x1     ernstMain, Mlucas.c:378
+			# So refuse the build rather than hand back a binary that cannot run on the target it
+			# names. A toolchain that still has -march=knl is exactly one old enough to be safe:
+			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
+			if ! try_flag -march=knl; then
+				echo "Error: ${CC:-gcc} does not support -march=knl, so it cannot target Knights Landing/Mill. Compilers that dropped the flag (GCC >= 15, recent Clang) also emit AVX512VL instructions that KNL cannot execute, so the resulting binary would build and then die on the first one. Use GCC <= 14 for this build mode, or build with 'avx512' instead if you are targeting Skylake-SP or later." >&2
+				exit 1
+			fi
+			ARGS+=(-march=knl)
+			# ER/PF are performance-only - reciprocal and prefetch sequences - so a toolchain that
+			# has -march=knl but has dropped these is still correct, just slower. Warn and continue:
+			for knl_flag in -mavx512er -mavx512pf; do
 				# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 				if try_flag "$knl_flag"; then
 					ARGS+=("$knl_flag")
 				else
-					echo "Warning: ${CC:-gcc} does not support $knl_flag - building without it. The result will still run on Knights Landing/Mill, but slower than a toolchain retaining Knights support would produce." >&2
+					echo "Warning: ${CC:-gcc} does not support $knl_flag - building without it. The result still runs on Knights Landing/Mill, but the ER/PF-backed reciprocal and prefetch sequences are unavailable, so it will be slower." >&2
 				fi
 			done
 			;;

--- a/makemake.sh
+++ b/makemake.sh
@@ -325,12 +325,17 @@ if [[ ${#MODES[*]} -eq 1 ]]; then
 			# gone from recent Clang too. The build does not need them - it compiles and links with
 			# just f/cd/fma - so probe for each and carry on without whichever the toolchain has
 			# dropped, rather than failing outright on a modern compiler:
-			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
-			try_flag -march=knl && ARGS+=(-march=knl)
-			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
-			try_flag -mavx512er && ARGS+=(-mavx512er)
-			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
-			try_flag -mavx512pf && ARGS+=(-mavx512pf)
+			# Warn per dropped flag: the build still runs on KNL/KNM without them, but it is
+			# tuned for a generic AVX-512 target and ER/PF-backed reciprocal and prefetch
+			# sequences are unavailable, so it will be slower than the user is expecting.
+			for knl_flag in -march=knl -mavx512er -mavx512pf; do
+				# shellcheck disable=SC2310 # a failed probe is an answer, not an error
+				if try_flag "$knl_flag"; then
+					ARGS+=("$knl_flag")
+				else
+					echo "Warning: ${CC:-gcc} does not support $knl_flag - building without it. The result will still run on Knights Landing/Mill, but slower than a toolchain retaining Knights support would produce." >&2
+				fi
+			done
 			;;
 		avx512)
 			echo "Building for AVX512 SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"

--- a/makemake.sh
+++ b/makemake.sh
@@ -315,8 +315,22 @@ if [[ ${#MODES[*]} -eq 1 ]]; then
 			ARGS+=(-DUSE_AVX512 -march=skylake-avx512 -mavx512f -mavx512cd -mfma)
 			;;
 		avx512_knl)
-			echo "Building for avx512_knl SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
-			ARGS+=(-DUSE_AVX512 -march=knl -mavx512f -mavx512cd -mavx512er -mfma)
+			echo "Building for AVX-512 on Knights Landing / Knights Mill in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
+			# NOT interchangeable with the 'avx512' mode: KNL/KNM implement only AVX512F + CD (+ ER/PF),
+			# with no DQ, BW or VL. An 'avx512' build targets Skylake-SP and will SIGILL on a Xeon Phi -
+			# the first thing it hits is 'kmovd' (BW; KNL has only the 16-bit 'kmovw'), and any
+			# EVEX-encoded 256-bit op would need VL. So keep this mode, and keep it free of dq/bw/vl.
+			ARGS+=(-DUSE_AVX512 -mavx512f -mavx512cd -mfma)
+			# -march=knl and the ER/PF extensions were deprecated in GCC 14, removed in GCC 15, and are
+			# gone from recent Clang too. The build does not need them - it compiles and links with
+			# just f/cd/fma - so probe for each and carry on without whichever the toolchain has
+			# dropped, rather than failing outright on a modern compiler:
+			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
+			try_flag -march=knl && ARGS+=(-march=knl)
+			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
+			try_flag -mavx512er && ARGS+=(-mavx512er)
+			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
+			try_flag -mavx512pf && ARGS+=(-mavx512pf)
 			;;
 		avx512)
 			echo "Building for AVX512 SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"

--- a/makemake.sh
+++ b/makemake.sh
@@ -153,26 +153,25 @@ try_lto() {
 }
 
 # Returns success iff $CC, given the KNL flag set passed as arguments, generates no AVX512VL
-# instructions for a real Mlucas translation unit; 1 if it emits some; 2 if the check could not be
-# run (no objdump, or the compile failed). Probing the generated code is the only reliable test:
-# accepting -march=knl is necessary but NOT sufficient, since GCC 14 takes the flag and still emits
-# 256-bit EVEX ops, which Knights Landing cannot execute. radix48_ditN_cy_dif1.c is used because it
-# is one of the smaller translation units that still reproduces this (~1s to compile).
+# instructions for a real Mlucas translation unit; 1 if it emits some; 2 if the probe could not be
+# run at all. Probing the generated code is the only reliable test: accepting -march=knl is
+# necessary but NOT sufficient, since GCC 14 takes the flag and still emits 256-bit EVEX ops, which
+# Knights Landing cannot execute. Compiling to assembly with -S keeps this to the compiler alone -
+# no objdump, no assembler, no object file - and is quicker than -c into the bargain.
+# radix48_ditN_cy_dif1.c is used because it is one of the smaller translation units that still
+# reproduces this. -DINCLUDE_GMP=0 so the probe does not need the GMP headers installed; it only
+# inspects vector codegen in an FFT kernel, which GMP has no bearing on.
 knl_vl_clean() {
-	local cc=${CC:-gcc} od tmpdir n src
+	local cc=${CC:-gcc} tmpdir src
 	src=$(dirname -- "$0")/src
-	od=$(command -v objdump || command -v llvm-objdump) || return 2
 	[[ -r $src/radix48_ditN_cy_dif1.c ]] || return 2
 	tmpdir=$(mktemp -d) || return 2
 	trap 'rm -rf "$tmpdir"' RETURN
-	# -DINCLUDE_GMP=0 so the probe does not need the GMP headers installed; it only inspects
-	# vector codegen in an FFT kernel, which GMP has no bearing on.
-	"$cc" -c -O3 -w -D_GNU_SOURCE -DUSE_THREADS -DUSE_AVX512 -DINCLUDE_GMP=0 "$@" \
-		-I "$src" -o "$tmpdir/probe.o" "$src/radix48_ditN_cy_dif1.c" >/dev/null 2>&1 || return 2
-	# 256-bit EVEX inserts/extracts (no zmm operand) need AVX512VL; the 512-bit forms do not.
-	n=$("$od" -d "$tmpdir/probe.o" 2>/dev/null \
-		| grep -E 'vinsert[fi]32x4|vextract[fi]32x4' | grep -cv zmm) || n=0
-	[[ $n -eq 0 ]]
+	"$cc" -S -O3 -w -D_GNU_SOURCE -DUSE_THREADS -DUSE_AVX512 -DINCLUDE_GMP=0 "$@" \
+		-I "$src" -o "$tmpdir/probe.s" "$src/radix48_ditN_cy_dif1.c" >/dev/null 2>&1 || return 2
+	# A 256-bit EVEX insert/extract - one naming a ymm register but no zmm - needs AVX512VL.
+	# The 512-bit forms name a zmm and are fine on KNL.
+	! grep -E 'vinsert[fi]32x4|vextract[fi]32x4' "$tmpdir/probe.s" | grep ymm | grep -qv zmm
 }
 
 if [[ ! $OSTYPE == darwin* ]]; then
@@ -364,13 +363,11 @@ if [[ ${#MODES[*]} -eq 1 ]]; then
 			#     SDE-ERROR: Executed instruction not valid for specified chip (KNL):
 			#       vinsertf32x4 ymm0, ymm0, xmm1, 0x1     radix40_ditN_cy_dif1
 			# while a clang-built one runs to a correct residue on an emulated KNL.
-			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 			if ! try_flag -march=knl; then
 				echo "Error: ${CC:-gcc} does not support -march=knl, so it cannot target Knights Landing/Mill. GCC removed the flag in 15. Use GCC <= 13 or Clang for this build mode, or build with 'avx512' instead if you are targeting Skylake-SP or later." >&2
 				exit 1
 			fi
 			ARGS+=(-march=knl)
-			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 			# 'set -e' is in force, so capture the status via '||' rather than a bare call:
 			knl_vl_status=0
 			knl_vl_clean -mavx512f -mavx512cd -mfma -march=knl || knl_vl_status=$?
@@ -378,18 +375,8 @@ if [[ ${#MODES[*]} -eq 1 ]]; then
 				echo "Error: ${CC:-gcc} accepts -march=knl but still generates AVX512VL instructions, which Knights Landing/Mill cannot execute - the binary would build and then die on the first one. GCC 14 is known to do this. Use GCC <= 13 or Clang for this build mode." >&2
 				exit 1
 			elif [[ $knl_vl_status -eq 2 ]]; then
-				# The direct check could not run (no objdump, or the probe would not compile). Rather
-				# than build something that may not run, fall back to what has been measured: every GCC
-				# from 14 on emits AVX512VL here, so refuse those. This is a stand-in for the codegen
-				# check, not a replacement - anything else only gets a warning, since a version number
-				# is exactly the kind of assumption the probe exists to avoid.
-				knl_cc_id=$("${CC:-gcc}" --version 2>/dev/null | head -1)
-				knl_cc_major=$("${CC:-gcc}" -dumpversion 2>/dev/null | cut -d. -f1)
-				if [[ $knl_cc_id != *[Cc]lang* && ${knl_cc_major:-0} =~ ^[0-9]+$ && ${knl_cc_major:-0} -ge 14 ]]; then
-					echo "Error: cannot verify that ${CC:-gcc} avoids AVX512VL for this target (no objdump, or the probe failed to compile), and GCC $knl_cc_major is known to generate it regardless of -march=knl, which Knights Landing/Mill cannot execute. Refusing rather than building a binary that would die on the first one. Use GCC <= 13 or Clang for this build mode, or install binutils so the check can run." >&2
-					exit 1
-				fi
-				echo "Warning: could not verify that ${CC:-gcc} avoids AVX512VL for this target (no objdump, or the probe failed to compile). Proceeding on the strength of -march=knl alone; if the resulting binary dies on a Xeon Phi with an illegal-instruction fault, this is why." >&2
+				echo "Error: could not run the AVX512VL codegen check - ${CC:-gcc} failed to compile the probe translation unit. Refusing rather than guessing; re-run with the compiler in a working state." >&2
+				exit 1
 			fi
 			# ER/PF are a separate axis from -march=knl, not implied by it: Clang 19 and later still accept
 			# -march=knl but have dropped -mavx512er/-mavx512pf and do not define __AVX512ER__. That is safe
@@ -397,8 +384,7 @@ if [[ ${#MODES[*]} -eq 1 ]]; then
 			# on __AVX512ER__ - is unreachable: its sole caller sits inside a commented-out test harness. So
 			# a toolchain without ER/PF builds a functionally identical binary. Warn rather than refuse:
 			for knl_flag in -mavx512er -mavx512pf; do
-				# shellcheck disable=SC2310 # a failed probe is an answer, not an error
-				if try_flag "$knl_flag"; then
+					if try_flag "$knl_flag"; then
 					ARGS+=("$knl_flag")
 				else
 					echo "Warning: ${CC:-gcc} does not support $knl_flag - building without it. The result still runs on Knights Landing/Mill; the only code this gates is currently unreachable, so the binary is functionally the same." >&2

--- a/makemake.sh
+++ b/makemake.sh
@@ -378,6 +378,17 @@ if [[ ${#MODES[*]} -eq 1 ]]; then
 				echo "Error: ${CC:-gcc} accepts -march=knl but still generates AVX512VL instructions, which Knights Landing/Mill cannot execute - the binary would build and then die on the first one. GCC 14 is known to do this. Use GCC <= 13 or Clang for this build mode." >&2
 				exit 1
 			elif [[ $knl_vl_status -eq 2 ]]; then
+				# The direct check could not run (no objdump, or the probe would not compile). Rather
+				# than build something that may not run, fall back to what has been measured: every GCC
+				# from 14 on emits AVX512VL here, so refuse those. This is a stand-in for the codegen
+				# check, not a replacement - anything else only gets a warning, since a version number
+				# is exactly the kind of assumption the probe exists to avoid.
+				knl_cc_id=$("${CC:-gcc}" --version 2>/dev/null | head -1)
+				knl_cc_major=$("${CC:-gcc}" -dumpversion 2>/dev/null | cut -d. -f1)
+				if [[ $knl_cc_id != *[Cc]lang* && ${knl_cc_major:-0} =~ ^[0-9]+$ && ${knl_cc_major:-0} -ge 14 ]]; then
+					echo "Error: cannot verify that ${CC:-gcc} avoids AVX512VL for this target (no objdump, or the probe failed to compile), and GCC $knl_cc_major is known to generate it regardless of -march=knl, which Knights Landing/Mill cannot execute. Refusing rather than building a binary that would die on the first one. Use GCC <= 13 or Clang for this build mode, or install binutils so the check can run." >&2
+					exit 1
+				fi
 				echo "Warning: could not verify that ${CC:-gcc} avoids AVX512VL for this target (no objdump, or the probe failed to compile). Proceeding on the strength of -march=knl alone; if the resulting binary dies on a Xeon Phi with an illegal-instruction fault, this is why." >&2
 			fi
 			# ER/PF are a separate axis from -march=knl, not implied by it: Clang 19 and later still accept


### PR DESCRIPTION
Makes the `avx512_knl` build mode either produce a binary that runs on a Xeon Phi or refuse to build at all, and adds CI that executes KNL code under emulation so a regression is caught rather than shipped.

## 1. The deprecation notice was wrong, and harmful

`avx512_knl` printed:

```
Warning: The 'avx512_knl' option is deprecated, use 'avx512' instead.
```

The two modes are not interchangeable. KNL and KNM implement **AVX512F + CD (+ ER/PF)** — no **DQ, BW or VL** — while `avx512` targets Skylake-SP and enables all of them. An `avx512` binary dies almost immediately on a Xeon Phi; under Intel SDE's KNL chip check:

```
SDE-ERROR: Executed instruction not valid for specified chip (KNL): kmovd k0, ecx
Function: qfcos
```

`kmovd` is AVX512BW; KNL has only the 16-bit `kmovw`. Anyone with a Knights Landing box who followed that advice got a SIGILL. Notice removed, replaced with an explanation of why the mode has to stay.

## 2. The mode could not build, and then could build something worse

It hardcoded `-march=knl … -mavx512er`. Both were deprecated in GCC 14 and **removed in GCC 15**, so on GCC 16 it simply failed:

```
cc: error: unrecognized command-line option '-mavx512er'; did you mean '-mavx512bw'?
```

The base flag set is now `-mavx512f -mavx512cd -mfma` — the correct KNL feature set, deliberately **no dq/bw/vl**, since adding those is exactly the bug in §1 — with the KNL-specific flags probed individually.

The harder question is which toolchains can be trusted with the mode at all. Counting 256-bit EVEX inserts/extracts (AVX512VL, which KNL does not implement) across a representative set of translation units:

| compiler | `-march=knl` | `-mavx512er` | VL ops, base | VL ops, `+ -march=knl` |
| --- | --- | --- | --- | --- |
| gcc 11.4 | yes | yes | 0 | 0 |
| gcc 12.4 | yes | yes | 0 | 0 |
| gcc 13.3 | yes | yes | 0 | 0 |
| **gcc 14.2 / 14.4** | **yes** | **yes** | **463** | **149** |
| gcc 15.3 | no | no | 202 | n/a |
| gcc 16.2 | no | no | 186 | n/a |
| clang 14.0 / 16.0 / 18.1 | yes | yes | 0 | 0 |
| clang 19.1 / 22.1 | yes | **no** | 0 | 0 |

This is a GCC bug, now filed as [PR target/127459](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=127459) - with only AVX512F enabled, GCC emits `vinserti32x4` in its EVEX.256 form, which requires AVX512VL, and `-mno-avx512vl` does not suppress it. A regression: clean in GCC 11-13, present in 14 through 16. The gate below is the workaround, and can be relaxed once that is fixed.

**GCC 14 accepts `-march=knl` and is still unsafe.** An earlier revision of this PR gated on whether the compiler still had the flag; that let GCC 14 straight through, and the binary it produces dies under SDE on `vinsertf32x4 ymm0, ymm0, xmm1, 0x1` in `radix40_ditN_cy_dif1`. On GCC 14 the flag actually *raises* the count rather than lowering it — radix144 alone goes from 12 to 76.

So the gate probes the generated code instead of the flag: it compiles one real FFT kernel with the KNL flag set and refuses if any 256-bit EVEX insert/extract comes out. That tests the property we need rather than a proxy for it. If `objdump` is unavailable the check cannot run, and it then falls back to the measured boundary — GCC 14 and later refused, anything else warned — so the mode never silently produces a binary that cannot run.

ER/PF are a separate axis from `-march=knl`, not implied by it: Clang 19 and later accept `-march=knl` while having dropped `-mavx512er`/`-mavx512pf` and not defining `__AVX512ER__`. They stay warnings rather than errors, because the tree's only ER code — the `VRCP28PD` block in `mi64_modmul53_batch()`, gated on `__AVX512ER__` — is unreachable: its sole caller sits inside a commented-out test harness in `mi64.c`. A toolchain without ER therefore builds a functionally identical binary. If that routine is ever wired up, this needs revisiting.

Behaviour on every toolchain tested:

| toolchain | outcome |
| --- | --- |
| gcc 11.4 – 13.3 | builds, no warnings |
| gcc 14.x | **refused** — flag accepted, codegen unsafe |
| gcc 15.x, 16.x | **refused** — no `-march=knl` |
| clang 14 – 18 | builds, no warnings |
| clang 19+, 22 | builds, with two ER/PF warnings |

## 3. New `Linux-KNL` CI job

Builds the mode and runs `-s tt` under `sde64 -knl`, which sets both CPUID *and* SDE's chip check, so any instruction outside the KNL ISA aborts the run instead of quietly succeeding on the AVX-512 host. That is the regression this job exists to catch — it would have caught §1.

Two deliberate pins:

- **`runs-on: ubuntu-24.04`, not `latest`.** GCC 13 is the last GCC that can target KNL at all, and 24.04 ships GCC 13 and Clang 18, both of which pass. On a newer image this job would correctly but unhelpfully refuse to build.
- **SDE 9.24.0, hash-pinned.** Intel removed the `-knl`/`-knm` knobs in 9.38 and no longer serves any pre-9.38 build — `downloadmirror.intel.com` returns 403 for 9.24, 9.27 and 9.33 alike. It is therefore hosted as a release asset on this repository, byte-identical to Intel's tarball, whose licence permits redistribution without modification, and verified by SHA-256 before unpacking.

## Verification

Every row below was run locally, with SDE 9.24.0 — the same version the CI job uses.

| toolchain | build | binary | `sde64 -knl` |
| --- | --- | --- | --- |
| gcc 13.3 | clean, no warnings | 0 VL instructions | `Res64: 5F1F741C1FBDA658` |
| clang 22.1 | clean, two ER/PF warnings | 0 VL instructions | `Res64: 5F1F741C1FBDA658` |
| gcc 14.4 | **refused** | — | (the binary it would have built dies on the first VL instruction) |
| gcc 16.2 | **refused** | — | — |

That residue matches what the same case produces from an ordinary x86-64 build, so this is a correct KNL run, not merely an absence of chip-check violations.

Also verified: the refusal paths with `objdump` hidden from `PATH` (gcc 14 refused by the version fallback, gcc 13 warns and proceeds); the `avx512` build failing on KNL exactly as in §1; and the ShellCheck finding count unchanged, with the new probe call sites carrying the same narrow `SC2310` disables as the existing ones.

The earlier revision of this description reported that SDE segfaulted locally and that the CI run step was therefore unverified. That was SDE 8.69.1, which this PR no longer uses; 9.24.0 runs correctly on this machine, so the run step is now exercised locally as well as in CI.

## A GCC bug found along the way

The VL instructions in the table above are a GCC defect, not something specific to Mlucas. Minimal case:

```c
void sink(int *);

void f(const unsigned *tab, unsigned long long k)
{
	int out[8];
	out[0] = tab[(k >>  0) & 15];
	/* ... eight of these ... */
	out[7] = tab[(k >> 28) & 15];
	sink(out);
}
```

`gcc -O3 -mavx512f -S` emits `vinserti32x4 $0x1, %xmm1, %ymm0, %ymm0` — the EVEX.256 form, requiring AVX512VL — with only AVX512F enabled and `__AVX512VL__` undefined. `-mno-avx512vl` does not suppress it. It is a regression introduced in GCC 14 and still present in 16.2; Clang is unaffected at every version tested. I have a Bugzilla account request pending and will file it upstream, and link it here.

This PR does not depend on that being fixed — the gate refuses the affected compilers regardless.

## KNM

No separate mode. KNM is KNL plus 4FMAPS/4VNNIW/VPOPCNTDQ, none of which Mlucas uses, so an `avx512_knl` binary already runs on it — and `-mavx5124fmaps`/`-mavx5124vnniw` are gone from both GCC 16 and Clang 22 anyway.

