### PR TITLE
CI: run the ASan Linux job on ARM too, instrumenting the ASIMD build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,9 +314,10 @@ jobs:
   ASan-Linux:
     name: AddressSanitizer Linux
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
         cc: [gcc, clang]
       fail-fast: false
     env:
@@ -335,23 +336,55 @@ jobs:
     - name: Script
       run: |
         set -x
-        # Build NOSIMD under the sanitizer (see PR #71 discussion): testing the hand-tuned
-        # SIMD asm under ASan/UBSan adds little, and on macOS it fails to assemble under -Og
-        # ("invalid CFI advance_loc expression"). NOSIMD exercises the same C-level logic.
-        bash -e -o pipefail -- makemake.sh use_hwloc nosimd
-        (cd obj_nosimd; make clean)
+        # On x86, build NOSIMD under the sanitizer (see PR #71 discussion): on macOS the SIMD asm
+        # fails to assemble under -Og ("invalid CFI advance_loc expression"), and NOSIMD exercises
+        # the same C-level logic. #221 picks the x86 SIMD coverage back up separately (AVX2
+        # natively, AVX-512 under SDE).
+        #
+        # aarch64/Linux has no such assembler problem, so there the native (ASIMD) build is the one
+        # to instrument - it is the only place in CI where hand-tuned SIMD asm gets built under a
+        # sanitizer at all. Issue #12, a SEGV in radix48_dit_pass1 during 'Mlucas -s m', was
+        # reported by ASan on an ARM runner, and with every sanitizer job pinned to NOSIMD there is
+        # currently nothing left that could find its like.
+        if [[ $HOSTTYPE == aarch64 ]]; then MODE=; else MODE=nosimd; fi
+        bash -e -o pipefail -- makemake.sh use_hwloc $MODE
+        (cd obj${MODE:+_$MODE}; make clean)
+        # config-fermat.sh runs from the NOSIMD build on aarch64, as in the Linux job above, so
+        # that build is needed there in addition to the ASIMD one:
+        if [[ -z $MODE ]]; then
+            bash -e -o pipefail -- makemake.sh use_hwloc nosimd
+            (cd obj_nosimd; make clean)
+        fi
         for word in '' 1word 2word 3word 4word nword; do
             echo -e "\nMfactor $word\n"
             bash -e -o pipefail -- makemake.sh mfac $word nosimd
             (cd obj_mfac${word:+_$word}_nosimd; make clean)
         done
-        cd obj_nosimd
+        cd obj${MODE:+_$MODE}
+        # Guard against the ARM cell silently degrading into a second copy of the x86 one if
+        # auto-detection ever changes: makemake.sh announces the selected mode on stdout but does
+        # not record it in build.log, so ask the binary itself what it was built as.
+        if [[ -z $MODE ]]; then
+            ./Mlucas -s tt -cpu 0 > mode.log 2>&1
+            grep -q 'Build uses ARMv8 advanced-SIMD' mode.log || {
+                echo '::error::ARM cell is not an ASIMD build - it would be testing nothing'; exit 1; }
+        fi
         for s in tt t s m; do time ./Mlucas -s $s -cpu "0:$(( $(nproc --all) - 1 ))"; done
         for s in tt t s; do time ./Mlucas -prp -s $s -cpu "0:$(( $(nproc --all) - 1 ))"; done
+        # On ARM the native build is ASIMD, whose trial-factoring routines are stubs
+        # ("No TF support on ARMv8!" in twopmodq80.c, under #ifdef USE_ARM_V8_SIMD), so
+        # config-fermat.sh and the Mfactor self-tests run from the NOSIMD builds - the same
+        # substitution the Linux and Singlethread-Linux jobs make.
+        cd ../obj_nosimd
         bash -e -o pipefail -- ../config-fermat.sh -cpu "0:$(( $(nproc --all) - 1 ))"
         for word in '' 1word 2word 3word 4word nword; do
             ( cd "../obj_mfac${word:+_$word}_nosimd" && time "./Mfactor${word:+_$word}" -m 521 -bmax 20 )
         done
+    - uses: actions/upload-artifact@v7
+      if: always()
+      with:
+        name: ${{ matrix.os }}_${{ matrix.cc }}_asan_mlucas
+        path: ${{ github.workspace }}
 
   TSan-Linux:
     name: ThreadSanitizer Linux


### PR DESCRIPTION
Right now **no job anywhere builds hand-tuned SIMD asm under a sanitizer.** Every sanitizer job is pinned to NOSIMD, because macOS cannot assemble the SIMD under `-Og` (`invalid CFI advance_loc expression`). That pinning is correct for macOS, but it gave up the one configuration that has actually caught a SIMD memory bug in this codebase.

Issue #12 - a SEGV in `radix48_dit_pass1` during `Mlucas -s m` - was reported by AddressSanitizer on an ARM runner. As things stand there is nothing left in CI that could find its like.

This is the ARM counterpart to #221, which covers the x86 side (AVX2 natively, AVX-512 under SDE). The two do not overlap.

## What it does

Adds `ubuntu-24.04-arm` to the existing `ASan-Linux` matrix rather than adding a job. The build mode comes from `$HOSTTYPE`, the way the `Linux` and `Singlethread-Linux` jobs already select theirs:

* **x86 cells** keep the NOSIMD build and behave exactly as before.
* **ARM cells** let `makemake.sh` auto-detect, which selects ASIMD - the build this exists to instrument.
* On ARM, `config-fermat.sh` and the Mfactor self-tests run from the NOSIMD builds. That is the same substitution the `Linux` and `Singlethread-Linux` jobs make: ASIMD's trial-factoring routines are stubs (`No TF support on ARMv8!`, under `#ifdef USE_ARM_V8_SIMD` in `twopmodq80.c`).
* Same tiers as the x86 cells - `tt t s m` plus PRP `tt t s`. My earlier revision gated the medium tier; that is gone, since ASIMD is far faster per iteration than the NOSIMD build the x86 cells already run `-s m` on.
* Adds the artifact upload the sibling Linux jobs have.

**It asserts the binary is really ASIMD.** `makemake.sh` announces the selected mode on stdout but does not record it in `obj/build.log`, so a check against the build log would silently pass while testing nothing - I wrote that version first and it would have failed the job for the wrong reason. The job greps the run itself for `Build uses ARMv8 advanced-SIMD`, which `util.c` prints only under `#ifdef USE_ARM_V8_SIMD` (the near-miss line for a scalar build on ASIMD-capable hardware reads `CPU supports ARMv8 advanced-SIMD ... but using scalar floating-point build`, and does not match). Without this the ARM cells quietly degrade into duplicates of the x86 ones the moment auto-detection changes.

## Verified on aarch64 hardware

Debian 12, gcc 12.2 and clang 14, using the flags `makemake.sh` generates:

* **gcc**: full native (ASIMD) build with `-Og -fsanitize=address,undefined` compiles, links and self-tests clean.
* **clang**: the SIMD-heaviest translation units - `radix48_ditN_cy_dif1.c` (the one from #12), `radix32_wrapper_square.c`, `radix32_dif_dit_pass.c`, `radix16_dif_dit_pass.c` - all assemble with zero diagnostics under `-mcpu=native -Og -fsanitize=address,undefined`. So the macOS assembler problem does not reproduce on ARM Linux with either compiler.

Caveat worth stating: that box runs clang 14, while `ubuntu-24.04-arm` has a much newer one. The `Linux` job already builds ASIMD with clang on those runners without sanitizers, so the only new variable is `-Og -fsanitize=...`, but this PR's own CI run is the real check.

## On #12 itself

Separately I tried to reproduce #12 on aarch64 hardware against current `main`, and it does **not** reproduce: the exact reported configuration passes, including under ASan, and the `-s m` sweep reached `M57984131` at 3072K with radices 48/32/32/32 and passed it. I would not call the issue fixed on that basis - different platform (Debian/gcc vs macOS/clang), different microarchitecture, and the report says "sometimes" - but it is worth recording. This job is what would tell us either way, on an ongoing basis, rather than by my hand-running it once.

## Dropped from the earlier revision

The previous version also failed the job on any `WARNING: 0 of` line (an FFT length with no passing radix set) and on any `runtime error:` from UBSan, on the grounds that the self-test's exit status is not sufficient on its own until #216 lands, and that an ASan report is not sufficient either since a register clobber corrupts results without making a bad memory access. I still think both are worth having, but they are new failure conditions on cells that are green today, so they belong in their own PR rather than riding along on this one. Happy to open that separately.

CI only; no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
