### PR TITLE
CI: only run FreeBSD test binaries the guest can execute

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -541,6 +541,22 @@ jobs:
       run: |
         set -ex -o pipefail
         sysctl -a
+        # Build every mode, but only run binaries this guest can actually execute. The VM is
+        # scheduled onto whatever host Azure has free, and AVX-512 availability varies with it;
+        # $CC -march=native is the reliable oracle, because the compiler consults XCR0 as well as
+        # CPUID and so knows whether the OS has enabled the state, not merely whether the silicon
+        # has the feature.
+        native=$($CC -dM -E -march=native - </dev/null)
+        runnable() {
+            case $1 in
+                ''|NOSIMD) return 0 ;;
+                SSE2)      echo "$native" | grep -q __SSE2__ ;;
+                AVX)       echo "$native" | grep -q __AVX__ ;;
+                AVX2)      echo "$native" | grep -q __AVX2__ ;;
+                AVX512)    echo "$native" | grep -q __AVX512F__ ;;
+                *)         return 1 ;;
+            esac
+        }
         for mode in '' NOSIMD SSE2 AVX AVX2 AVX512; do
           echo -e "\n$mode\n"
             bash -e -o pipefail -- makemake.sh use_hwloc $mode
@@ -551,7 +567,9 @@ jobs:
                 (
                     cd obj_mfac${word:+_$word}${mode:+_$mode}
                     make clean
-                    [ ! -x Mfactor${word:+_$word} ] || ./Mfactor${word:+_$word} -h
+                    if [ -x Mfactor${word:+_$word} ] && runnable "$mode"; then
+                        ./Mfactor${word:+_$word} -h
+                    fi
                 )
             done
         done


### PR DESCRIPTION
Three of the four FreeBSD jobs are failing on `main` right now, all at the same line:

```
+ ./Mfactor -h
Illegal instruction
##[error]Process completed with exit code 132.
```

The mode loop builds through `AVX512` and then runs the binary unconditionally. The VM lands on whatever host Azure has free, and AVX-512 availability travels with it — in the latest `main` run, FreeBSD 13 drew an Intel Xeon Platinum and passed, while 12, 14 and 15 drew AMD EPYC parts and trapped:

| release | host CPU | `__AVX512F__` from `$CC -march=native` | outcome |
|---|---|---|---|
| 12 | AMD EPYC 9V74 | absent | `Illegal instruction` |
| 13 | Intel Xeon Platinum | **defined** | **passed** |
| 14 | AMD EPYC 9V74 | absent | `Illegal instruction` |
| 15 | AMD EPYC 7763 | absent | `Illegal instruction` |

Because the step runs under `set -ex`, the job stops at the first trap — *before* the `-s tt t s m` self-tests and `config-fermat.sh` that sit below the loop. Those are the parts worth having a FreeBSD runner for, so today the job either passes by luck or contributes compile coverage only.

This gates **execution**, not the build. Every mode still compiles on every release; only the modes the guest can run get their binary invoked.

## Why `$CC -march=native` and not CPUID

The compiler consults `XCR0` as well as CPUID, so it reports whether the OS has actually enabled the register state — not merely whether the silicon has the feature. That distinction is load-bearing here rather than theoretical: **FreeBSD 14's guest advertises AVX-512 in CPUID leaf 7 and still traps.** A CPUID-based gate would have let that one through and left the job red. The compiler's view is correct on all four cells.

Conveniently the job already runs `$CC -dM -E -march=native` in its "Before script" step, so this is the same oracle, just consulted where the decision is made.

## Verified

Replaying each guest's recorded `-march=native` output through the new guard:

```
FreeBSD 12  would run: auto NOSIMD SSE2 AVX AVX2
FreeBSD 13  would run: auto NOSIMD SSE2 AVX AVX2 AVX512
FreeBSD 14  would run: auto NOSIMD SSE2 AVX AVX2
FreeBSD 15  would run: auto NOSIMD SSE2 AVX AVX2
```

FreeBSD 13 keeps everything including AVX-512; the other three skip AVX-512 alone and retain the full set through AVX2 — exactly what each already completes today before trapping. So no coverage is lost on any cell that currently has it, and three jobs stop failing for a reason unrelated to the code under test.

This was suggested inline on #251 but not applied before it merged; opening it separately so it does not get lost.