### PR TITLE
Mfactor: don't compile the AVX-512 vector sieve for IMCI-512 (KNC)

### DIFF
--- a/src/factor.c
+++ b/src/factor.c
@@ -101,7 +101,7 @@ To build the sieve factoring code in standalone mode, see the compile instructio
 		uint32 p_last_small;	//largest odd prime appearing in the product; that is; the (nclear)th odd prime.
 		uint32 nprime;			// #sieving primes (counting from 3)
 		uint32 MAX_SIEVING_PRIME;
-	#ifdef USE_AVX512
+	#if defined(USE_AVX512) && !defined(USE_IMCI512)
 		uint32 *psmall;
 	#endif
 		uint8 *pdiff;
@@ -692,7 +692,7 @@ int main(int argc, char *argv[])
 
 // This stuff is for the small-primes sieve:
 	uint32 max_diff;
-  #ifdef USE_AVX512	// Use vector-int math and gather-load/scatter-store to accelerate the bit-clearing
+  #if defined(USE_AVX512) && !defined(USE_IMCI512)	// Use vector-int math and gather-load/scatter-store to accelerate the bit-clearing
 	uint32 *psmall;
   #endif
 	uint8 *pdiff;	/* Compact table storing the (difference/2) between adjacent odd primes.
@@ -1521,7 +1521,7 @@ ASSERT(0 == init_savefile(RESTARTFILE, pstring, bmin,bmax, kmin,know,kmax, passm
 	}
 printf("Allocated %u words in master template, %u in per-pass bit_map [%u x that in bit_atlas]\n",len,i,TF_PASSES);
 
-  #ifdef USE_AVX512	// Use vector-int math and gather-load/scatter-store to accelerate the bit-clearing
+  #if defined(USE_AVX512) && !defined(USE_IMCI512)	// Use vector-int math and gather-load/scatter-store to accelerate the bit-clearing
 	psmall = (uint32 *)calloc(NUM_SIEVING_PRIME * NTHREADS, sizeof(uint32));
 	if (psmall == NULL) {
 		fprintf(stderr,"Memory allocation failure for PSMALL array");
@@ -1580,7 +1580,7 @@ printf("Allocated %u words in master template, %u in per-pass bit_map [%u x that
 		/* Init first few diffs between 3/5, 5/7, 7/11, so can start loop with curr_p = 11 == 1 (mod 10), as required by twopmodq32_x8(): */
 		pdiff[0] = 0;	pdiff[1] = pdiff[2] = 1;
 		ihi = curr_p = 11;
-	#ifdef USE_AVX512	// Use vector-int math and gather-load/scatter-store to accelerate the bit-clearing
+	#if defined(USE_AVX512) && !defined(USE_IMCI512)	// Use vector-int math and gather-load/scatter-store to accelerate the bit-clearing
 		psmall[0] = 3; psmall[1] = 5; psmall[2] = 7;
 	#endif
 		/* Process chunks of length 30, starting with curr_p == 11 (mod 30). Applying the obvious divide-by-3,5 mini-sieve,
@@ -1620,7 +1620,7 @@ printf("Allocated %u words in master template, %u in per-pass bit_map [%u x that
 					else	/* It's prime - add final increment to current pdiff[i] and then increment i: */
 					{
 						ihi = (curr_p + pdsum_8[j]);
-					#ifdef USE_AVX512	// Use vector-int math and gather-load/scatter-store to accelerate the bit-clearing
+					#if defined(USE_AVX512) && !defined(USE_IMCI512)	// Use vector-int math and gather-load/scatter-store to accelerate the bit-clearing
 						psmall[i] = ihi;
 					#endif
 						pdiff[i] += pdiff_8[j];
@@ -2302,7 +2302,7 @@ candidate factors that survive sieving.	*/
 			targ->interval_lo = interval_lo;
 			targ->interval_hi = interval_hi;
 			targ->fbits_in_2p = fbits_in_2p;
-		#ifdef USE_AVX512
+		#if defined(USE_AVX512) && !defined(USE_IMCI512)
 			targ->psmall = psmall;
 		#endif
 			targ->nclear = nclear;
@@ -2428,7 +2428,7 @@ candidate factors that survive sieving.	*/
 			p_last_small,	//largest odd prime appearing in the product; that is, the (nclear)th odd prime.
 			i,	// #sieving primes (counting from 3)
 			MAX_SIEVING_PRIME,
-		  #if defined(USE_AVX512) && !defined(USE_GPU)
+		  #if defined(USE_AVX512) && !defined(USE_IMCI512) && !defined(USE_GPU)
 			psmall,
 		  #endif
 			pdiff,
@@ -2605,7 +2605,7 @@ MFACTOR_HELP:
 		const uint32 p_last_small,	//largest odd prime appearing in the product; that is, the (nclear)th odd prime.
 		const uint32 nprime,	// #sieving primes (counting from 3)
 		const uint32 MAX_SIEVING_PRIME,
-	  #ifdef USE_AVX512
+	  #if defined(USE_AVX512) && !defined(USE_IMCI512)
 		const uint32 *psmall,
 	  #endif
 		const uint8 *pdiff,
@@ -2643,7 +2643,7 @@ MFACTOR_HELP:
 											   || (!defined(P2WORD) && !(defined(USE_FLOAT) && defined(USE_SSE2) && (OS_BITS == 64))))))
 		double fbits_in_2p  = targ->fbits_in_2p;
 	#endif
-	#ifdef USE_AVX512
+	#if defined(USE_AVX512) && !defined(USE_IMCI512)
 		uint32 *psmall = targ->psmall;
 	#endif
 		uint32 nclear       = targ->nclear;
@@ -3177,7 +3177,7 @@ MFACTOR_HELP:
 
 			/*   ...and clear the bits corresponding to the small primes.	*/
 
-		#ifdef USE_AVX512	// Use vector-int math and gather-load/scatter-store to accelerate the bit-clearing
+		#if defined(USE_AVX512) && !defined(USE_IMCI512)	// Use vector-int math and gather-load/scatter-store to accelerate the bit-clearing
 								// EWM: For pmax around the 'sweet spot', this 2-loop approach is barely faster than
 								// above pure-C scalar-int code, though AVX-512 asm is a clear winner for large pmax.
 			// Split our loop-over-primes into 2 parts, the 2nd of which handles primes > bit_len
@@ -3291,7 +3291,7 @@ MFACTOR_HELP:
 				}
 			}
 
-		#endif	// USE_AVX512 ?
+		#endif	// AVX-512 (non-IMCI) sieve ?
 
 //	if(pass==4)printf("\nPass %u: word0 after deep-prime clearing = %16" PRIX64 "\n",pass,bit_map2[0]);
 

--- a/src/factor.h
+++ b/src/factor.h
@@ -28,6 +28,14 @@
 
 #include "util.h"
 
+/* IMCI-512 (1st-gen Xeon Phi / Knights Corner) shares AVX-512's zmm/k register names, and platform.h
+makes USE_IMCI512 imply USE_AVX512 - but it has none of the instructions the vectorized small-primes
+sieve in factor.c needs: vprolvd, vmovups, kmovw and the register form of vpbroadcastd all fail to
+assemble for k1om. That sieve - and the psmall[] table which exists solely to feed it - is therefore
+gated on 'defined(USE_AVX512) && !defined(USE_IMCI512)' rather than on USE_AVX512 alone, the same
+idiom mi64.c already uses, so KNC falls back to the scalar bit-clearing loop (a live path in any
+case: the AVX-512 arm defers to it for small exponents). */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -335,7 +343,7 @@ uint32	CHECK_PKMOD4620(uint64 *p, uint32 lenP, uint64 k, uint32*incr);
 		const uint32 p_last_small,	//largest odd prime appearing in the product; that is, the (nclear)th odd prime.
 		const uint32 nprime,		// #sieving primes (counting from 3)
 		const uint32 MAX_SIEVING_PRIME,
-	#if defined(USE_AVX512) && !defined(USE_GPU)
+	#if defined(USE_AVX512) && !defined(USE_IMCI512) && !defined(USE_GPU)
 		const uint32 *psmall,
 	#endif
 		const uint8 *pdiff,


### PR DESCRIPTION
`platform.h:263` makes `USE_IMCI512` imply `USE_AVX512`, so the vectorized small-primes sieve in `PerPass_tfSieve()` is compiled for Knights Corner — which has IMCI-512, not AVX-512F, and none of the gather/scatter or mask instructions that block uses.

Building `Mfactor` for K1OM therefore fails outright:

```
../src/factor.c:3212: Error: operand type mismatch for `vpbroadcastd'
../src/factor.c:3217: Error: `vmovups' is not supported on `k1om'
../src/factor.c:3223: Error: invalid instruction suffix for `kmov'
../src/factor.c:3229: Error: no such instruction: `vprolvd %zmm0,%zmm31,%zmm1{%k1}'
make: *** [Mfactor] Error 1
```

This adds a dedicated `USE_AVX512_SIEVE` flag in `factor.h`, set only when `USE_AVX512` is defined and `USE_IMCI512` is not, and keys the sieve on it. `mi64.c` already uses the same `defined(USE_AVX512) && !defined(USE_IMCI512)` idiom at lines 2414 and 4221; a named flag is used here because the carve-out is needed at ten sites in `factor.c` and two in `factor.h` — including the `psmall` parameter in `PerPass_tfSieve()`'s prototype and definition, which have to move together or the build breaks a different way.

KNC falls back to the scalar bit-clearing loop, which is a live path regardless: the AVX-512 arm defers to it for small exponents.

## Verified

**KNC, MPSS 3.8.6 cross-toolchain in a container.** Before, all six `Mfactor` word variants fail at `factor.c:3212`. After:

```
  base   BUILT   e_machine=181 (K1OM)
  1word  BUILT   e_machine=181 (K1OM)
  2word  BUILT   e_machine=181 (K1OM)
  3word  BUILT   e_machine=181 (K1OM)
  4word  BUILT   e_machine=181 (K1OM)
  nword  BUILT   e_machine=181 (K1OM)
```

Real Knights Corner binaries, not host objects — ELF `e_machine` 181.

**x86 AVX-512 is untouched.** Preprocessed `factor.c` for an AVX-512 build is identical before and after, once `# line` directives are discounted (the patch adds ten lines to `factor.h`, which shifts them). Checked against a negative control that disables the new flag and does show a difference, so the comparison is capable of failing.

## Why it matters now

#155 adds a K1OM CI job whose `Mfactor` builds are wrapped in `|| true`, so the job currently reports success while producing no binary at all. With this in, that mask can come off and the job will actually be testing something.

Not a regression — this has been the state since `USE_IMCI512` began implying `USE_AVX512`. It only surfaces once anything tries to build `Mfactor` for K1OM.