### PR TITLE
gitignore: ignore mlucas.cfg wherever it lands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,21 @@
 obj*/
+*.o
+
+# Files Mlucas and Mfactor write at run time, in whatever directory they are
+# started from - which is not necessarily one of the obj*/ build dirs.
 mlucas.cfg
+fermat.cfg
+results.txt
+worktodo.txt
+WINI.TMP
+*.stat
+
+# Savefiles: p<exponent> and its q<exponent> twin (Mersenne), f<exponent>
+# (Fermat), t<exponent> (Mfactor), plus the .G, .s1, .s2 and .<n>M variants.
+# The exponent is always a decimal string, so anchoring on a trailing digit
+# keeps these from swallowing sources such as src/f2psp.h.
+[fpqt][0-9]
+[fpqt][0-9]*[0-9]
+[fpqt][0-9]*[0-9].G
+[fpqt][0-9]*[0-9].s[12]
+[fpqt][0-9]*[0-9].[0-9]*M

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 obj*/
+mlucas.cfg


### PR DESCRIPTION
Follow-up to the stray `mlucas.cfg` you spotted on #83, and to your note there that additional files were fine to add.

`mlucas.cfg` is generated — the self-test writes it and every run reads it. Inside the object directories the existing `obj*/` rule already covers it, but a run started from the repository root, or from a scratch directory under it, drops one where nothing ignores it. It then sits in `git status` as untracked and is easy to sweep into a commit by accident, which is exactly what happened on #83 and twice more since while I was working in per-PR worktrees.

The entry has no slash, so git matches it at any depth rather than only at the top level:

```
$ git check-ignore -v mlucas.cfg run/mlucas.cfg run/sub/deep/mlucas.cfg
.gitignore:2:mlucas.cfg    mlucas.cfg
.gitignore:2:mlucas.cfg    run/mlucas.cfg
.gitignore:2:mlucas.cfg    run/sub/deep/mlucas.cfg
```

No currently-tracked file becomes ignored by it — checked with `git ls-files | git check-ignore --stdin`, which returns nothing.

Happy to fold in other generated artefacts (`*.stat`, `p*`/`q*`/`f*` savefiles, `t127`, `worktodo.txt`, `results.txt`) if you would rather have one pass at this, but those are more debatable — savefiles in particular are named by exponent and a blanket pattern could hide something wanted — so I kept this to the one file that has actually caused trouble.