### PR TITLE
Added support for FreeBSD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,10 +191,10 @@ jobs:
             # KNL-only via __AVX512ER__, so plain AVX-512 builds no longer need an ER-capable assembler -
             # which is why clang 5.0 on alpine:3.8 can now build AVX-512.) Probe and skip AVX-512 rather than
             # fail the build on a mode that provably can't work here.
-            if echo 'int main(void){__asm__ __volatile__("vpxord %%zmm31,%%zmm31,%%zmm31\n\tvmovdqa64 %%xmm16,%%xmm17\n\tkmovw %%k1,%%eax":::"zmm31","xmm16","xmm17","k1","eax");return 0;}' | "${CC:-gcc}" -mavx512f -x c -o /dev/null - >/dev/null 2>&1; then
+            if echo 'int main(void){__asm__ __volatile__("vpxord %%zmm31,%%zmm31,%%zmm31\n\tvmovdqa64 %%xmm16,%%xmm17\n\tkmovw %%k1,%%eax":::"zmm31","xmm16","xmm17","k1","eax");return 0;}' | $CC -mavx512f -mavx512cd -mavx512dq -mavx512bw -mavx512vl -mfma -x c -o /dev/null -; then
                 MODES+=( AVX512 )
             else
-                echo "::warning title=AVX-512 build skipped::$("${CC:-gcc}" --version | head -n1): its assembler can't handle the AVX-512 extended registers (zmm16-31/xmm16-31/k0-7) Mlucas's kernels need; skipping the AVX-512 build mode."
+                echo "::warning::Skipping the AVX512 build mode as the '$($CC --version | head -n1)' assembler cannot handle the required AVX512 extended registers (zmm16-31/xmm16-31/k0-7)."
             fi
         fi
         for mode in "${MODES[@]}"; do
@@ -229,7 +229,7 @@ jobs:
         sudo apt-get install -y libhwloc-dev
     - name: Before script
       run: |
-        echo "CFLAGS=-fdiagnostics-color -Wall -g -Og -fsanitize=address,undefined" >> "$GITHUB_ENV"
+        sed -i 's/-O3 -flto/-Og -fsanitize=address,undefined/' makemake.sh
         $CC --version
     - name: Script
       run: |
@@ -261,7 +261,7 @@ jobs:
         sudo apt-get install -y libhwloc-dev
     - name: Before script
       run: |
-        echo "CFLAGS=-fdiagnostics-color -Wall -g -Og -fsanitize=thread" >> "$GITHUB_ENV"
+        sed -i 's/-O3 -flto/-Og -fsanitize=thread/' makemake.sh
         $CC --version
     - name: Script
       run: |
@@ -282,7 +282,7 @@ jobs:
       run: |
         set -x
         set -o pipefail
-        gcc -c -fdiagnostics-color -g -O3 -march=native -DUSE_THREADS -fanalyzer src/*.c |& tee analyzer.log
+        gcc -c -fdiagnostics-color -std=gnu99 -g -O3 -march=native -DUSE_THREADS -fanalyzer src/*.c |& tee analyzer.log
         rm -- *.o
         echo -e '## GCC analyzer\n```' >> $GITHUB_STEP_SUMMARY
         grep 'warning:' analyzer.log | sed 's/\x1B\[\([0-9]\+\(;[0-9]\+\)*\)\?[mK]//g' | awk '{ print $NF }' | sort | uniq -c | sort -nr >> $GITHUB_STEP_SUMMARY
@@ -302,7 +302,7 @@ jobs:
       run: |
         set -x
         set -o pipefail
-        clang-tidy --use-color -checks='bugprone-*,-bugprone-reserved-identifier,cert-*,clang-analyzer-*,concurrency-*,misc-*,-misc-no-recursion,-misc-confusable-identifiers,performance-*,portability-*,readability-const-return-type,readability-container-*,readability-duplicate-include,readability-else-after-return,readability-make-member-function-cons,readability-non-const-parameter,readability-redundant-*,readability-simplify-*,readability-string-compare,readability-use-*' -header-filter='.*' src/*.c -- -Wall -O3 -march=native -DUSE_THREADS -DINCLUDE_HWLOC=1 |& tee clang-tidy.log
+        clang-tidy --use-color -checks='bugprone-*,-bugprone-reserved-identifier,cert-*,clang-analyzer-*,concurrency-*,misc-*,-misc-no-recursion,-misc-confusable-identifiers,performance-*,portability-*,readability-const-return-type,readability-container-*,readability-duplicate-include,readability-else-after-return,readability-make-member-function-cons,readability-non-const-parameter,readability-redundant-*,readability-simplify-*,readability-string-compare,readability-use-*' -header-filter='.*' src/*.c -- -std=gnu99 -Wall -O3 -march=native -DUSE_THREADS -DINCLUDE_HWLOC=1 |& tee clang-tidy.log
         echo -e '## Clang-Tidy\n```' >> $GITHUB_STEP_SUMMARY
         grep 'warning:' clang-tidy.log | sed 's/\x1B\[\([0-9]\+\(;[0-9]\+\)*\)\?[mK]//g' | awk '{ print $NF }' | sort | uniq -c | sort -nr >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
@@ -320,8 +320,8 @@ jobs:
     - name: Cppcheck
       run: |
         mkdir build
-        cppcheck --enable=all -DUSE_THREADS -DINCLUDE_HWLOC=1 --force --cppcheck-build-dir=build -j "$(nproc)" --clang .
-        cppcheck --enable=all -DUSE_THREADS -DINCLUDE_HWLOC=1 --force --cppcheck-build-dir=build --clang . &> cppcheck.log
+        cppcheck --std=c99 --enable=all -DUSE_THREADS -DINCLUDE_HWLOC=1 --force --cppcheck-build-dir=build -j "$(nproc)" --clang .
+        cppcheck --std=c99 --enable=all -DUSE_THREADS -DINCLUDE_HWLOC=1 --force --cppcheck-build-dir=build --clang . &> cppcheck.log
         echo -e '## Cppcheck\n```' >> $GITHUB_STEP_SUMMARY
         grep '\(error\|warning\|style\|performance\|portability\|information\):' cppcheck.log | awk '{ print $2, $NF }' | sort | uniq -c | sort -nr >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
@@ -341,7 +341,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-14, macos-15-intel, macos-15, macos-26]
+        os: [macos-14, macos-15-intel, macos-15, macos-26-intel, macos-26]
       fail-fast: false
     steps:
     - uses: actions/checkout@v7
@@ -351,7 +351,7 @@ jobs:
     - name: Before script
       run: |
         clang --version
-        if (( $(sysctl -n hw.optional.neon) )); then
+        if [[ $HOSTTYPE == arm64 ]]; then
             clang -dM -E -mcpu=native - </dev/null
         else
             clang -dM -E -march=native - </dev/null
@@ -362,7 +362,7 @@ jobs:
         set -o pipefail
         sysctl -a
         MODES=( '' NOSIMD )
-        if (( $(sysctl -n hw.optional.neon) )); then
+        if [[ $HOSTTYPE == arm64 ]]; then
             MODES+=( ASIMD )
         else
             MODES+=( SSE2 AVX AVX2 AVX512 )
@@ -386,7 +386,7 @@ jobs:
         grep 'warning:' build.log | sed 's/\x1B\[\([0-9]\+\(;[0-9]\+\)*\)\?[mK]//g' | grep -v '^ld:' | awk '{ print $NF }' | sort | uniq -c | sort -nr >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
         for s in tt t s m l; do time ./Mlucas -s $s -cpu "0:$(( $(sysctl -n hw.ncpu) - 1 ))" 2>&1 | tee -a test.log; done
-        if (( $(sysctl -n hw.optional.neon) )); then
+        if [[ $HOSTTYPE == arm64 ]]; then
             cd ../obj_NOSIMD
         fi
         bash -- ../config-fermat.sh -cpu "0:$(( $(sysctl -n hw.ncpu) - 1 ))"
@@ -402,7 +402,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-15-intel, macos-latest]
+        os: [macos-26-intel, macos-latest]
       fail-fast: false
     steps:
     - uses: actions/checkout@v7
@@ -415,7 +415,7 @@ jobs:
       run: |
         set -x
         MODES=( '' NOSIMD )
-        if (( $(sysctl -n hw.optional.neon) )); then
+        if [[ $HOSTTYPE == arm64 ]]; then
             MODES+=( ASIMD )
         else
             MODES+=( SSE2 AVX AVX2 AVX512 )
@@ -436,7 +436,7 @@ jobs:
         done
         cd obj
         time ./Mlucas -s m
-        if (( $(sysctl -n hw.optional.neon) )); then
+        if [[ $HOSTTYPE == arm64 ]]; then
             cd ../obj_NOSIMD
         fi
         bash -- ../config-fermat.sh
@@ -457,7 +457,7 @@ jobs:
         brew install hwloc
     - name: Before script
       run: |
-        echo "CFLAGS=-fdiagnostics-color -Wall -g -Og -fsanitize=address,undefined" >> "$GITHUB_ENV"
+        sed -i '' 's/-O3 -flto/-Og -fsanitize=address,undefined/' makemake.sh
         clang --version
     - name: Script
       run: |
@@ -483,7 +483,7 @@ jobs:
         brew install hwloc
     - name: Before script
       run: |
-        echo "CFLAGS=-fdiagnostics-color -Wall -g -Og -fsanitize=thread" >> "$GITHUB_ENV"
+        sed -i '' 's/-O3 -flto/-Og -fsanitize=thread/' makemake.sh
         clang --version
     - name: Script
       run: |
@@ -493,6 +493,76 @@ jobs:
         make clean
         time ./Mlucas -s m -cpu "0:$(( $(sysctl -n hw.ncpu) - 1 ))"
       continue-on-error: true
+
+  FreeBSD:
+    name: Mlucas FreeBSD
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        release: [12, 13, 14, 15]
+      fail-fast: false
+    env:
+      CC: clang
+    steps:
+    - uses: actions/checkout@v7
+    - name: Script
+      uses: vmactions/freebsd-vm@v1
+      with:
+        release: ${{ matrix.release }}
+        envs: 'CC'
+        usesh: true
+        sync: nfs
+        prepare: |
+          set -e
+          if [ "${{ matrix.release }}" = "12" ]; then
+            cat >/etc/pkg/FreeBSD.conf <<'EOF'
+          FreeBSD: {
+            url: "https://mirror.sg.gs/freebsd-pkg/${ABI}/latest",
+            mirror_type: "none",
+            signature_type: "fingerprints",
+            fingerprints: "/usr/share/keys/pkg",
+            enabled: yes
+          }
+          EOF
+            env PACKAGESITE='https://mirror.sg.gs/freebsd-pkg/FreeBSD:12:amd64/latest' /usr/sbin/pkg bootstrap -f -y
+            pkg update -f
+          fi
+          pkg install -y bash gmp hwloc2
+    - name: Before script
+      shell: freebsd {0} 
+      run: |
+        set -e -o pipefail
+        sed -i '' 's/^MAX=29/MAX=28/' config-fermat.sh
+        $CC --version
+        $CC -dM -E -march=native - </dev/null
+    - name: Script
+      shell: freebsd {0} 
+      run: |
+        set -ex -o pipefail
+        sysctl -a
+        for mode in '' NOSIMD SSE2 AVX AVX2 AVX512; do
+          echo -e "\n$mode\n"
+            bash -e -o pipefail -- makemake.sh use_hwloc $mode
+            (cd obj${mode:+_$mode}; make clean)
+            for word in '' 1word 2word 3word 4word nword; do
+                echo -e "\nMfactor $word\n"
+                bash -e -o pipefail -- makemake.sh mfac $word $mode || true
+                (
+                    cd obj_mfac${word:+_$word}${mode:+_$mode}
+                    make clean
+                    [ ! -x Mfactor${word:+_$word} ] || ./Mfactor${word:+_$word} -h
+                )
+            done
+        done
+        cd obj
+        for s in tt t s m; do time ./Mlucas -s "$s" -cpu "0:$(( $(sysctl -n hw.ncpu) - 1 ))" | tee -a test.log; done
+        bash -- ../config-fermat.sh -cpu "0:$(( $(sysctl -n hw.ncpu) - 1 ))"
+    - uses: actions/upload-artifact@v7
+      if: always()
+      with:
+        name: freebsd-${{ matrix.release }}-mlucas
+        path: ${{ github.workspace }}
 
   Windows:
     name: Windows
@@ -595,7 +665,7 @@ jobs:
     - name: Before script
       shell: bash
       run: |
-        echo "CFLAGS=-fdiagnostics-color -Wall -g -Og -fsanitize=address,undefined" >> "$GITHUB_ENV"
+        sed -i 's/-O3 -flto/-Og -fsanitize=address,undefined/' makemake.sh
         $CC --version
     - name: Script
       shell: bash

--- a/makemake.sh
+++ b/makemake.sh
@@ -37,6 +37,7 @@ Mfactor=Mfactor
 TARGET=$Mlucas
 ARGS=(-DUSE_THREADS) # Optional compile args
 WORDS=''
+C_ARGS=()
 # Optional link args
 LD_ARGS=()
 # Optional Make args
@@ -49,6 +50,10 @@ HWLOC=0
 case $OSTYPE in
 	darwin*)
 		echo -e "MacOS detected for build host.\n"
+		CPU_THREADS=$(sysctl -n hw.ncpu)
+		;;
+	freebsd*)
+		echo -e "FreeBSD detected for build host.\n"
 		CPU_THREADS=$(sysctl -n hw.ncpu)
 		;;
 	msys | cygwin)
@@ -275,13 +280,6 @@ if [[ ${#MODES[*]} -eq 1 ]]; then
 			ARGS+=(-DUSE_AVX512 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mavx512vl -mfma)
 			;;
 		k1om)
-			# Cross-build note: the Intel MPSS SDK's environment-setup-k1om-mpss-linux script exports
-			# CFLAGS and CPPFLAGS itself. The Makefile uses 'CFLAGS ?=', which defers to the environment,
-			# so merely sourcing the SDK script silently drops -O3 and -D_GNU_SOURCE and builds at -O0.
-			# At -O0 you get two failures that are NOT k1om defects: "impossible constraint in 'asm'" in
-			# radix16_dif_dit_pass_asm.h (the "e" constraint on pfetch_dist needs the optimiser), and
-			# threadpool.c losing CPU_ZERO/sched_setaffinity (that one is the missing -D_GNU_SOURCE).
-			# Re-export CFLAGS/CPPFLAGS *after* sourcing the SDK script.
 			echo "Building for 1st-gen Xeon Phi 512-bit SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
 			ARGS+=(-DUSE_IMCI512)
 			;;
@@ -323,32 +321,24 @@ if [[ ${#MODES[*]} -eq 1 ]]; then
 
 elif [[ $OSTYPE == darwin* ]]; then
 
-	# MacOS: sysctl -n prints nothing (and exits nonzero) for an absent key - e.g. all the
-	# hw.optional.avx* keys on Apple Silicon - so capture each with a 0 default. This also lets the
-	# combined AVX-512||AVX2 test below use plain arithmetic without an empty operand tripping
-	# '((: || : syntax error' (as `(( || $(...) ))` would when the first sysctl yields nothing):
-	avx512f=$(sysctl -n hw.optional.avx512f 2>/dev/null || echo 0)
-	avx2_0=$( sysctl -n hw.optional.avx2_0  2>/dev/null || echo 0)
-	avx1_0=$( sysctl -n hw.optional.avx1_0  2>/dev/null || echo 0)
-	sse2=$(   sysctl -n hw.optional.sse2    2>/dev/null || echo 0)
-	neon=$(   sysctl -n hw.optional.neon    2>/dev/null || echo 0)
+	avx512f=$(sysctl -n hw.optional.avx512f)
 	if ((avx512f)) && try_avx512_asm; then
 		echo -e "The CPU supports the AVX512 SIMD build mode.\n"
 		ARGS+=(-DUSE_AVX512 -march=native -mavx512f -mavx512cd -mavx512dq -mavx512bw -mavx512vl -mfma)
-	elif ((avx512f || avx2_0)); then
+	elif ((avx512f)) || (($(sysctl -n hw.optional.avx2_0))); then
 		if ((avx512f)); then
 			echo "Warning: CPU supports AVX-512 but ${CC:-gcc}'s assembler rejects the extended register names needed ... falling back to AVX2." >&2
 		fi
 		echo -e "The CPU supports the AVX2 SIMD build mode.\n"
 		ARGS+=(-DUSE_AVX2 -march=native -mavx2 -mfma)
-	elif ((avx1_0)); then
+	elif (($(sysctl -n hw.optional.avx1_0))); then
 		echo -e "The CPU supports the AVX SIMD build mode.\n"
 		ARGS+=(-DUSE_AVX -march=native -mavx)
-	elif ((sse2)); then
+	elif (($(sysctl -n hw.optional.sse2))); then
 		echo -e "The CPU supports the SSE2 SIMD build mode.\n"
 		# On my Core2Duo Mac, 'native' gives "error: bad value for -march= switch":
 		ARGS+=(-DUSE_SSE2 -march=core2 -msse2)
-	elif ((neon)); then
+	elif (($(sysctl -n hw.optional.neon))); then
 		echo -e "The CPU supports the ASIMD build mode.\n"
 		ARGS+=(-DUSE_ARM_V8_SIMD)
 		if try_flag -mcpu=native; then
@@ -413,25 +403,25 @@ int main()
 {
 // defined(__amd64) || defined(__amd64__) || defined(_M_AMD64) || defined(_M_EMT64) || defined(__x86_64) || defined(__x86_64__)
 #ifdef __x86_64__
-	#ifdef __AVX512F__
+	#ifdef __AVX512F__ // defined(__AVX512F__) && defined(__AVX512CD__) && defined(__AVX512DQ__) && defined(__AVX512BW__) && defined(__AVX512VL__) && defined(__FMA__)
 		puts("avx512");
-	#elif defined __AVX2__
+	#elif defined(__AVX2__) // defined(__AVX2__) && defined(__FMA__)
 		puts("avx2");
-	#elif defined __AVX__
+	#elif defined(__AVX__)
 		puts("avx");
-	#elif defined __SSE2__
+	#elif defined(__SSE2__)
 		puts("sse2");
 	#else
-		puts("none_x86");
+		puts("nosimd_x86");
 	#endif
 #elif defined(__aarch64__)
 	#ifdef __ARM_NEON
 		puts("asimd");
 	#else
-		puts("none_arm");
+		puts("nosimd_arm");
 	#endif
 #else
-	puts("none");
+	puts("nosimd");
 #endif
 	return 0;
 }
@@ -440,14 +430,19 @@ EOF
 	args=()
 	case $HOSTTYPE in
 		aarch64 | arm*)
-			args+=(-mcpu=native)
+			if try_flag -mcpu=native; then
+				args+=(-mcpu=native)
+			elif try_flag -march=native; then
+				args+=(-march=native)
+			fi
 			;;
 		x86_64 | *)
 			args+=(-march=native)
 			;;
 	esac
-	"${CC:-gcc}" -Wall -g -O3 "${args[@]}" -o "$tmpdir/simd" "$tmpdir/simd.c"
+	"${CC:-gcc}" -std=gnu99 -Wall -g -O3 "${args[@]}" -o "$tmpdir/simd" "$tmpdir/simd.c"
 	if ! output=$("$tmpdir/simd"); then
+		echo "$output"
 		echo "Error: Unable to detect the SIMD build mode" >&2
 		exit 1
 	fi
@@ -486,7 +481,7 @@ EOF
 			# else: no arch flag - aarch64 has NEON/ASIMD in its baseline ISA, and ancient clang (e.g. 3.8) supports
 			# neither -mcpu=native nor -march=native, so building without either still yields a working ASIMD binary
 			;;
-		none_arm)
+		nosimd_arm)
 			echo -e "The CPU supports no Mlucas-recognized SIMD build mode ... building in scalar-double mode.\n"
 			echo "Warning: This likely means there is a bug in this script. Please report!" >&2
 			if try_flag -mcpu=native; then
@@ -495,14 +490,14 @@ EOF
 				ARGS+=(-march=native)
 			fi
 			;;
-		none_x86)
+		nosimd_x86)
 			echo -e "The CPU supports no Mlucas-recognized SIMD build mode ... building in scalar-double mode.\n"
-			echo "Warning: This is a 64-bit x86 system without even SSE2, which likely means there is a bug in this script. Please report!" >&2
+			echo "Warning: This likely means there is a bug in this script. Please report!" >&2
 			ARGS+=(-march=native)
 			;;
-		none)
+		nosimd)
 			echo -e "The CPU architecture is not recognized by this script ... building in scalar-double mode.\n"
-			try_flag -march=native && ARGS+=(-march=native)
+			ARGS+=(-march=native)
 			;;
 		*)
 			echo -e "The CPU supports no Mlucas-recognized SIMD build mode ... building in scalar-double mode.\n"
@@ -531,18 +526,14 @@ fi
 # CFLAGS environment variable before invoking this script - the generated Makefile's "CFLAGS ?=" already
 # defers to a pre-set environment CFLAGS instead of the computed value below. Prefer -flto=auto (parallel
 # LTO codegen, see #56) over plain -flto when supported:
-CFLAGS_PROBED=(-Wall -g -O3)
-# The Mlucas sources use C99 features (for-loop-scope declarations, mixed declarations-and-code) plus GNU
-# extensions (statement expressions in the checked-alloc macros). Old gcc (e.g. 4.8 on Ubuntu 14.04)
-# defaults to gnu89/gnu90 and rejects the C99 constructs with a hard error, so request -std=gnu99
-# unconditionally: every toolchain then compiles the same dialect, and gnu99 (vs plain c99) keeps the GNU
-# extensions enabled. -D_GNU_SOURCE (set in CPPFLAGS below) still exposes the POSIX/GNU library surface:
-CFLAGS_PROBED+=(-std=gnu99)
-try_flag -fdiagnostics-color && CFLAGS_PROBED=(-fdiagnostics-color "${CFLAGS_PROBED[@]}")
+C_ARGS=(-std=gnu99 -Wall -g -O3)
+if try_flag -fdiagnostics-color; then
+	C_ARGS=(-fdiagnostics-color "${C_ARGS[@]}")
+fi
 if try_lto -flto=auto; then
-	CFLAGS_PROBED+=(-flto=auto)
+	C_ARGS+=(-flto=auto)
 elif try_lto -flto; then
-	CFLAGS_PROBED+=(-flto)
+	C_ARGS+=(-flto)
 else
 	echo "Warning: ${CC:-gcc} does not support (or reliably link with) -flto ... building without LTO." >&2
 fi
@@ -555,26 +546,30 @@ fi
 # stack trace of the issue. If one wishes, one can run 'strip -g Mlucas' to remove the debugging symbols:
 cat <<EOF >Makefile
 CC ?= gcc
-CFLAGS ?= ${CFLAGS_PROBED[*]}
-CPPFLAGS ?= -D_GNU_SOURCE -I/usr/local/include -I/opt/homebrew/include
-LDFLAGS ?= -L/opt/homebrew/lib
-LDLIBS ?= ${LD_ARGS[@]} # -static
+CFLAGS = ${C_ARGS[*]}
+CPPFLAGS += -D_GNU_SOURCE -I/usr/local/include -I/opt/homebrew/include
+LDFLAGS += -L/usr/local/lib -L/opt/homebrew/lib
+LDLIBS = ${LD_ARGS[@]} # -static
+
+VPATH = ../src
+.PATH: ../src
+.SUFFIXES: .c .o
 
 OBJS=br.o dft_macro.o fermat_mod_square.o fgt_m61.o get_cpuid.o get_fft_radices.o get_fp_rnd_const.o get_preferred_fft_radix.o getRealTime.o imul_macro.o mers_mod_square.o mi64.o Mlucas.o pairFFT_mul.o pair_square.o pm1.o qfloat.o radix1008_ditN_cy_dif1.o radix1024_ditN_cy_dif1.o radix104_ditN_cy_dif1.o radix10_ditN_cy_dif1.o radix112_ditN_cy_dif1.o radix11_ditN_cy_dif1.o radix120_ditN_cy_dif1.o radix128_ditN_cy_dif1.o radix12_ditN_cy_dif1.o radix13_ditN_cy_dif1.o radix144_ditN_cy_dif1.o radix14_ditN_cy_dif1.o radix15_ditN_cy_dif1.o radix160_ditN_cy_dif1.o radix16_dif_dit_pass.o radix16_ditN_cy_dif1.o radix16_dyadic_square.o radix16_pairFFT_mul.o radix16_wrapper_ini.o radix16_wrapper_square.o radix176_ditN_cy_dif1.o radix17_ditN_cy_dif1.o radix18_ditN_cy_dif1.o radix192_ditN_cy_dif1.o radix208_ditN_cy_dif1.o radix20_ditN_cy_dif1.o radix224_ditN_cy_dif1.o radix22_ditN_cy_dif1.o radix240_ditN_cy_dif1.o radix24_ditN_cy_dif1.o radix256_ditN_cy_dif1.o radix26_ditN_cy_dif1.o radix288_ditN_cy_dif1.o radix28_ditN_cy_dif1.o radix30_ditN_cy_dif1.o radix31_ditN_cy_dif1.o radix320_ditN_cy_dif1.o radix32_dif_dit_pass.o radix32_ditN_cy_dif1.o radix32_dyadic_square.o radix32_wrapper_ini.o radix32_wrapper_square.o radix352_ditN_cy_dif1.o radix36_ditN_cy_dif1.o radix384_ditN_cy_dif1.o radix4032_ditN_cy_dif1.o radix40_ditN_cy_dif1.o radix44_ditN_cy_dif1.o radix48_ditN_cy_dif1.o radix512_ditN_cy_dif1.o radix52_ditN_cy_dif1.o radix56_ditN_cy_dif1.o radix5_ditN_cy_dif1.o radix60_ditN_cy_dif1.o radix63_ditN_cy_dif1.o radix64_ditN_cy_dif1.o radix6_ditN_cy_dif1.o radix72_ditN_cy_dif1.o radix768_ditN_cy_dif1.o radix7_ditN_cy_dif1.o radix80_ditN_cy_dif1.o radix88_ditN_cy_dif1.o radix8_dif_dit_pass.o radix8_ditN_cy_dif1.o radix960_ditN_cy_dif1.o radix96_ditN_cy_dif1.o radix992_ditN_cy_dif1.o radix9_ditN_cy_dif1.o rng_isaac.o threadpool.o twopmodq100.o twopmodq128_96.o twopmodq128.o twopmodq160.o twopmodq192.o twopmodq256.o twopmodq64_test.o twopmodq80.o twopmodq96.o twopmodq.o types.o util.o
 OBJS_MFAC=getRealTime.o get_cpuid.o get_fft_radices.o get_fp_rnd_const.o imul_macro.o mi64.o qfloat.o rng_isaac.o twopmodq100.o twopmodq128_96.o twopmodq128.o twopmodq160.o twopmodq192.o twopmodq256.o twopmodq64_test.o twopmodq80.o twopmodq96.o twopmodq.o types.o util.o threadpool.o factor.o
 
-$Mlucas: \$(OBJS)
-	\$(CC) \$(LDFLAGS) \$(CFLAGS) -o \$@ \$^ \$(LDLIBS)
-$Mfactor: \$(OBJS_MFAC)
-	\$(CC) \$(LDFLAGS) \$(CFLAGS) -o \$@ \$^ \$(LDLIBS)
+$Mlucas: \${OBJS}
+	\${CC} \${LDFLAGS} \${CFLAGS} -o $Mlucas \${OBJS} \${LDLIBS}
+$Mfactor: \${OBJS_MFAC}
+	\${CC} \${LDFLAGS} \${CFLAGS} -o $Mfactor \${OBJS_MFAC} \${LDLIBS}
 factor.o: ../src/factor.c
-	\$(CC) \$(CFLAGS) \$(CPPFLAGS) -c ${ARGS[@]} -DFACTOR_STANDALONE $WORDS -DTRYQ=4 \$<
-%.o: ../src/%.c
-	\$(CC) \$(CFLAGS) \$(CPPFLAGS) -c ${ARGS[@]} ${WORDS:+$WORDS -DFACTOR_STANDALONE} \$<
+	\${CC} \${CFLAGS} \${CPPFLAGS} -c ${ARGS[@]} -DFACTOR_STANDALONE $WORDS -DTRYQ=4 -o factor.o ../src/factor.c
+.c.o:
+	\${CC} \${CFLAGS} \${CPPFLAGS} -c ${ARGS[@]} ${WORDS:+$WORDS -DFACTOR_STANDALONE} -o \$@ \$<
 clean:
-	rm -f \$(OBJS) \$(OBJS_MFAC)
+	rm -f \${OBJS} \${OBJS_MFAC}
 
-.phony: clean
+.PHONY: clean
 EOF
 
 echo -e "Building $TARGET"

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -65,6 +65,11 @@ me at: heber.tomer@gmail.com
 #include "threadpool.h"
 #include "util.h"	// This is to get (or not) <hwloc.h>
 
+#ifdef __FreeBSD__
+#include <sys/param.h>
+#include <sys/cpuset.h>
+#endif
+
 #ifdef MULTITHREAD	// Wrap contents of this file in flag (set via platform.h at compile time) ensuring no code built in unthreaded mode
 
 	#define THREAD_POOL_DEBUG	0


### PR DESCRIPTION
* Added support for FreeBSD to the `makemake.sh` script and generated Makefile
* Updated the CI
  * Added FreeBSD job using the [vmactions/freebsd-vm](https://github.com/marketplace/actions/freebsd-vm) Action
  * Updated macOS jobs to use the newer macOS 26 Intel runner
* Minor cleanups from #67
  * Made requirement for C99 consistent everywhere

This added error masking to the new FreeBSD CI job, which would for example need to be removed in #103 or a follow up.