### PR TITLE
Add the Jacobi residue check for LL tests (part of #97)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,18 @@ jobs:
             # and costs slightly less than 127 did (726k trial divides vs 1.66M).
             ( cd "../obj_mfac${word:+_$word}${MSFX}" && time "./Mfactor${word:+_$word}" -m 521 -bmax 20 )
         done
+    - name: Jacobi residue check tests
+      run: |
+        set -x
+        set -o pipefail
+        # A second native build with the test-only fault injector compiled in (see tests/jacobi-check.sh
+        # for what it is used for). The native obj/ Makefile is reused with one extra define; its objects
+        # were cleaned above, so this is a full compile of the native mode.
+        mkdir obj_fi
+        sed 's/^CPPFLAGS += /CPPFLAGS += -DMLUCAS_FAULT_INJECT /' obj/Makefile > obj_fi/Makefile
+        make -C obj_fi -j "$(nproc --all)" Mlucas
+        JACOBI_TEST_CPU="0:$(( $(nproc --all) - 1 ))" JACOBI_TEST_DIR="$PWD/obj/jacobi-tests" \
+            time bash tests/jacobi-check.sh obj/Mlucas obj_fi/Mlucas obj/mlucas.cfg |& tee -a obj/test.log
     - uses: actions/upload-artifact@v7
       if: always()
       with:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Feature | | Mlucas | Prime95/MPrime
 \- | Suyama | ✔️ | 
 **PRP** | Proof generation | | ✔️
 \- | Proof certification | | ✔️
-**Error Checking** | Jacobi (LL/P-1) | | LL only
+**Error Checking** | Jacobi (LL/P-1) | LL only | LL only
 \- | Gerbicz (PRP/Pépin) | ✔️ | ✔️
 **Random Shifts** | | ✔️ | ✔️
 **Interface** | CLI | ✔️ | MPrime only
@@ -106,7 +106,7 @@ This README is still in progress. For now, see the original [Mlucas README](http
 
 ## Help
 
-The [help.txt](help.txt) file includes a variety of usage information not covered in the original [README](https://mersenneforum.org/mayer/README.html), concentrating largely on the Mlucas command line options. A separate documentation page covers [Fermat numbers](docs/Fermat-testing.md).
+The [help.txt](help.txt) file includes a variety of usage information not covered in the original [README](https://mersenneforum.org/mayer/README.html), concentrating largely on the Mlucas command line options. A separate documentation page covers [Fermat numbers](docs/Fermat-testing.md). Lucas-Lehmer tests are protected by a Jacobi residue check, controlled by the `JacobiCheck` and `JacobiCheckHours` mlucas.ini options - see help.txt section [11].
 
 ## Contributing
 

--- a/help.txt
+++ b/help.txt
@@ -229,6 +229,24 @@ The (very rough) time estimates are for 1000 iterations done using 4 or more cor
 	given Mersenne number exponent on their hardware, similarly to the -fft option. Performs
 	as many iterations as specified via the -iters flag (which is required if -m is invoked).
 
+o JACOBI RESIDUE CHECK: For production (i.e. non-self-test) Lucas-Lehmer tests of Mersenne
+numbers - not PRP, not p-1, and not Fermat/Pe'pin tests - Mlucas computes the Jacobi symbol
+J(s - 2 | M(p)) of the current residue s, which must equal -1 for every LL iterate if the
+exponent p is prime. The check runs whenever a restart file is read (checking the residue
+before anything is built on it), on the final residue before a result is reported, and
+periodically at checkpoints, no more often than every JacobiCheckHours hours of wall-clock
+time (cf. section [11]). A corrupted residue passes the check with probability 1/2, and the
+symbol is invariant under the LL recurrence, so every check after the first examines the same
+value: a corruption that passes its first check is never caught by a later one. This is
+therefore a cheap, weak check that catches half of all corruption events; how often it runs
+sets how much work is lost when one is caught, not the odds of catching it. It does not
+certify a result - a reported LL result still needs an independent double-check. A symbol of
+0 should not occur for a prime exponent; it means the residue shares a factor with the
+modulus, i.e. a corruption that no rollback would clear, so Mlucas stops rather than retry.
+The check requires GMP 5.1 or later; a build without a suitable GMP prints a one-time warning
+and runs without it. See sections [11], [12] and [14] for the mlucas.ini controls, savefiles
+and log messages it produces.
+
 ======================
 
 [5]: Fermat-number primality testing:
@@ -287,6 +305,9 @@ The (very rough) time estimates are for 1000 iterations done using 4 or more cor
 	we check whether b^(N+1) == b^2 (mod N). For N = M(p) we have N+1 = 2^p, thus this variant
 	requires (p-1) pure mod-squarings. Any self-tests done in PRP mode will do the first (iters)
 	of these.
+
+PRP-testing keeps the Gerbicz error check described above; the Jacobi residue check of
+section [4] applies only to Lucas-Lehmer tests and does not run in PRP mode.
 
 ======================
 
@@ -477,12 +498,15 @@ on a low_RAM might contain
 	CheckInterval = 10000	/* I'm using the space right of the value for a C-style comment. */
 	LowMem = 1	// But one could also use C++ comment format...
 	InterimGCD = 0	# Or bash-shell and Python-style comment format...
+	JacobiCheck = 1	Redundant, since 1 is the default, but shown here for illustration...
+	JacobiCheckHours = 6	...as is halving the default Jacobi-check interval to 6 hours.
 	LowMem = 2	Or no comment delimiter at all. Note that the program uses the first entry
 			matching a given option name, so the second LowMem entry here will be ignored.
 
-This specifies savefile-writes for LL/PRP/p-1 every 10000 iterations, and allows PRP-testing
-but excludes p-1 stage 2. The InterimGCD option setting is moot in this case since it only
-applies to p-1 stage 2.
+This specifies savefile-writes for LL/PRP/p-1 every 10000 iterations, allows PRP-testing but
+excludes p-1 stage 2, and (redundantly) leaves the Jacobi residue check on while halving its
+default checkpoint interval to 6 hours. The InterimGCD option setting is moot in this case
+since it only applies to p-1 stage 2.
 
 Note that the option-name and comment formats in mlucas.ini differ from those in local.ini -
 the latter is read and updated by the several primenet.py work-management scripts described
@@ -542,6 +566,19 @@ o DISABLING INTERIM GCDs IN P-1 STAGE 2: Set InterimGCD = 0 in mlucas.ini. This 
 the program to wait until any p-1 stage 2 is finished to take a GCD (check for a factor),
 irrespective of the depth of the stage.
 
+o JACOBI RESIDUE CHECK: Set JacobiCheck = 0 in mlucas.ini to disable the LL residue check
+described in section [4] (default 1; the check is unavailable, and this setting has no
+effect, on a build without GMP >= 5.1). JacobiCheckHours = N sets how often, in wall-clock
+hours, the check additionally runs at checkpoints (default 12; fractional values are
+allowed; 0 checks at every checkpoint, mainly useful for testing).
+
+The interval is given in hours rather than iterations because the check's cost is scalar GMP
+work that does not scale with the per-iteration FFT the way iteration counts do, so a fixed
+iteration interval would impose wildly different overhead on different hardware. Hours bound
+how long a corrupted residue can survive undetected, while the built-in rule of never
+re-checking sooner than 100x the previous check's duration bounds the overhead to near 1%
+regardless of machine speed.
+
 ======================
 
 [12]: Savefile format and creation:
@@ -571,6 +608,22 @@ renamed p[exponent].s1. The reason for this is twofold:
 	Say you ran p-1 on a low-memory system, such that only stage 1 was run. Later, you install
 	more RAM, which allows for more efficient stage 2 work. At that point, it may make sense
 	to rerun some exponents to deeper stage 2 bounds. See section [9b] for how to do this.
+
+o With the Jacobi residue check enabled (cf. sections [4] and [11]), an LL run additionally
+keeps the two most recent Jacobi-passed checkpoints, saved as p[exponent].J (the latest) and
+p[exponent].J1 (the one before it), in the same format as the p/q savefiles. A failed check means
+the corruption happened after the last passing one (an earlier corruption that passed would go on
+passing, see section [4]), so .J is the natural place to roll back to; .J1 is a spare in case .J
+is unreadable or fails its own on-read check; on a failed check Mlucas rolls back through
+the chain p -> q -> .J -> .J1 -> from scratch, Jacobi-checking each file as it is read. At a
+332-million-bit exponent each savefile is 41.5 MB, so an LL run's p, q, .J and .J1 files
+together total roughly 166 MB.
+
+o Savefiles append a 4-byte Jacobi-check-failure count after the existing roundoff- and
+Gerbicz-error counts. Older Mlucas versions and third-party savefile readers ignore trailing
+fields they don't recognize, so old and new binaries can read each other's savefiles; an old
+binary that rewrites the file drops the count back to 0, exactly as the existing error counts
+already do across a v19 downgrade.
 
 o P-1 runs also store a file p[exponent].s1_prod encoding the precomputed small-prime-powers
 product used for the stage 1 left-to-right modular binary powering. This can save time on
@@ -636,6 +689,54 @@ Once you have identified the desired process IDs:
 
 For the current list of signal types which the program listens for, see the sig_handler() function near
 the top of Mlucas.c . As of this writing (v20.1.1), the program listens for INT,TERM,HUP,ALRM,USR1 and USR2.
+
+[14b]: Jacobi residue check log messages:
+
+The Jacobi residue check (cf. sections [4], [11] and [12]) writes lines to the p[exponent].stat
+file. What each means and what, if anything, to do about it:
+
+	"At iteration N, shift = S: Jacobi check passed (T sec)."
+	Normal. No action needed.
+
+	"Jacobi check at iteration N FAILED (symbol = +1, T sec)! Restarting from the current
+	savefile." (or "...the last Jacobi-passed savefile" / "...the previous Jacobi-passed
+	savefile" / "...scratch", depending on how many consecutive failures have occurred)
+	"Restart file p12345 (iteration N) passed the Jacobi check (T sec)."
+	"Restart file p12345 (iteration N) FAILED the Jacobi check (symbol = 1, T sec) - its
+	residue is corrupt; trying the next savefile in the chain."
+	"INFO: no restart file passes the Jacobi check...starting run from scratch."
+	"Jacobi-check-error restart: Mod-doubling residue shift ..."
+	Normal recovery: the check caught a corrupted residue and the program is rolling back
+	through the p -> q -> .J -> .J1 -> scratch chain to find a good one. No action needed
+	unless this recurs often, in which case see the 5-consecutive-failures entry below.
+
+	"Jacobi check at iteration N failed with symbol 0: the residue shares a factor with the
+	modulus, which cannot happen for a correct LL residue of a prime exponent. Aborting
+	rather than retrying; ... please check this machine for hardware errors."
+	Exponents are checked for primality when the worktodo entry is read, so a symbol of 0
+	means the residue itself has been corrupted in a way rollback cannot clear. Treat it
+	like the 5-consecutive-failures case below.
+
+	"Jacobi check at iteration N failed %u times in a row, the last after restarting from
+	scratch - ... Please check this machine for hardware errors."
+	Five consecutive Jacobi-check failures, the last one from a fresh restart, means the
+	corruption is not being cleared by rolling back savefiles, so it is not transient. Stop
+	the run and test the machine's RAM and CPU before restarting.
+
+A SIGINT/SIGTERM-driven checkpoint (cf. section [14a]) never runs the Jacobi check, so shutdown
+is not slowed down; the residue is instead checked when the run is next restarted.
+
+The Jacobi-check failure count is also folded into the "error-code" hex field of the JSON
+results line (cf. section [12] for the savefile-resident version of this count): bits 4-7 hold
+the (capped) Jacobi-failure count, bits 8-13 the roundoff-error count, and bits 20-23 the
+Gerbicz-check-failure count, matching the layout the GIMPS primenet server expects (which
+ignores the low byte when deciding whether a result is "clean"). The same count also appears
+as "jacobi" in the results line's "errors" object, e.g.:
+
+	{"status":"C", "exponent":44501, "worktype":"LL", "res64":"40755C45A05FA7C0",
+	"fft-length":2048, "shift-count":0, "error-code":"00000000",
+	"errors":{"Roundoff":0, "jacobi":0}, "program":{"name":"Mlucas", "version":"21.0.2"},
+	"timestamp":"2026-09-07 02:49:29"}
 
 ======================
 

--- a/help.txt
+++ b/help.txt
@@ -236,11 +236,12 @@ exponent p is prime. The check runs whenever a restart file is read (checking th
 before anything is built on it), on the final residue before a result is reported, and
 periodically at checkpoints, no more often than every JacobiCheckHours hours of wall-clock
 time (cf. section [11]). A corrupted residue passes the check with probability 1/2, and the
-symbol is invariant under the LL recurrence, so every check after the first examines the same
-value: a corruption that passes its first check is never caught by a later one. This is
-therefore a cheap, weak check that catches half of all corruption events; how often it runs
-sets how much work is lost when one is caught, not the odds of catching it. It does not
-certify a result - a reported LL result still needs an independent double-check. A symbol of
+symbol is invariant under the LL recurrence from one iteration after a corruption on, so every
+later check examines the same value: a corruption that passes the first check after it is never
+caught by a later one. This is therefore a cheap, weak check that catches about half of all
+corruption events; how often it runs sets how much work is lost when one is caught, not the
+odds of catching it. It does not certify a result - a reported LL result still needs an
+independent double-check. A symbol of
 0 should not occur for a prime exponent; it means the residue shares a factor with the
 modulus, i.e. a corruption that no rollback would clear, so Mlucas stops rather than retry.
 The check requires GMP 5.1 or later; a build without a suitable GMP prints a one-time warning
@@ -613,8 +614,10 @@ o With the Jacobi residue check enabled (cf. sections [4] and [11]), an LL run a
 keeps the two most recent Jacobi-passed checkpoints, saved as p[exponent].J (the latest) and
 p[exponent].J1 (the one before it), in the same format as the p/q savefiles. A failed check means
 the corruption happened after the last passing one (an earlier corruption that passed would go on
-passing, see section [4]), so .J is the natural place to roll back to; .J1 is a spare in case .J
-is unreadable or fails its own on-read check; on a failed check Mlucas rolls back through
+passing, see section [4]), so .J is the natural place to roll back to; .J1 covers .J being
+unreadable or failing its own on-read check, and the rare corruption that struck exactly at a
+checked checkpoint, passed that check and fails every later one - the retry from .J then fails
+at the same iteration and the rollback moves on to .J1; on a failed check Mlucas rolls back through
 the chain p -> q -> .J -> .J1 -> from scratch, Jacobi-checking each file as it is read. At a
 332-million-bit exponent each savefile is 41.5 MB, so an LL run's p, q, .J and .J1 files
 together total roughly 166 MB.

--- a/src/Mdata.h
+++ b/src/Mdata.h
@@ -108,6 +108,9 @@ extern int DO_GCHECK;	// Mersenne/PRP or Fermat/Pepin case
 extern int ITERS_BETWEEN_GCHECK_UPDATES;	// #iterations between Gerbicz-checksum updates
 extern int ITERS_BETWEEN_GCHECKS;			// #iterations between Gerbicz-checksum residue-integrity checks
 extern uint32 NERR_GCHECK;	// v20: Add counter for Gerbicz-check errors encountered during test
+extern uint32 NERR_JACOBI;	// v21: Counter for Jacobi-check failures encountered during test
+extern int JACOBI_CHECK;	// v21: mlucas.ini JacobiCheck - 0 disables the LL Jacobi residue check (default on)
+extern double JACOBI_CHECK_HOURS;	// v21: mlucas.ini JacobiCheckHours - wall-clock hours between periodic checks (0 = every checkpoint)
 
 #undef	FACTOR_PASS_MAX
 #define	FACTOR_PASS_MAX	16
@@ -194,7 +197,8 @@ All but the "else" stuff below is specific to factor.c built in standalone mode:
 #define ERR_SKIP_RADIX_SET			14	// In context of self-testing, not fatal for run overall but skip the current set of FFT radices
 #define ERR_INTERRUPT				15	// On one of several interrupt SIGs, exit iteration loop prematurely, write savefiles and exit
 #define ERR_GERBICZ_CHECK			16
-#define ERR_MAX		ERR_GERBICZ_CHECK
+#define ERR_JACOBI_CHECK			17	// v21: LL Jacobi-symbol residue check failed - roll back to a Jacobi-passed savefile
+#define ERR_MAX		ERR_JACOBI_CHECK
 
 /***********************************************************************************************/
 /* Globals. Unless specified otherwise, these are declared in Mdata.h and defined in Mlucas.c: */

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -86,6 +86,9 @@ int USE_SHORT_CY_CHAIN = 0;
 int ITERS_BETWEEN_CHECKPOINTS;	/* number of iterations between checkpoints */
 int DO_GCHECK = FALSE;	// If Mersenne/PRP or Fermat/Peoin test, Toggle to TRUE at runtime
 uint32 NERR_GCHECK = 0;	// v20: Add counter for Gerbicz-check errors encountered during test
+uint32 NERR_JACOBI = 0;	// v21: Counter for Jacobi-check failures encountered during test
+int JACOBI_CHECK = TRUE;	// v21: mlucas.ini JacobiCheck; forced FALSE when no usable GMP is compiled in
+double JACOBI_CHECK_HOURS = 12.0;	// v21: mlucas.ini JacobiCheckHours; 0 = check at every checkpoint
 int ITERS_BETWEEN_GCHECK_UPDATES = 1000;	// iterations between Gerbicz-checkproduct updates
 int ITERS_BETWEEN_GCHECKS     = 1000000;	// #iterations between Gerbicz-checksum residue-integrity checks
 
@@ -143,7 +146,8 @@ const char *err_code[ERR_MAX] = {
 	"ERR_UNKNOWN_FATAL",
 	"ERR_SKIP_RADIX_SET",
 	"ERR_INTERRUPT",
-	"ERR_GERBICZ_CHECK"
+	"ERR_GERBICZ_CHECK",
+	"ERR_JACOBI_CHECK"
 };
 
 // Shift count and auxiliary arrays used to support rotated-residue computations:
@@ -405,6 +409,15 @@ uint32	ernstMain
 	that point (needed for the [d] mode_flag, since the update may not be in the final iteration interval).
 	gchk_nfail bounds the retry count, so a persistent (non-transient) final-check failure cannot spin: */
 	uint32 gchk_final = FALSE, gchk_iter = 0, gchk_first_sub = 0, gchk_nfail = 0, loop_exit = 0;
+	/* v21: LL Jacobi-check state (cf. jacobi_check()). do_jcheck: enabled for this assignment. jchk_tlast/jchk_tdur:
+	wall time of, and taken by, the previous check - the next waits JACOBI_CHECK_HOURS and at least 100x jchk_tdur, so the
+	check never exceeds ~1% of the run however slow the host. jchk_nfail: consecutive failures; selects the rollback
+	target (p/q, then .J, then .J1, then scratch) and bounds the retries. jchk_file: position in that chain during a
+	restart-file read. jchk_passed: this checkpoint passed, so the .J/.J1 files get updated after the p/q write: */
+	int do_jcheck = FALSE, jchk_passed = FALSE, jchk_file = 0, jsym = 0;
+	uint32 jchk_nfail = 0;
+	double jchk_tlast = 0.0, jchk_tdur = 0.0, jchk_tsec = 0.0;
+	char jchk_fname[STR_MAX_LEN];
 	/* Exponent of number to be tested - note that for trial-factoring, we represent p
 	strictly in string[STR_MAX_LEN] form in this module, only converting it to numeric
 	form in the factoring module. For all other types of assignments uint64 should suffice: */
@@ -463,10 +476,11 @@ RANGE_BEG:
 	p = 0ull; ierr = 0;
 	USE_SHORT_CY_CHAIN = 0;		// v19: Reset carry-chain length fiddler to default (faster/lower-accuracy) at start of each run:
 	ROE_ITER = 0; ROE_VAL = 0.0;
-	NERR_GCHECK = NERR_ROE = 0;	// v20: Add counters for Gerbicz-check errors and dangerously high ROEs encountered
+	NERR_GCHECK = NERR_ROE = NERR_JACOBI = 0;	// v20: Add counters for Gerbicz-check errors and dangerously high ROEs encountered
 								// during test - if a restart, will re-read actual cumulative values from checkpoint file.
 	gchk_final = FALSE; gchk_nfail = 0;	// v21: End-of-run G-check state. Reset here, i.e. once per assignment - NOT on the
 										// READ_RESTART_FILE rollback path, else a repeating failure could retry without bound.
+	jchk_nfail = 0; jchk_file = 0; jchk_passed = FALSE; jchk_tdur = 0.0; jchk_tlast = getRealTime();	// v21: ditto for the Jacobi check
 	// Clear out any FFT-radix or known-factor data that might remain from a just-completed run:
 	for(i = 0; i < 10; i++) { RADIX_VEC[i] = 0; }
 	nfac = 0; mi64_clear(KNOWN_FACTORS,40);
@@ -502,6 +516,33 @@ RANGE_BEG:
 			sprintf(cbuf,"User set CheckInterval = %d in %s.\n",(int)dtmp,MLUCAS_INI_FILE);	check_interval = (int)dtmp;
 		}
 		mlucas_fprint(cbuf,1);
+	}
+	// v21: LL Jacobi residue check controls - cf. jacobi_check(). Defaults re-established before each read so an
+	// entry removed from the file between assignments does not linger:
+	JACOBI_CHECK = TRUE;	JACOBI_CHECK_HOURS = 12.0;
+	dtmp = mlucas_getOptVal(MLUCAS_INI_FILE,"JacobiCheck");
+	if(dtmp == dtmp) {	// NaN means "not set" - keep the default
+		if(dtmp == 0.0 || dtmp == 1.0) {
+			JACOBI_CHECK = (int)dtmp;
+			sprintf(cbuf,"User set JacobiCheck = %d in %s.\n",JACOBI_CHECK,MLUCAS_INI_FILE);
+		} else {
+			sprintf(cbuf,"User set unsupported value JacobiCheck = %f in %s ... must be 0 or 1, ignoring.\n",dtmp,MLUCAS_INI_FILE);
+		}
+		mlucas_fprint(cbuf,1);
+	}
+	dtmp = mlucas_getOptVal(MLUCAS_INI_FILE,"JacobiCheckHours");
+	if(dtmp == dtmp) {
+		if(dtmp < 0.0 || dtmp > 8760.0) {
+			sprintf(cbuf,"User set JacobiCheckHours = %f in %s ... must be in [0, 8760], ignoring.\n",dtmp,MLUCAS_INI_FILE);
+		} else {
+			JACOBI_CHECK_HOURS = dtmp;
+			sprintf(cbuf,"User set JacobiCheckHours = %g in %s%s.\n",dtmp,MLUCAS_INI_FILE,(dtmp == 0.0) ? " (Jacobi check at every checkpoint)" : "");
+		}
+		mlucas_fprint(cbuf,1);
+	}
+	if(JACOBI_CHECK && !jacobi_check_available()) {
+		sprintf(cbuf,"WARN: The Jacobi residue check needs Mlucas built against GMP >= 5.1 ... disabling it for this run.\n");
+		mlucas_fprint(cbuf,1);	JACOBI_CHECK = FALSE;
 	}
 
 /*  ...If multithreading enabled, set max. # of threads based on # of available (logical) processors,
@@ -1507,6 +1548,8 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 		ASSERT(i == j*j, "#iterations between Gerbicz-checksum updates must = sqrt(#iterations between residue-integrity checks)");
 		ASSERT(i%k == 0 && k%j == 0, "G-checkproduct update interval must divide savefile-update one, which must divide the G-check interval");
 	}
+	// v21: The Jacobi residue check applies to production (non-selftest) LL tests of Mersenne numbers - cf. jacobi_check():
+	do_jcheck = JACOBI_CHECK && !INTERACT && (TEST_TYPE == TEST_TYPE_PRIMALITY) && (MODULUS_TYPE == MODULUS_TYPE_MERSENNE);
 
 	// PRP-test: Init bitwise multiply-by-base array - cf. comment re. modified Fermat-PRP needed by Gerbicz check
 	// above ==> all bits = 0 for Mersenne-PRP-test, rather than all-ones-with-least-significant-bit-0 as for the
@@ -1524,9 +1567,22 @@ READ_RESTART_FILE:
 			strcpy(g_cstr, RESTARTFILE); strcat(g_cstr, ".G");
 		} else if(s2_continuation) {
 			strcpy(g_cstr, RESTARTFILE); strcat(g_cstr, ".s1");
+		} else if(do_jcheck) {
+			/* v21: With the Jacobi check on, every restart-file read walks the chain p -> q -> .J -> .J1 -> scratch, indexed by
+			jchk_file: a file that fails to read, fails to convert, or fails the Jacobi check on read is skipped for the next.
+			On a checkpoint-time Jacobi failure the failure site sets the starting position from the consecutive-failure count,
+			so a file which passed on read but led straight to another failure (a corrupt residue passes the check with
+			probability 1/2) is not tried twice. Reaching the end of the chain starts the run from scratch: */
+			strcpy(g_cstr, RESTARTFILE); g_cstr[0] = ((MODULUS_TYPE == MODULUS_TYPE_MERSENNE) ? 'p' : 'f');
+			if(jchk_file == 1) { g_cstr[0] = 'q'; }
+			else if(jchk_file == 2) { strcat(g_cstr, ".J"); }
+			else if(jchk_file == 3) { strcat(g_cstr, ".J1"); }
 		}
 		/* See if there's a restart file: */
-		fp = mlucas_fopen(g_cstr, "rb");
+		if(do_jcheck && jchk_file >= 4)
+			fp = 0x0;	// v21: Jacobi rollback chain exhausted - handled as "no restart file" below
+		else
+			fp = mlucas_fopen(g_cstr, "rb");
 		/* If so, read the savefile: */
 		if(fp) {
 			if(TEST_TYPE == TEST_TYPE_PRP) {
@@ -1549,11 +1605,30 @@ READ_RESTART_FILE:
 				if(ierr == ERR_GERBICZ_CHECK) {
 					sprintf(cbuf,"Failed to correctly read last-good-Gerbicz-check data savefile!");
 					mlucas_fprint(cbuf,0); ASSERT(0,cbuf);
+				} else if(do_jcheck) {	// v21: next file in the Jacobi rollback chain
+					jchk_file++;	goto READ_RESTART_FILE;
 				} else if(g_cstr[0] != 'q') {
 					g_cstr[0] = 'q';	goto READ_RESTART_FILE;
 				} else {
 					sprintf(cbuf,"Failed to correctly read both primary or secondary savefile!");
 					mlucas_fprint(cbuf,0); ASSERT(0,cbuf);
+				}
+			}
+			/* v21: Jacobi-check the residue just read, before anything is built on it. This is the one check a freshly loaded
+			residue gets: it catches a savefile written from an already-corrupt residue (the S-H checksum triplet only proves the
+			file is self-consistent), and it is what makes rolling back through the chain safe. Not counted in NERR_JACOBI - the
+			checkpoint-time failure that led here (if any) already was: */
+			if(do_jcheck) {
+				jsym = jacobi_check(p, arrtmp, (uint32)((p+63)>>6), 2, &jchk_tsec);
+				jchk_tlast = getRealTime(); jchk_tdur = jchk_tsec;
+				if(jsym == -1) {
+					snprintf(cbuf,sizeof(cbuf), "Restart file %s (iteration %" PRIu64 ") passed the Jacobi check (%.1f sec).\n",g_cstr,itmp64,jchk_tsec);
+					mlucas_fprint(cbuf,1);
+				} else {
+					snprintf(cbuf,sizeof(cbuf), "Restart file %s (iteration %" PRIu64 ") FAILED the Jacobi check (symbol = %d, %.1f sec) - its residue is corrupt; trying the next savefile in the chain.\n",g_cstr,itmp64,jsym,jchk_tsec);
+					mlucas_fprint(cbuf,1);
+					// q is a byte-for-byte copy of p, so a p that read fine but fails the check means q would too - skip it:
+					jchk_file = (jchk_file == 0) ? 2 : jchk_file + 1;	goto READ_RESTART_FILE;
 				}
 			}
 			// If user attempts to restart run with different PRP base than it was started with, ignore the new value and continue with the initial one:
@@ -1592,9 +1667,9 @@ READ_RESTART_FILE:
 			deadly" aliased-ROE type are negligibly small. Even should such an improbability occur, if it does the program will once
 			more pseudorandomize the FFT inputs by again mod-doubling the shift count, i.e. we'll never get stuck:
 			*/
-			if(ierr == ERR_GERBICZ_CHECK) {
+			if(ierr == ERR_GERBICZ_CHECK || ierr == ERR_JACOBI_CHECK) {	// v21: same reasoning applies to a Jacobi-check rollback
 				MOD_ADD64(RES_SHIFT,RES_SHIFT,p,RES_SHIFT);
-				snprintf(cbuf,sizeof(cbuf), "Gerbicz-check-error restart: Mod-doubling residue shift to avoid repeating any possible fractional-error aliasing in retry, new shift = %" PRIu64 "\n",RES_SHIFT);
+				snprintf(cbuf,sizeof(cbuf), "%s-check-error restart: Mod-doubling residue shift to avoid repeating any possible fractional-error aliasing in retry, new shift = %" PRIu64 "\n",(ierr == ERR_GERBICZ_CHECK) ? "Gerbicz" : "Jacobi",RES_SHIFT);
 				mlucas_fprint(cbuf,1);
 			}
 			/* Allocate floating-point residue array and convert savefile bytewise residue to floating-point form, after
@@ -1603,7 +1678,9 @@ READ_RESTART_FILE:
 			if(!convert_res_bytewise_FP((uint8 *)arrtmp, a, n, p)) {
 				snprintf(cbuf,sizeof(cbuf), "ERROR: convert_res_bytewise_FP Failed on primality-test residue read from savefile %s!\n",g_cstr);
 				mlucas_fprint(cbuf,0);
-				if(g_cstr[0] != 'q' && !(ierr == ERR_GERBICZ_CHECK)) {	// Secondary savefile only exists for regular checkpoint files
+				if(do_jcheck) {	// v21: next file in the Jacobi rollback chain
+					jchk_file++;	goto READ_RESTART_FILE;
+				} else if(g_cstr[0] != 'q' && !(ierr == ERR_GERBICZ_CHECK)) {	// Secondary savefile only exists for regular checkpoint files
 					g_cstr[0] = 'q';
 					goto READ_RESTART_FILE;
 				} else {
@@ -1620,6 +1697,8 @@ READ_RESTART_FILE:
 				s1 = sum64(b_uint64_ptr, n); s2 = s3 = s1;	// Init triply-redundant checksum of G-checkproduct
 			}
 		  }
+			if(ierr == ERR_JACOBI_CHECK) ierr = 0;	// v21: Jacobi rollback target read and vetted - resume from it
+			jchk_file = 0;	// v21: any later restart-file read starts from the primary savefile again
 			ASSERT(ilo > 0,"Require ilo > 0!");
 			ihi = ilo+ITERS_BETWEEN_CHECKPOINTS;
 			/* If for some reason last checkpoint was at a non-multiple of ITERS_BETWEEN_CHECKPOINTS, round down: */
@@ -1635,6 +1714,19 @@ READ_RESTART_FILE:
 				snprintf(cbuf,sizeof(cbuf), "INFO: Needed restart file %s not found...moving on to next assignment in %s.\n",g_cstr,WORKFILE);
 				mlucas_fprint(cbuf,1);
 				goto GET_NEXT_ASSIGNMENT;
+			} else if(do_jcheck && jchk_file < 4) {	// v21: Jacobi rollback chain: this file is absent, try the next
+				if(jchk_file <= 1 || ierr == ERR_JACOBI_CHECK) {	// .J/.J1 are normally absent on a fresh start - don't mention them then
+					snprintf(cbuf,sizeof(cbuf), "INFO: restart file %s not found...looking for the next one.\n",g_cstr);
+					mlucas_fprint(cbuf,1);
+				}
+				jchk_file++;	goto READ_RESTART_FILE;
+			} else if(do_jcheck) {	// v21: chain exhausted
+				if(ierr == ERR_JACOBI_CHECK)
+					sprintf(cbuf, "INFO: no restart file passes the Jacobi check...starting run from scratch.\n");
+				else
+					sprintf(cbuf, "INFO: no restart file found...starting run from scratch.\n");
+				mlucas_fprint(cbuf,1);
+				ierr = 0; restart = FALSE; jchk_file = 0;
 			} else if(g_cstr[0] != 'q') {
 				snprintf(cbuf,sizeof(cbuf), "INFO: primary restart file %s not found...looking for secondary...\n",g_cstr);
 				mlucas_fprint(cbuf,1);
@@ -2122,6 +2214,33 @@ READ_RESTART_FILE:
 		// Zero high uint64s of target arrays, since double-to-int residue conversion is bytewise & may leave >=1 MSBs in high word untouched:
 		// Fermat-mod residue formally needs an extra bit, though said bit should == 1
 		// only in the highly unlikely case of a prime-Fermat Pepin-test result:
+	#ifdef MLUCAS_FAULT_INJECT
+		/* Test-only fault injector - build with -DMLUCAS_FAULT_INJECT, never in a release build. At the checkpoint whose
+		iteration count equals $MLUCAS_FAULT_ITER, add 1.0 to balanced digit $MLUCAS_FAULT_WORD (default 0) of the residue,
+		i.e. perturb the residue by 2^(bit offset of that digit). The perturbed value is what gets checked, saved and iterated
+		on from here, exactly as a memory fault in the residue array would be - which makes the ensuing check/rollback path
+		testable deterministically (a given (iteration, digit) always yields the same verdict). Fires once per process, so
+		the retry after a rollback runs clean. Iterations below 64 are refused: the residue is not full-size before
+		~log2(p) iterations, so an early injection tests nothing about the real arithmetic path: */
+		{
+			static int fi_parsed = 0, fi_done = 0; static uint32 fi_iter = 0, fi_word = 0;
+			if(!fi_parsed) {
+				const char *fi_e = getenv("MLUCAS_FAULT_ITER"), *fi_w = getenv("MLUCAS_FAULT_WORD");
+				fi_parsed = 1;
+				if(fi_e) {
+					fi_iter = (uint32)strtoul(fi_e,0x0,10);	if(fi_w) fi_word = (uint32)strtoul(fi_w,0x0,10);
+					ASSERT(fi_iter >= 64, "MLUCAS_FAULT_ITER must be >= 64: the residue is not full-size before ~log2(p) iterations.");
+					ASSERT(fi_word < (uint32)n, "MLUCAS_FAULT_WORD must be less than the FFT length.");
+				}
+			}
+			if(fi_iter && !fi_done && ihi == fi_iter && ierr == 0 && !INTERACT) {
+				uint32 fi_j1 = fi_word + ((fi_word >> DAT_BITS) << PAD_BITS);	// padded-array index of digit fi_word
+				a[fi_j1] += 1.0;	fi_done = 1;
+				snprintf(cbuf,sizeof(cbuf), "FAULT INJECTION: added 1.0 to residue digit %u at iteration %u.\n",fi_word,ihi);
+				mlucas_fprint(cbuf,1);
+			}
+		}
+	#endif
 		j = (p+63+(MODULUS_TYPE == MODULUS_TYPE_FERMAT))>>6;	arrtmp[j-1] = 0ull;
 		convert_res_FP_bytewise(	a, (uint8 *)      arrtmp, n, p, &Res64, &Res35m1, &Res36m1);	// LL/PRP-test/[p-1 stage 1] residue
 		// G-check residue...must not touch i1,i2,i3 again until ensuing write_ppm1_savefiles call!
@@ -2172,6 +2291,48 @@ READ_RESTART_FILE:
 				, timebuffer, PSTRING, iter_or_stage[TEST_TYPE == TEST_TYPE_PM1], ihi, (float)ihi / (float)maxiter * 100,get_time_str(tdiff)
 				, 1000*get_time(tdiff)/(ihi - ilo), Res64, AME, MME, RES_SHIFT);
 			mlucas_fprint(cbuf,scrnFlag);
+		}
+
+		/* v21: LL Jacobi residue check on the shift-removed residue just converted into arrtmp[] (cf. jacobi_check()).
+		Runs on the final residue - the value about to be reported - and otherwise once JACOBI_CHECK_HOURS have elapsed
+		since the previous check (at every checkpoint if that is 0), but never on an interrupt-driven checkpoint (a
+		shutdown must not stall for the ~30 sec a 100M-bit check takes; the residue is checked on the ensuing restart
+		instead), and never sooner than 100x the previous check's duration, which caps the overhead near 1% however
+		slow the host. Must precede the loop_exit break below, since LL writes no final savefile: */
+		jchk_passed = FALSE;
+		if(do_jcheck && ierr == 0) {
+			double tnow = getRealTime(), twait = MAX(JACOBI_CHECK_HOURS*3600.0, 100.0*jchk_tdur);
+			if(ihi == maxiter || JACOBI_CHECK_HOURS == 0.0 || (tnow - jchk_tlast) >= twait) {
+				jsym = jacobi_check(p, arrtmp, j, 2, &jchk_tsec);
+				jchk_tlast = getRealTime(); jchk_tdur = jchk_tsec;
+				if(jsym == -1) {
+					snprintf(cbuf,sizeof(cbuf), "At iteration %u, shift = %" PRIu64 ": Jacobi check passed (%.1f sec).\n",ihi,RES_SHIFT,jchk_tsec);
+					mlucas_fprint(cbuf,scrnFlag);
+					jchk_nfail = 0; jchk_passed = TRUE;
+				} else if(jsym == 0) {
+					/* Symbol 0 means gcd(s - 2, M(p)) > 1. Exponents are checked prime when the worktodo entry is parsed (the
+					composite case, where M(q) | M(p) for q | p and the LL sequence collapses mod M(q), never gets here), so for
+					a genuine LL residue this has probability ~1/q per iteration over the factors q of M(p) - i.e. it does not
+					happen. A residue that lands on it is corrupt in a way no rollback is likely to clear, so stop rather than
+					retry, and say what was seen: */
+					snprintf(cbuf,sizeof(cbuf), "Jacobi check at iteration %u failed with symbol 0: the residue shares a factor with the modulus, which cannot happen for a correct LL residue of a prime exponent. Aborting rather than retrying; %s savefiles left in place - please check this machine for hardware errors.\n",ihi,PSTRING);
+					mlucas_fprint(cbuf,1); ASSERT(0,cbuf);
+				} else {
+					NERR_JACOBI++; jchk_nfail++;
+					if(jchk_nfail >= 5) {
+						snprintf(cbuf,sizeof(cbuf), "Jacobi check at iteration %u failed %u times in a row, the last after restarting from scratch - the error is not being cleared by rolling back, so it is not transient. Aborting rather than retrying without bound; %s savefiles left in place. Please check this machine for hardware errors.\n",ihi,jchk_nfail,PSTRING);
+						mlucas_fprint(cbuf,1); ASSERT(0,cbuf);
+					}
+					/* Rollback target from the failure count: the current savefiles first (the corruption may postdate them);
+					then the two Jacobi-passed checkpoints; then scratch. Each candidate is itself Jacobi-checked on read: */
+					jchk_file = (jchk_nfail == 1) ? 0 : (jchk_nfail == 2) ? 2 : (jchk_nfail == 3) ? 3 : 4;
+					snprintf(cbuf,sizeof(cbuf), "Jacobi check at iteration %u FAILED (symbol = %+d, %.1f sec)! Restarting from %s.\n",ihi,jsym,jchk_tsec,
+						(jchk_file == 0) ? "the current savefile" : (jchk_file == 2) ? "the last Jacobi-passed savefile" : (jchk_file == 3) ? "the previous Jacobi-passed savefile" : "scratch");
+					mlucas_fprint(cbuf,1);
+					ierr = ERR_JACOBI_CHECK;
+					goto READ_RESTART_FILE;
+				}
+			}
 		}
 
 		// Do not save a final residue unless p-1 (if not, still leave penultimate residue file intact).
@@ -2413,6 +2574,33 @@ READ_RESTART_FILE:
 					mlucas_fprint(cbuf,1);
 				}
 			}	// ihi a multiple of ITERS_BETWEEN_GCHECKS?
+		}
+
+		/* v21: LL Jacobi check - on a passing check keep the two most recent Jacobi-passed checkpoints, p[exp].J (this one)
+		and p[exp].J1 (the previous). A failing check normally implies the corruption postdates the last passing one (the
+		symbol is invariant under the recurrence, so an earlier corruption that passed would go on passing), which makes .J
+		the natural rollback target. .J1 covers the two ways that can fail: .J unreadable or failing its on-read check, and
+		a corruption that landed exactly at a checked checkpoint, passed that check (so .J holds it) and fails every later
+		one - the retry from .J then fails at the same iteration and the chain advances to .J1. Both exercised in tests: */
+		if(do_jcheck && jchk_passed) {
+			strcpy(g_cstr, RESTARTFILE);	strcat(g_cstr, ".J");
+			snprintf(jchk_fname,STR_MAX_LEN, "%s.J1",RESTARTFILE);
+			fp = mlucas_fopen(g_cstr, "rb");	// Only rotate if a .J exists yet (rename would just fail noisily otherwise)
+			if(fp) {
+				fclose(fp); fp = 0x0;
+				if(mlucas_rename(g_cstr, jchk_fname)) {
+					snprintf(cbuf,sizeof(cbuf), "WARN: unable to rename %s ==> %s; the previous Jacobi-passed checkpoint is lost.\n",g_cstr,jchk_fname);
+					mlucas_fprint(cbuf,1);
+				}
+			}
+			fp = mlucas_fopen_atomic(g_cstr, "wb");
+			if(fp) {
+				write_ppm1_savefiles(g_cstr,p,n,fp, itmp64, (uint8 *)arrtmp,Res64,Res35m1,Res36m1, (uint8 *)e_uint64_ptr,i1,i2,i3);
+				close_savefile(g_cstr,fp); fp = 0x0;
+			} else {
+				snprintf(cbuf,sizeof(cbuf), "ERROR: unable to open Jacobi-check savefile %s for write of checkpoint data.\n",g_cstr);
+				mlucas_fprint(cbuf,1);
+			}
 		}
 
 		if(ierr == ERR_INTERRUPT) exit(0);
@@ -5443,8 +5631,8 @@ int read_ppm1_savefiles(const char *fname, uint64 p, uint32 *kblocks, FILE *fp, 
 	reported to the server as a maximal hardware-error code. Init from the globals so that fields which
 	the file does not contain (older formats) are left as-is, exactly as before:
 	*/
-	uint32 prp_base = PRP_BASE, nerr_roe = NERR_ROE, nerr_gcheck = NERR_GCHECK;
-	uint64 res_shift = 0ull, gcheck_shift = GCHECK_SHIFT, len_v17,len_v19;
+	uint32 prp_base = PRP_BASE, nerr_roe = NERR_ROE, nerr_gcheck = NERR_GCHECK, nerr_jacobi = NERR_JACOBI;
+	uint64 res_shift = 0ull, gcheck_shift = GCHECK_SHIFT, len_v17,len_v19,len_v20;
 	uint128 ui128,vi128; uint192 ui192,vi192; uint256 ui256,vi256;	// Fixed-length 2/3/4-word ints for stashing results of multiword modexp.
 	*Res64 = 0ull;	// 0 value on return indicates failure of some kind
 	mi64_clear(pow,4); mi64_clear(rem,4);
@@ -5511,6 +5699,7 @@ int read_ppm1_savefiles(const char *fname, uint64 p, uint32 *kblocks, FILE *fp, 
 	*/
 	len_v17 = (uint64)nbytes + 28;
 	len_v19 = len_v17 + 11 + (DO_GCHECK ? (uint64)nbytes + 30 : 0ull);
+	len_v20 = len_v19 + 8;	// v21: + the two 4-byte error counts (NERR_ROE, NERR_GCHECK)
 
 	i = read_ppm1_residue(nbytes, fp, arr1, Res64,Res35m1,Res36m1);
 	if(!i) return 0;
@@ -5685,11 +5874,29 @@ Thus if we use a negative-power algo, to recover 2^p (mod q = 2^k.qodd):
 		nerr += i << (8*j);
 	}
 	nerr_gcheck = MAX(nerr,nerr_gcheck);
+	/* v21: Jacobi-check failure count, appended after the v20 fields so that older readers - which stop after the two
+	counts above - are unaffected. Absent from v20/v21-format savefiles: EOF on its first byte, with the file length
+	confirming a complete v20-format file, means "not tracked yet" and the count continues from its current value: */
+	nerr = 0ull;
+	for(j = 0; j < 4; j++) {
+		i = fgetc(fp);
+		if(i == EOF) {
+			if(!j) {
+				if(!savefile_ends_at(func,fname,fp,1,len_v20,FALSE)) return 0;
+				goto SAVEFILE_READ_DONE;
+			} else {
+				sprintf(cbuf, "%s: Expected 4 Jacobi-check-error-count bytes in savefile %s!\n",func,fname);
+				fprintf(stderr,"%s", cbuf);	return 0;
+			}
+		}
+		nerr += i << (8*j);
+	}
+	nerr_jacobi = MAX(nerr,nerr_jacobi);
 
 SAVEFILE_READ_DONE:
 	// v21: Read succeeded - only now commit the parsed values to their globals:
 	RES_SHIFT = res_shift;	PRP_BASE = prp_base;	GCHECK_SHIFT = gcheck_shift;
-	NERR_ROE = nerr_roe;	NERR_GCHECK = nerr_gcheck;
+	NERR_ROE = nerr_roe;	NERR_GCHECK = nerr_gcheck;	NERR_JACOBI = nerr_jacobi;
 	/* Don't deallocate arr1 here, since we'll need it later for savefile writes. */
 	return 1;
 }
@@ -5764,6 +5971,7 @@ void write_ppm1_savefiles(const char *fname, uint64 p, int n, FILE *fp, uint64 i
 	// v20: Write cumulative #errs for ROE >= 0.4375 (>= for LL, > for PRP) and Gerbicz-check for the test in question:
 	i  = write_savefile_field(fp,NERR_ROE   ,4);
 	i &= write_savefile_field(fp,NERR_GCHECK,4);
+	i &= write_savefile_field(fp,NERR_JACOBI,4);	// v21: appended last, so older readers can ignore it
 	if(!i) goto SAVEFILE_WRITE_ERR;
 	return;
 
@@ -6524,14 +6732,15 @@ void generate_JSON_report(
 		if(is_hex_string(char_addr, 32) && STRNEQN(char_addr,"00000000000000000000000000000000",32))
 			strncpy(aid,char_addr,32);
 	}
-	const uint32 error_code = (MIN(NERR_ROE, 0x3F) << 8) | (MIN(NERR_GCHECK, 0xF) << 20);
+	// Bit layout follows the GIMPS server's convention: Jacobi-check failures in bits 4-7, roundoff in 8-13, Gerbicz in 20-23:
+	const uint32 error_code = (MIN(NERR_JACOBI, 0xF) << 4) | (MIN(NERR_ROE, 0x3F) << 8) | (MIN(NERR_GCHECK, 0xF) << 20);
 	// Write the result line. The 2 nested conditionals here are LL-or-PRP and has-AID-or-not:
 	if(TEST_TYPE == TEST_TYPE_PRIMALITY) {
 		snprintf(ttype,10,"LL");
 		if(*aid) {
-			snprintf(p_cstr,STR_MAX_LEN,"{\"status\":\"%c\", \"exponent\":%" PRIu64 ", \"worktype\":\"%s\", \"res64\":\"%016" PRIX64 "\", \"fft-length\":%u, \"shift-count\":%" PRIu64 ", \"error-code\":\"%08X\", \"errors\":{\"Roundoff\":%u}, \"program\":{\"name\":\"Mlucas\", \"version\":\"%s\"}, \"timestamp\":\"%s\", \"aid\":\"%s\"}\n",prp_status[isprime],p,ttype,Res64,n,RES_SHIFT,error_code,NERR_ROE,VERSION,timebuffer,aid);
+			snprintf(p_cstr,STR_MAX_LEN,"{\"status\":\"%c\", \"exponent\":%" PRIu64 ", \"worktype\":\"%s\", \"res64\":\"%016" PRIX64 "\", \"fft-length\":%u, \"shift-count\":%" PRIu64 ", \"error-code\":\"%08X\", \"errors\":{\"Roundoff\":%u, \"jacobi\":%u}, \"program\":{\"name\":\"Mlucas\", \"version\":\"%s\"}, \"timestamp\":\"%s\", \"aid\":\"%s\"}\n",prp_status[isprime],p,ttype,Res64,n,RES_SHIFT,error_code,NERR_ROE,NERR_JACOBI,VERSION,timebuffer,aid);
 		} else {
-			snprintf(p_cstr,STR_MAX_LEN,"{\"status\":\"%c\", \"exponent\":%" PRIu64 ", \"worktype\":\"%s\", \"res64\":\"%016" PRIX64 "\", \"fft-length\":%u, \"shift-count\":%" PRIu64 ", \"error-code\":\"%08X\", \"errors\":{\"Roundoff\":%u}, \"program\":{\"name\":\"Mlucas\", \"version\":\"%s\"}, \"timestamp\":\"%s\"}\n",prp_status[isprime],p,ttype,Res64,n,RES_SHIFT,error_code,NERR_ROE,VERSION,timebuffer);
+			snprintf(p_cstr,STR_MAX_LEN,"{\"status\":\"%c\", \"exponent\":%" PRIu64 ", \"worktype\":\"%s\", \"res64\":\"%016" PRIX64 "\", \"fft-length\":%u, \"shift-count\":%" PRIu64 ", \"error-code\":\"%08X\", \"errors\":{\"Roundoff\":%u, \"jacobi\":%u}, \"program\":{\"name\":\"Mlucas\", \"version\":\"%s\"}, \"timestamp\":\"%s\"}\n",prp_status[isprime],p,ttype,Res64,n,RES_SHIFT,error_code,NERR_ROE,NERR_JACOBI,VERSION,timebuffer);
 		}
 	} else if(TEST_TYPE == TEST_TYPE_PRP && KNOWN_FACTORS[0]) {	// PRP-CF result
 		// Print list of known factors used for CF test. Unlike the Primenet assignment formtting on the input side,
@@ -6961,6 +7170,71 @@ void modinv(uint64 p, uint64 *vec1, uint64 *vec2, uint32 nlimb) {
 	// Done with the GMP arrays ... gmp_one needs clearing as well, cf. the comment in gcd():
 	mpz_clear(gmp_arr1); mpz_clear(gmp_arr2); mpz_clear(gmp_one);
 #endif	// INCLUDE_GMP ?
+}
+
+/*********************/
+
+/* v21: Jacobi-symbol residue check.
+
+For an LL test of M(p) = 2^p - 1, p an odd prime, the iterates s_n satisfy J(s_n - 2 | M(p)) = -1 for every
+n >= 1 whatever M(p)'s primality: s_n - 2 = (s_{n-1} - 2)(s_{n-1} + 2) with s_{n-1} + 2 = s_{n-2}^2 a square,
+so the symbol telescopes to J(s_1 - 2 | M(p)) = J(12 | M(p)) = J(3 | M(p)) = -1 (M(p) = 1 mod 3, 3 mod 4).
+A corrupted residue satisfies it with probability 1/2 - and the symbol is *invariant* under the recurrence from
+one iteration after a corruption on (J(s_{n+1} - 2) = J(s_n - 2) J(s_{n-1}^2) = J(s_n - 2) once s_{n-1} is itself
+an iterate of the corrupted value). So the checks see at most two independent values per corruption: the symbol
+at the corrupted iteration itself, only if a check happens to run exactly there, and one further value shared
+by every later check. A corruption mid-interval - the realistic case - gets one coin: caught with probability
+1/2 by the first check after it, or never. This is therefore a cheap, weak check; the check cadence sets how
+much work is lost when a corruption is caught, not the odds of catching it. It does not certify the result.
+The circular residue shift is irrelevant to the symbol (J(2 | M(p)) = +1), but the -2 must be applied to the
+unshifted value, i.e. the form convert_res_FP_bytewise() leaves in arrtmp[] and the savefiles hold.
+
+Computes J(res - sub | N), N = 2^p -+ 1 per MODULUS_TYPE, res[] the shift-removed residue in little-endian
+bytewise form. Only the low ceil(p/8) bytes are read, so stale high bytes in the top limb are harmless.
+Returns +1, -1 or 0 and sets *tsec to the wall time taken. GMP's mpz_jacobi became subquadratic in 5.1.0;
+the older quadratic version would take hours at 100M bits, so a build against an older GMP (or without GMP)
+reports the check unavailable rather than run it. Measured (i9-10885H, GMP 6.3): 0.08 s at 1M bits, 28 s at
+100M, 146 s at 332M, 259 s at 595M.
+*/
+int jacobi_check_available(void) {
+#if INCLUDE_GMP && defined(__GNU_MP_RELEASE) && (__GNU_MP_RELEASE >= 50100)
+	return 1;
+#else
+	return 0;
+#endif
+}
+
+int jacobi_check(uint64 p, const uint64 *res, uint32 nlimb, uint32 sub, double *tsec) {
+#if !(INCLUDE_GMP && defined(__GNU_MP_RELEASE) && (__GNU_MP_RELEASE >= 50100))
+	if(tsec) *tsec = 0.0;
+	return JACOBI_UNAVAILABLE;
+#else
+	// Unlike standard types and Mlucas internal structs, GMP objects must be declared before any expressions:
+	mpz_t gmp_a, gmp_n;
+	int jsym;
+	double clock1, clock2;
+	size_t nbytes;
+	ASSERT(res != 0x0, "Null residue pointer input to jacobi_check()!");
+	ASSERT(MODULUS_TYPE == MODULUS_TYPE_MERSENNE || MODULUS_TYPE == MODULUS_TYPE_FERMAT, "jacobi_check(): unsupported modulus type!");
+	ASSERT(nlimb >= (uint32)((p+63+(MODULUS_TYPE == MODULUS_TYPE_FERMAT))>>6), "jacobi_check(): nlimb too small for the exponent!");
+	nbytes = (size_t)((p + (MODULUS_TYPE == MODULUS_TYPE_FERMAT) + 7)>>3);	// Fermat-mod residue may need the extra bit
+	clock1 = getRealTime();
+	mpz_init(gmp_a); mpz_init(gmp_n);
+	mpz_import(gmp_a, nbytes, -1, 1, 0, 0, res);	// least-significant byte first, host byte order within each byte
+	mpz_ui_pow_ui(gmp_n, 2ul, (unsigned long)p);
+	if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE)
+		mpz_sub_ui(gmp_n, gmp_n, 1ul);
+	else
+		mpz_add_ui(gmp_n, gmp_n, 1ul);
+	mpz_sub_ui(gmp_a, gmp_a, (unsigned long)sub);
+	if(mpz_sgn(gmp_a) < 0)
+		mpz_add(gmp_a, gmp_a, gmp_n);
+	jsym = mpz_jacobi(gmp_a, gmp_n);
+	mpz_clear(gmp_a); mpz_clear(gmp_n);
+	clock2 = getRealTime();
+	if(tsec) *tsec = clock2 - clock1;
+	return jsym;
+#endif
 }
 
 /*********************/

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -398,6 +398,13 @@ uint32	ernstMain
 	uint32 dum = 0,findex = 0,ierr = 0,ilo = 0,ihi = 0,iseed,isprime,kblocks = 0,maxiter = 0,n = 0,npad = 0;
 	uint64 itmp64,cy, s1 = 0ull,s2 = 0ull,s3 = 0ull;	// s1,2,3: Triply-redundant whole-array checksum on b,c-arrays used in the G-check
 	uint32 mode_flag = 0, first_sub = 0, last_sub;
+	/* v21: End-of-run Gerbicz check. The regular check only fires at multiples of ITERS_BETWEEN_GCHECKS,
+	which maxiter (= p for a Mersenne PRP, = 2^m-1 for a Pepin test) never is, so the tail of every run
+	went unchecked. gchk_final is set when the checkproduct receives its last update of the run; gchk_iter
+	is the iteration count that update corresponds to, and gchk_first_sub the first_sub value in effect at
+	that point (needed for the [d] mode_flag, since the update may not be in the final iteration interval).
+	gchk_nfail bounds the retry count, so a persistent (non-transient) final-check failure cannot spin: */
+	uint32 gchk_final = FALSE, gchk_iter = 0, gchk_first_sub = 0, gchk_nfail = 0, loop_exit = 0;
 	/* Exponent of number to be tested - note that for trial-factoring, we represent p
 	strictly in string[STR_MAX_LEN] form in this module, only converting it to numeric
 	form in the factoring module. For all other types of assignments uint64 should suffice: */
@@ -458,6 +465,8 @@ RANGE_BEG:
 	ROE_ITER = 0; ROE_VAL = 0.0;
 	NERR_GCHECK = NERR_ROE = 0;	// v20: Add counters for Gerbicz-check errors and dangerously high ROEs encountered
 								// during test - if a restart, will re-read actual cumulative values from checkpoint file.
+	gchk_final = FALSE; gchk_nfail = 0;	// v21: End-of-run G-check state. Reset here, i.e. once per assignment - NOT on the
+										// READ_RESTART_FILE rollback path, else a repeating failure could retry without bound.
 	// Clear out any FFT-radix or known-factor data that might remain from a just-completed run:
 	for(i = 0; i < 10; i++) { RADIX_VEC[i] = 0; }
 	nfac = 0; mi64_clear(KNOWN_FACTORS,40);
@@ -1846,6 +1855,10 @@ READ_RESTART_FILE:
 		ASSERT(maxiter > 0,"Require (uint32)maxiter > 0");
 		if(ihi > maxiter)
 			ihi = maxiter;
+		/* v21: The end-of-run G-check flag is set and consumed within a single iteration interval, so clear it here.
+		This also keeps it from going stale across the various mid-interval error-recovery gotos (ROE FFT-length
+		bump, ERR_CARRY savefile-rollback), any of which can restart an interval in which it had already been set: */
+		gchk_final = FALSE;
 		// If p-1: start of each iteration cycle, copy bits ilo:ihi-1 of PM1_S1_PRODUCT into low bits of BASE_MULTIPLIER_BITS vector:
 		if(TEST_TYPE == TEST_TYPE_PM1) {
 			k = (ihi+63)>>6;// #limbs of PM1_S1_PRODUCT needed, INCL. BITS 0:ILO-1 WHICH WILL BE GETTING OFF-SHIFTED - only extract ilo:ihi-1
@@ -1926,11 +1939,26 @@ READ_RESTART_FILE:
 				compute b *= c (mod n). But again wasteful, would rather just complete the fwd-FFT of c[] instead of undoing and then immediately
 				redoing the initial fwd-FFT-radix pass of it. But, we do this infrequently enough that we don't care!
 				[EWM: Update: Added the FFT mode_flag control mechanism to eliminate this redundant work] */
+				i += itodo;
+				/* v21: Only iteration counts which are multiples of L = ITERS_BETWEEN_GCHECK_UPDATES may be folded
+				into the checkproduct: the Gerbicz identity [b == u0.d^(2^L)] holds only if the update points are
+				equally spaced L apart. The sole non-multiple-of-L endpoint is that of the final partial subinterval
+				(itodo clipped to maxiter-i above), so skip the b[]-update for it. Instead the run's final G-check is
+				done at the last L-aligned update point, i.e. at iteration L*(maxiter/L) - see the G-check block below.
+				(Self-tests never reach that check, so leave their b[]-handling exactly as it was.)
+				*/
+				if(!INTERACT && (i % ITERS_BETWEEN_GCHECK_UPDATES)) continue;
+				/* Is this the last checkproduct update of the run, i.e. the one our end-of-run G-check must use?
+				(No further update can occur, since the next L-aligned iteration count exceeds maxiter.) Snapshot the
+				iteration count and first_sub, since the check itself may not run until a later iteration interval: */
+				gchk_final = !INTERACT && (i + ITERS_BETWEEN_GCHECK_UPDATES > maxiter);
+				if(gchk_final) {
+					gchk_iter = i; gchk_first_sub = first_sub;
+				}
 				memcpy(c, a, nbytes);	// Copy a into c and do fwd-FFT-only of c:
 				// If going to proceed to actual Gerbicz-check, need to save an un-updated copy of the checkproduct:
-				i += itodo;
 			//	fprintf(stderr,"At Iter %u: copy a[] -> c[]\n",i);
-				if(i % ITERS_BETWEEN_GCHECKS == 0) {
+				if(i % ITERS_BETWEEN_GCHECKS == 0 || gchk_final) {
 					memcpy(d, b, nbytes);
 				}
 			// All-but-Last  sub: [c] !need fwd-weighting and initial-fwd-FFT-pass done on entry, exit moot since fwd-FFT-only: mode_flag = 01_2:
@@ -1966,7 +1994,9 @@ READ_RESTART_FILE:
 			// Last  subinterval: [b] !need fwd-weighting and initial-fwd-FFT-pass done on entry,  undone on exit: mode_flag = 01_2
 			/* Note: Interrupt during this step should not be a problem, the handling code in func_mod_square will complete the FFT-mul
 			step and force the undo-initial-FFT-pass-and-DWT-weighting step, leaving a pure-int G-check residue ready for savefile-writing: */
-				mode_flag = 3 - first_sub - (last_sub<<1);
+			// v21: If this is the run's last checkproduct update, b[] gets no further FFT ops, so it must be returned
+			// to pure-int form here - the skipped final-partial-subinterval update would otherwise have done that:
+				mode_flag = 3 - first_sub - ((last_sub || gchk_final)<<1);
 			//	printf("Iter %u: FFT(b)*FFT(c) step.\n",i);
 				ierr = func_mod_square  (b, (int*)arrtmp, n, i,i+1, (uint64)c + (uint64)mode_flag, p, scrnFlag, &tdif2, FALSE, 0x0);
 				if(ierr) {
@@ -1982,7 +2012,7 @@ READ_RESTART_FILE:
 			//	fprintf(stderr,"FFT(b)*FFT(c), mode = %u\n",mode_flag);
 				// If not going to proceed to actual Gerbicz-check, save a post-updated copy of the checkproduct,
 				// in order to guard against single-bit or other data corruption in b[] (h/t George Woltman):
-				if(i % ITERS_BETWEEN_GCHECKS != 0) {
+				if(i % ITERS_BETWEEN_GCHECKS != 0 && !gchk_final) {
 					memcpy(d, b, nbytes);
 					s1 = sum64(b_uint64_ptr, n); s2 = s3 = s1;	// Init triply-redundant checksum of G-checkproduct
 				}
@@ -2148,7 +2178,10 @@ READ_RESTART_FILE:
 		// We don't save "final residue" in cofactor-PRP mode, since in the (mod M(p)) case this is for p+1 squarings (G-check needs this),
 		// i.e. needs a mod-div-by-base^2 postprocessing step to put in form of the p-1 squarings of the standard Fermat-PRP test:
 		// Comment by Catherine Cowie, 2024: for Pepin tests we actually do need a final residue saved, as the worktodo format for a Pepin test does not include possibility of cofactor testing. See https://github.com/primesearch/Mlucas/pull/11 for more information.
-		if ((ihi == maxiter) && (INTERACT || (TEST_TYPE != TEST_TYPE_PM1 && !(TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT))))
+		// v21: ...but if the run's final Gerbicz check is still pending, defer this exit until after the G-check
+		// block below has done it. (Without this deferral no Mersenne-PRP run ever performs a final G-check.)
+		loop_exit = (ihi == maxiter) && (INTERACT || (TEST_TYPE != TEST_TYPE_PM1 && !(TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT)));
+		if(loop_exit && !gchk_final)
 				break;
 
 		/* If Mersenne/PRP or Fermat test, do Gerbicz-check every million squarings. Make sure current run has done at least
@@ -2158,8 +2191,14 @@ READ_RESTART_FILE:
 		o ilo = 0, ihi = 1000: integer divide gives ilo/1000 = 0, ihi/1000 = 1 difference > 0, thus contains an update
 		o ilo = 1000, ihi = 1507: ilo/1000 = 1, ihi/1000 = 1 difference = 0, thus !contains an update
 		*/
+		/* v21: gchk_final adds the run's last check, at iteration gchk_iter = L*(maxiter/L) <= ihi - the latest
+		iteration count at which the Gerbicz identity is applicable, since it needs L-aligned update points. That
+		update was made during the current iteration interval, so the (ilo/j < ihi/j) precondition is met by
+		construction; and gchk_iter need not equal ihi, so use it in place of ihi throughout the block below.
+		*/
 		i = ITERS_BETWEEN_GCHECKS; j = ITERS_BETWEEN_GCHECK_UPDATES;
-		if(MLUCAS_KEEP_RUNNING && DO_GCHECK && (ilo/j < ihi/j) && (ihi % i) == 0) {
+		if(!gchk_final) gchk_iter = ihi;
+		if(MLUCAS_KEEP_RUNNING && DO_GCHECK && (gchk_final || ((ilo/j < ihi/j) && (ihi % i) == 0))) {
 			// Un-updated copy of the checkproduct saved in [d]; square that ITERS_BETWEEN_GCHECK_UPDATES times...
 			/*
 			Mar 2022: User hit assertion-exit below ... had set CheckInterval = 1000 = ITERS_BETWEEN_GCHECK_UPDATES,
@@ -2171,8 +2210,9 @@ READ_RESTART_FILE:
 			// If First subinterval also TRUE, [d] needs fwd-weighting and initial-fwd-FFT-pass done on entry: mode_flag = 00_2.
 			/* Note: Interrupt during this step should not be a problem, the handling code in func_mod_square will complete the FFT-mul
 			step and force the undo-initial-FFT-pass-and-DWT-weighting step, leaving a pure-int G-check residue ready for savefile-writing: */
-			mode_flag = 1 - first_sub;
-			ierr = func_mod_square  (d,0x0, n, ihi,ihi+ITERS_BETWEEN_GCHECK_UPDATES, (uint64)mode_flag, p, scrnFlag, &tdiff, FALSE, 0x0);
+			// v21: for the end-of-run check, use the first_sub value in effect when [d] was snapshotted:
+			mode_flag = 1 - (gchk_final ? gchk_first_sub : first_sub);
+			ierr = func_mod_square  (d,0x0, n, gchk_iter,gchk_iter+ITERS_BETWEEN_GCHECK_UPDATES, (uint64)mode_flag, p, scrnFlag, &tdiff, FALSE, 0x0);
 			if(ierr) {
 				if(ierr == ERR_INTERRUPT) {
 					fprintf(stderr,"Caught interrupt in Gerbicz-checkproduct mod-squaring update ... skipping G-check and savefile-update and performing immediate-exit.\n");
@@ -2190,8 +2230,10 @@ READ_RESTART_FILE:
 			c_uint64_ptr[j-1] = 0ull;
 			// [1] Convert b[],d[] to bytewise form, former assumed already in e[] doubles-array, latter into currently-unused c[] doubles-array:
 			convert_res_FP_bytewise(d, (uint8 *)c_uint64_ptr, n, p, 0x0,0x0,0x0);
-			// Only need to compute this for initial interval - after that the needed adjustment-shift remains constant
-			if(ihi == ITERS_BETWEEN_GCHECKS && RES_SHIFT) {
+			// Only need to compute this for initial interval - after that the needed adjustment-shift remains constant.
+			// v21: '<=' rather than '==' so that a run too short to ever hit iteration ITERS_BETWEEN_GCHECKS - for which
+			// the end-of-run check below is the *only* check, hence the first - also gets GCHECK_SHIFT computed:
+			if(gchk_iter <= ITERS_BETWEEN_GCHECKS && RES_SHIFT) {
 				if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE) {
 					/* d[] needs initial-shift applied prior to final scalar multiply, but don't explicitly,
 					store the initial shift, so need to recompute it from a current value s at iteration i:
@@ -2201,7 +2243,9 @@ READ_RESTART_FILE:
 						y odd : y = (y+p)>>1
 					*/
 					itmp64 = RES_SHIFT;
-					for(i = ITERS_BETWEEN_GCHECK_UPDATES; i < ITERS_BETWEEN_GCHECKS; i++) {	// Recover shift at initial ITERS_BETWEEN_GCHECK_UPDATES-iteration subinterval from that at initial savefile-checkpoint
+					// v21: halve down from iteration ihi, at which RES_SHIFT currently stands (== ITERS_BETWEEN_GCHECKS
+					// for the regular first-interval check, but > gchk_iter for an end-of-run one):
+					for(i = ITERS_BETWEEN_GCHECK_UPDATES; i < ihi; i++) {	// Recover shift at initial ITERS_BETWEEN_GCHECK_UPDATES-iteration subinterval from that at initial savefile-checkpoint
 						if(itmp64 & 1)	// y odd
 							itmp64 = (itmp64+p)>>1;
 						else			// y even
@@ -2265,7 +2309,7 @@ READ_RESTART_FILE:
 			}
 			ASSERT(mi64_cmpult(c_uint64_ptr,d_uint64_ptr,j), "Gerbicz checkproduct reduction (mod 2^p-1) failed!");
 			if(mi64_cmp_eq(e_uint64_ptr,c_uint64_ptr,j)) {
-				sprintf(cbuf,"At iteration %u, shift = %" PRIu64 ": Gerbicz check passed.\n",ihi,RES_SHIFT);
+				sprintf(cbuf,"At iteration %u, shift = %" PRIu64 ": Gerbicz check passed.\n",gchk_iter,RES_SHIFT);
 				mlucas_fprint(cbuf,0);
 				// In G-check case we need b[] for that, thus skipped the d = b redundancy-copy ... do that now:
 				memcpy(d, b, nbytes);
@@ -2279,10 +2323,19 @@ READ_RESTART_FILE:
 					memcpy(d, b, nbytes);
 					s1 = sum64(b_uint64_ptr, n); s2 = s3 = s1;	// Init triply-redundant checksum of G-checkproduct
 				} else {
-					if(ihi == ITERS_BETWEEN_GCHECKS)
-						sprintf(cbuf,"Gerbicz check iteration %u failed! Restarting from scratch.\n",ihi);
+					/* v21: A failure of the end-of-run check rolls back exactly as any other G-check failure does, but
+					since it recurs at the very end of every retry, an error which the rollback cannot clear (i.e. a
+					reproducible one, not the transient data corruption this machinery targets) would retry forever
+					and the run would never terminate. So bound the retries and hard-exit with a diagnostic instead of
+					looping - the savefiles and the worktodo entry are left intact, and no result is emitted: */
+					if(gchk_final && ++gchk_nfail > 3) {
+						snprintf(cbuf,sizeof(cbuf),"Final Gerbicz check at iteration %u failed %u times in a row - the error is not being cleared by restarting from the last-good-Gerbicz-check data, so it is not transient. Aborting rather than retrying without bound; %s savefiles left in place. Please check this machine for hardware errors.\n",gchk_iter,gchk_nfail,PSTRING);
+						mlucas_fprint(cbuf,1); ASSERT(0,cbuf);
+					}
+					if(gchk_iter <= ITERS_BETWEEN_GCHECKS)
+						sprintf(cbuf,"Gerbicz check iteration %u failed! Restarting from scratch.\n",gchk_iter);
 					else
-						sprintf(cbuf,"Gerbicz check iteration %u failed! Restarting from last-good-Gerbicz-check data.\n",ihi);
+						sprintf(cbuf,"Gerbicz check iteration %u failed! Restarting from last-good-Gerbicz-check data.\n",gchk_iter);
 					mlucas_fprint(cbuf,0);
 					ierr = ERR_GERBICZ_CHECK;
 					NERR_GCHECK++;
@@ -2290,6 +2343,10 @@ READ_RESTART_FILE:
 				}
 			}
 		}
+		// v21: Deferred loop-exit: the final Gerbicz check has now been done, so leave without a final-residue write,
+		// exactly as the pre-check exit above would have. (No-op unless the check just done was the end-of-run one.)
+		if(loop_exit)
+			break;
 
 		/* Make sure we start with primary restart file: */
 		RESTARTFILE[0] = ((MODULUS_TYPE == MODULUS_TYPE_MERSENNE) ? 'p' : 'f');

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -2319,7 +2319,7 @@ READ_RESTART_FILE:
 		fp = mlucas_fopen(RESTARTFILE, "wb");
 		if(fp) {		// In the non-PRP-test case, write_ppm1_savefiles() treats the latter 4 args as null:
 			write_ppm1_savefiles(RESTARTFILE,p,n,fp, itmp64, (uint8 *)arrtmp,Res64,Res35m1,Res36m1, (uint8 *)e_uint64_ptr,i1,i2,i3);
-			fclose(fp); fp = 0x0;
+			close_savefile(RESTARTFILE,fp); fp = 0x0;
 			/* If we're on the primary restart file, set up for secondary: */
 			if(RESTARTFILE[0] != 'q') {
 				RESTARTFILE[0] = 'q';	goto WRITE_RESTART_FILE;
@@ -2345,7 +2345,7 @@ READ_RESTART_FILE:
 				fp = mlucas_fopen(g_cstr, "wb");
 				if(fp) {
 					write_ppm1_savefiles(g_cstr,p,n,fp, itmp64, (uint8 *)arrtmp,Res64,Res35m1,Res36m1, (uint8 *)e_uint64_ptr,i1,i2,i3);
-					fclose(fp); fp = 0x0;
+					close_savefile(g_cstr,fp); fp = 0x0;
 				} else {
 					snprintf(cbuf,sizeof(cbuf), "ERROR: unable to open Gerbicz-check savefile %s for write of checkpoint data.\n",g_cstr);
 					mlucas_fprint(cbuf,1);
@@ -5191,6 +5191,77 @@ int test_types_compatible(uint32 t1, uint32 t2)
 		return t1 == t2;
 }
 
+/* v21: Write the [nbyte] low bytes of [val] to *fp, low byte first, returning 0 if any of the writes
+fails. Prior to v21 every fixed-width savefile field was written using unchecked fputc(), so a write
+error - a filesystem which has just filled up being the realistic case - silently truncated the
+savefile. And since the secondary savefile gets written immediately afterward from the same in-memory
+data, both copies ended up damaged in the same way, with nothing whatsoever printed to screen or
+logfile. Contrast the residue-body fwrite() in write_ppm1_residue(), whose return value has always
+been checked: that one fails loudly and leaves the secondary savefile holding the previous good
+checkpoint, from which the run then restarts cleanly. Same failure, same filesystem - the only
+difference is whether the return value gets looked at, so look at all of them:
+*/
+int write_savefile_field(FILE *fp, const uint64 val, const uint32 nbyte)
+{
+	uint32 i;
+	for(i = 0; i < nbyte; i++) {
+		if(fputc((int)((val >> (8*i)) & 0xff), fp) == EOF)
+			return 0;
+	}
+	return 1;
+}
+
+/* v21: A savefile is only as good as the bytes which actually made it out of the stdio buffer: a
+failed fclose() means buffered data was lost, i.e. exactly the silent-truncation case the checked
+writes above exist to prevent. Treat it the same way - abort while the *other* savefile copy still
+holds the previous good checkpoint, rather than proceed with two damaged copies on disk:
+*/
+void close_savefile(const char *fname, FILE *fp)
+{
+	if(fclose(fp) == EOF) {
+		snprintf(cbuf,sizeof(cbuf),"ERROR: close of savefile %s failed - filesystem full? Aborting rather than leave a silently-truncated savefile.\n",fname);
+		mlucas_fprint(cbuf,0);	ASSERT(0,cbuf);
+	}
+}
+
+/* v21: Several savefile fields were added in later program versions, so a savefile whose data simply
+stops where such a field would begin may be one written by an older version. But it may equally be a
+current-format savefile which a failed write truncated, and prior to v21 the two were conflated: the
+older-format reading was simply assumed, and since that makes read_ppm1_savefiles() return *success*,
+a truncated savefile got accepted and the still-valid backup copy sitting next to it was never even
+consulted. So sanity-check the older-format claim before accepting it - a savefile written by an older
+version ends *exactly* at a format boundary, thus:
+	[1] the EOF must have occurred on the very first byte of the missing field, not partway through it;
+	[2] the file length must exactly equal [expect_len], the length such an older-format savefile has
+	    for this exponent and test type;
+	[3] the run must not need any of the fields which are being skipped: if [need_gcheck] is set the
+	    Gerbicz-check residue is one of them, and no older-format savefile contains it - reading such a
+	    file would leave the G-check accumulator uninitialized.
+Returns 1 if the older-format reading holds up, 0 if the file is simply damaged. [nread] = number of
+bytes the caller's read loop consumed, the one which returned EOF included.
+*/
+int savefile_ends_at(const char *func, const char *fname, FILE *fp, uint32 nread, uint64 expect_len, int need_gcheck)
+{
+	long fsize;
+	if(need_gcheck) {
+		sprintf(cbuf,"%s: savefile %s lacks the Gerbicz-check residue this test type requires.\n",func,fname);
+		fprintf(stderr,"%s", cbuf);	return 0;
+	}
+	if(nread != 1) {	// EOF partway through a field: no version of the program ever wrote such a file
+		sprintf(cbuf,"%s: savefile %s ends in mid-field - truncated, not an older-format savefile.\n",func,fname);
+		fprintf(stderr,"%s", cbuf);	return 0;
+	}
+	if(fseek(fp,0L,SEEK_END) != 0 || (fsize = ftell(fp)) < 0L) {
+		sprintf(cbuf,"%s: Unable to determine length of savefile %s.\n",func,fname);
+		fprintf(stderr,"%s", cbuf);	return 0;
+	}
+	if((uint64)fsize != expect_len) {
+		sprintf(cbuf,"%s: savefile %s is %ld bytes, but an older-format one would be %" PRIu64 " - truncated.\n",func,fname,fsize,expect_len);
+		fprintf(stderr,"%s", cbuf);	return 0;
+	}
+	return 1;
+}
+
 /*** READ: Assumes a valid file pointer has been gotten via a call of the form
 fp = mlucas_fopen(RESTARTFILE,"rb");
 ***/
@@ -5298,6 +5369,16 @@ int read_ppm1_savefiles(const char *fname, uint64 p, uint32 *kblocks, FILE *fp, 
 	const char func[] = "read_ppm1_savefiles";
 	uint32 i,j,k,len,nbytes = 0,nerr;
 	uint64 itmp64, nsquares = 0ull, *avec = (uint64 *)arr1, exp[4],pow[4],rem[4];
+	/* v21: Parse the savefile fields which live in globals into locals, and copy them to the globals
+	only once the read has fully succeeded. Formerly PRP_BASE, NERR_ROE and NERR_GCHECK were written
+	directly, so a *failed* read left them holding fgetc()-EOF garbage (0xFEFEFEFF) which nothing ever
+	restored: if the secondary savefile was unusable too, the ensuing start-from-scratch then ran as a
+	"4278124287-PRP test", and the poisoned error counters got written into every later savefile and
+	reported to the server as a maximal hardware-error code. Init from the globals so that fields which
+	the file does not contain (older formats) are left as-is, exactly as before:
+	*/
+	uint32 prp_base = PRP_BASE, nerr_roe = NERR_ROE, nerr_gcheck = NERR_GCHECK;
+	uint64 res_shift = 0ull, gcheck_shift = GCHECK_SHIFT, len_v17,len_v19;
 	uint128 ui128,vi128; uint192 ui192,vi192; uint256 ui256,vi256;	// Fixed-length 2/3/4-word ints for stashing results of multiword modexp.
 	*Res64 = 0ull;	// 0 value on return indicates failure of some kind
 	mi64_clear(pow,4); mi64_clear(rem,4);
@@ -5356,6 +5437,14 @@ int read_ppm1_savefiles(const char *fname, uint64 p, uint32 *kblocks, FILE *fp, 
 		nbytes = (p>>3) + 1;
 		TRANSFORM_TYPE = RIGHT_ANGLE;
 	}
+	/* v21: Exact lengths of the two historical savefile formats which end short of the current one, used
+	by savefile_ends_at() to tell a legitimately-shorter older-format savefile from a truncated current one:
+		pre-v18: t,m,s header (10 bytes) + residue and its S-H checksum triplet (nbytes+18);
+		    v19: the above + kblocks (3) + RES_SHIFT (8), and if a G-check test, + PRP_BASE (4)
+		         + G-check residue and its checksum triplet (nbytes+18) + GCHECK_SHIFT (8):
+	*/
+	len_v17 = (uint64)nbytes + 28;
+	len_v19 = len_v17 + 11 + (DO_GCHECK ? (uint64)nbytes + 30 : 0ull);
 
 	i = read_ppm1_residue(nbytes, fp, arr1, Res64,Res35m1,Res36m1);
 	if(!i) return 0;
@@ -5452,33 +5541,47 @@ Thus if we use a negative-power algo, to recover 2^p (mod q = 2^k.qodd):
 	for(j = 0; j < 3 && i != EOF; j++) {
 		i = fgetc(fp);	*kblocks += (uint64)i << (8*j);
 	}
-	if(i == EOF) {
+	if(i == EOF) {	// v21: EOF here means either a pre-v18 savefile or a truncated current-format one - which?
 		*kblocks = 0;
-		sprintf(cbuf,"%s: Hit EOF in read of FFT-kblocks ... assuming a pre-v18 savefile.\n",func); fprintf(stderr,"%s", cbuf); return 1;
+		if(!savefile_ends_at(func,fname,fp,j,len_v17,DO_GCHECK)) return 0;
+		sprintf(cbuf,"%s: Hit EOF in read of FFT-kblocks in savefile %s ... assuming a pre-v18 savefile.\n",func,fname); mlucas_fprint(cbuf,1);
+		goto SAVEFILE_READ_DONE;
 	}
 	/* May 2018: 8 bytes for circular-shift to apply to the (unshifted) residue read from the file: */
-	i = 0; RES_SHIFT = 0ull;
+	i = 0;
 	for(j = 0; j < 8 && i != EOF; j++) {
-		i = fgetc(fp);	RES_SHIFT += (uint64)i << (8*j);
+		i = fgetc(fp);	res_shift += (uint64)i << (8*j);
 	}
 	if(i == EOF) {
-		RES_SHIFT = 0ull;
-		sprintf(cbuf,"%s: Hit EOF in read of FFT-kblocks ... assuming a pre-v18 savefile.\n",func); fprintf(stderr,"%s", cbuf); return 1;
+		res_shift = 0ull;
+		if(!savefile_ends_at(func,fname,fp,j,len_v17+3,DO_GCHECK)) return 0;
+		sprintf(cbuf,"%s: Hit EOF in read of residue-shift in savefile %s ... assuming a pre-v18 savefile.\n",func,fname); mlucas_fprint(cbuf,1);
+		goto SAVEFILE_READ_DONE;
 	}
 
   // v19: For PRP-tests, also read a second Gerbicz-check residue array [arr2] and associated S-H checksum triplet [i1,i2,i3]:
   if(DO_GCHECK) {	// v21: Change to key off DO_GCHECK, to allow Fermat-mod Pepin-tests to use the Gerbicz check, too
 	ASSERT(arr2 != 0x0, "Null arr2 pointer!");
-	PRP_BASE = 0ull;
+	prp_base = 0;
 	for(j = 0; j < 4; j++) {
-		i = fgetc(fp);	PRP_BASE += i << (8*j);
+		i = fgetc(fp);
+		if(i == EOF) {	// v21: Formerly unchecked, leaving PRP_BASE = 0xFEFEFEFF on a failed read
+			sprintf(cbuf, "%s: Hit EOF in read of PRP-base in savefile %s!\n",func,fname);
+			fprintf(stderr,"%s", cbuf);	return 0;
+		}
+		prp_base += i << (8*j);
 	}
 	i = read_ppm1_residue(nbytes, fp, arr2, i1,i2,i3);
 	if(!i) return 0;
 	// G-check residues all need to be clshifted by residue-shift count at the ITERS_BETWEEN_GCHECK_UPDATESth PRP-test iteration:
-	GCHECK_SHIFT = 0ull;
+	gcheck_shift = 0ull;
 	for(j = 0; j < 8; j++) {
-		i = fgetc(fp);	GCHECK_SHIFT += (uint64)i << (8*j);
+		i = fgetc(fp);
+		if(i == EOF) {	// v21: ditto for GCHECK_SHIFT
+			sprintf(cbuf, "%s: Hit EOF in read of G-check residue-shift in savefile %s!\n",func,fname);
+			fprintf(stderr,"%s", cbuf);	return 0;
+		}
+		gcheck_shift += (uint64)i << (8*j);
 	}
   }
 
@@ -5488,25 +5591,39 @@ Thus if we use a negative-power algo, to recover 2^p (mod q = 2^k.qodd):
 	for(j = 0; j < 4; j++) {
 		i = fgetc(fp);
 		if(i == EOF) {
-			if(!j) {
-				sprintf(cbuf, "%s: Restart from v19 savefile - will start tracking #errors encountered at this point.\n",func);
-				fprintf(stderr,"%s", cbuf);
-				return 1;
+			if(!j) {	// v21: As above, only believe "older-format savefile" if the file length says so:
+				if(!savefile_ends_at(func,fname,fp,1,len_v19,FALSE)) return 0;
+				sprintf(cbuf, "%s: Restart from v19 savefile %s - will start tracking #errors encountered at this point.\n",func,fname);
+				mlucas_fprint(cbuf,1);
+				goto SAVEFILE_READ_DONE;
 			} else {	// If at least the first of the 3 bytes exists, all 3 had better be there:
-				sprintf(cbuf, "%s: Expected 4 nerr bytes!",func);
+				sprintf(cbuf, "%s: Expected 4 nerr bytes in savefile %s!\n",func,fname);
 				fprintf(stderr,"%s", cbuf);
 				return 0;
 			}
 		}
 		nerr += i << (8*j);
 	}
-	NERR_ROE = MAX(nerr,NERR_ROE);	// If restart-from-savefile as result of hitting an ROE, preserve the runtime-incremented value of NERR_ROE:
+	nerr_roe = MAX(nerr,nerr_roe);	// If restart-from-savefile as result of hitting an ROE, preserve the runtime-incremented value of NERR_ROE:
 	// Similar handling for G-check error count:
 	nerr = 0ull;
 	for(j = 0; j < 4; j++) {
-		i = fgetc(fp);	nerr += i << (8*j);
+		i = fgetc(fp);
+		if(i == EOF) {	// v21: This loop formerly had no EOF check at all, so a savefile truncated in its
+			// last 4 bytes read back as NERR_GCHECK = 0xFEFEFEFF = 4278124287 with the read still reporting
+			// success - which then got submitted to the server as error-code 0x00F00000 ("15 Gerbicz errors")
+			// plus a literal "gerbicz":4278124287, even for test types which have no Gerbicz check at all:
+			sprintf(cbuf, "%s: Expected 4 G-check-error-count bytes in savefile %s!\n",func,fname);
+			fprintf(stderr,"%s", cbuf);	return 0;
+		}
+		nerr += i << (8*j);
 	}
-	NERR_GCHECK = MAX(nerr,NERR_GCHECK);
+	nerr_gcheck = MAX(nerr,nerr_gcheck);
+
+SAVEFILE_READ_DONE:
+	// v21: Read succeeded - only now commit the parsed values to their globals:
+	RES_SHIFT = res_shift;	PRP_BASE = prp_base;	GCHECK_SHIFT = gcheck_shift;
+	NERR_ROE = nerr_roe;	NERR_GCHECK = nerr_gcheck;
 	/* Don't deallocate arr1 here, since we'll need it later for savefile writes. */
 	return 1;
 }
@@ -5527,16 +5644,13 @@ void write_ppm1_residue(const uint32 nbytes, FILE *fp, const uint8 arr_tmp[], co
 		snprintf(cbuf,sizeof(cbuf),"%s: Error writing residue to restart file.\n",func);
 		mlucas_fprint(cbuf,0);	ASSERT(0,cbuf);
 	}
-	/* ...and checksums:	*/
-	/* Res64: */
-	for(i = 0; i < 64; i+=8)
-		fputc((int)(Res64 >> i) & 0xff, fp);
-	/* Res35m1: */
-	for(i = 0; i < 40; i+=8)
-		fputc((int)(Res35m1 >> i) & 0xff, fp);
-	/* Res36m1: */
-	for(i = 0; i < 40; i+=8)
-		fputc((int)(Res36m1 >> i) & 0xff, fp);
+	/* ...and checksums (Res64: 8 bytes, Res35m1 and Res36m1: 5 bytes each) - v21: check these writes
+	as well, since a savefile truncated here reads back as an older-format, i.e. valid, one: */
+	if(!write_savefile_field(fp,Res64,8) || !write_savefile_field(fp,Res35m1,5) || !write_savefile_field(fp,Res36m1,5)) {
+		fclose(fp); fp = 0x0;
+		snprintf(cbuf,sizeof(cbuf),"%s: Error writing residue checksums to restart file.\n",func);
+		mlucas_fprint(cbuf,0);	ASSERT(0,cbuf);
+	}
 }
 
 // v20: E.g. distributed deep p-1 S2 may use B2 >= 2^32, so make ihi a uint64; add filename arg since S2 appends '.s2' to RESTARTFILE:
@@ -5550,14 +5664,12 @@ void write_ppm1_savefiles(const char *fname, uint64 p, int n, FILE *fp, uint64 i
 	kblocks = (n >> 10);
 	ASSERT(n == (kblocks << 10),"Not a proper unpadded FFT length");
 
-	/* See the function read_ppm1_savefiles() for the file format here: */
-	/* t: */
-	fputc(TEST_TYPE, fp);
-	/* m: */
-	fputc(MODULUS_TYPE, fp);
-	/* s: */
-	for(i = 0; i < 64; i+=8)
-		fputc((ihi >> i) & 0xff, fp);
+	/* See the function read_ppm1_savefiles() for the file format here. v21: All the fixed-width fields
+	go out through write_savefile_field(), which checks its writes - see the comment on that function: */
+	/* t: */	i  = write_savefile_field(fp,TEST_TYPE   ,1);
+	/* m: */	i &= write_savefile_field(fp,MODULUS_TYPE,1);
+	/* s: */	i &= write_savefile_field(fp,ihi         ,8);
+	if(!i) goto SAVEFILE_WRITE_ERR;
 
 	/* Set the expected number of residue bytes, depending on the modulus: */
 	if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE) {
@@ -5571,27 +5683,31 @@ void write_ppm1_savefiles(const char *fname, uint64 p, int n, FILE *fp, uint64 i
 
 	write_ppm1_residue(nbytes, fp, arr1, Res64,Res35m1,Res36m1);
 
-	// v18: FFT length in K (3 bytes):
-	for(i = 0; i < 24; i+=8)
-		fputc((kblocks >> i) & 0xff, fp);
-	// v18: circular-shift to apply to the (unshifted) residue read from the file (8 bytes):
-	for(i = 0; i < 64; i+=8)
-		fputc((RES_SHIFT >> i) & 0xff, fp);
+	// v18: FFT length in K (3 bytes), then circular-shift to apply to the residue read from the file (8 bytes):
+	i  = write_savefile_field(fp,kblocks  ,3);
+	i &= write_savefile_field(fp,RES_SHIFT,8);
+	if(!i) goto SAVEFILE_WRITE_ERR;
 
   // v19: For PRP-tests, also write a second Gerbicz-check residue array [arr2] and associated S-H checksum triplet [i1,i2,i3]:
   if(DO_GCHECK) {	// v21: Change to key off DO_GCHECK, to allow Fermat-mod Pepin-tests to use the Gerbicz check, too
-	for(i = 0; i < 32; i+=8)
-		fputc((PRP_BASE >> i) & 0xff, fp);
+	if(!write_savefile_field(fp,PRP_BASE,4)) goto SAVEFILE_WRITE_ERR;
 	write_ppm1_residue(nbytes, fp, arr2, i1,i2,i3);
 	// G-check residues all need to be clshifted by residue-shift count at the ITERS_BETWEEN_GCHECK_UPDATESth PRP-test iteration:
-	for(i = 0; i < 64; i+=8)
-		fputc((GCHECK_SHIFT >> i) & 0xff, fp);
+	if(!write_savefile_field(fp,GCHECK_SHIFT,8)) goto SAVEFILE_WRITE_ERR;
   }
 	// v20: Write cumulative #errs for ROE >= 0.4375 (>= for LL, > for PRP) and Gerbicz-check for the test in question:
-	for(i = 0; i < 32; i+=8)
-		fputc((NERR_ROE >> i) & 0xff, fp);
-	for(i = 0; i < 32; i+=8)
-		fputc((NERR_GCHECK >> i) & 0xff, fp);
+	i  = write_savefile_field(fp,NERR_ROE   ,4);
+	i &= write_savefile_field(fp,NERR_GCHECK,4);
+	if(!i) goto SAVEFILE_WRITE_ERR;
+	return;
+
+SAVEFILE_WRITE_ERR:	// v21: Formerly these writes were unchecked, so a full filesystem silently truncated
+	// the savefile - and, the secondary copy being written straight afterward from the same data, both
+	// copies alike. Abort here instead, at which point the *other* copy still holds the previous good
+	// checkpoint, exactly as already happens when the residue-body write above fails:
+	fclose(fp);
+	snprintf(cbuf,sizeof(cbuf),"write_ppm1_savefiles: Error writing savefile %s - filesystem full? Aborting rather than leave a silently-truncated savefile.\n",fname);
+	mlucas_fprint(cbuf,0);	ASSERT(0,cbuf);
 }
 
 /*********************/
@@ -6792,7 +6908,9 @@ int restart_file_valid(const char *fname, const uint64 p, uint8 *arr1, uint8 *ar
 	int retval = 0;
 	uint32 j;
 	uint64 Res64,Res35m1,Res36m1, i1,i2,i3, itmp64;
-	FILE *fptr = mlucas_fopen(fname,"r");
+	// v21: "rb", not "r": read_ppm1_savefiles()'s contract requires binary mode, and on Windows text mode
+	// mangles \r\n pairs and treats an embedded 0x1A as EOF, both of which occur in a bytewise residue:
+	FILE *fptr = mlucas_fopen(fname,"rb");
 	if(fptr) {
 		retval = read_ppm1_savefiles(fname, p, &j, fptr, &itmp64,
 										arr1, &Res64,&Res35m1,&Res36m1,	// Primality-test residue

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -415,7 +415,7 @@ uint32	ernstMain
 	target (p/q, then .J, then .J1, then scratch) and bounds the retries. jchk_file: position in that chain during a
 	restart-file read. jchk_passed: this checkpoint passed, so the .J/.J1 files get updated after the p/q write: */
 	int do_jcheck = FALSE, jchk_passed = FALSE, jchk_file = 0, jsym = 0;
-	uint32 jchk_nfail = 0;
+	uint32 jchk_nfail = 0, jchk_fail_iter = 0;	// jchk_fail_iter: iteration of the last failed check; a pass at or beyond it clears the count
 	double jchk_tlast = 0.0, jchk_tdur = 0.0, jchk_tsec = 0.0;
 	char jchk_fname[STR_MAX_LEN];
 	/* Exponent of number to be tested - note that for trial-factoring, we represent p
@@ -480,7 +480,7 @@ RANGE_BEG:
 								// during test - if a restart, will re-read actual cumulative values from checkpoint file.
 	gchk_final = FALSE; gchk_nfail = 0;	// v21: End-of-run G-check state. Reset here, i.e. once per assignment - NOT on the
 										// READ_RESTART_FILE rollback path, else a repeating failure could retry without bound.
-	jchk_nfail = 0; jchk_file = 0; jchk_passed = FALSE; jchk_tdur = 0.0; jchk_tlast = getRealTime();	// v21: ditto for the Jacobi check
+	jchk_nfail = 0; jchk_fail_iter = 0; jchk_file = 0; jchk_passed = FALSE; jchk_tdur = 0.0; jchk_tlast = getRealTime();	// v21: ditto for the Jacobi check
 	// Clear out any FFT-radix or known-factor data that might remain from a just-completed run:
 	for(i = 0; i < 10; i++) { RADIX_VEC[i] = 0; }
 	nfac = 0; mi64_clear(KNOWN_FACTORS,40);
@@ -2235,7 +2235,7 @@ READ_RESTART_FILE:
 			}
 			if(fi_iter && !fi_done && ihi == fi_iter && ierr == 0 && !INTERACT) {
 				uint32 fi_j1 = fi_word + ((fi_word >> DAT_BITS) << PAD_BITS);	// padded-array index of digit fi_word
-				a[fi_j1] += 1.0;	fi_done = 1;
+				a[fi_j1] += 1.0;	fi_done = (getenv("MLUCAS_FAULT_REPEAT") == 0x0);	// MLUCAS_FAULT_REPEAT: re-fire on every visit, i.e. a reproducible fault
 				snprintf(cbuf,sizeof(cbuf), "FAULT INJECTION: added 1.0 to residue digit %u at iteration %u.\n",fi_word,ihi);
 				mlucas_fprint(cbuf,1);
 			}
@@ -2308,7 +2308,11 @@ READ_RESTART_FILE:
 				if(jsym == -1) {
 					snprintf(cbuf,sizeof(cbuf), "At iteration %u, shift = %" PRIu64 ": Jacobi check passed (%.1f sec).\n",ihi,RES_SHIFT,jchk_tsec);
 					mlucas_fprint(cbuf,scrnFlag);
-					jchk_nfail = 0; jchk_passed = TRUE;
+					/* Only a pass at or beyond the last failure point clears the failure count: after a rollback the earlier
+					checkpoints pass again on the way back up, and letting them reset the count made a *reproducible* fault at
+					one iteration walk the chain forever (scratch -> passes -> fail -> ... , observed) instead of aborting: */
+					if(ihi >= jchk_fail_iter) jchk_nfail = 0;
+					jchk_passed = TRUE;
 				} else if(jsym == 0) {
 					/* Symbol 0 means gcd(s - 2, M(p)) > 1. Exponents are checked prime when the worktodo entry is parsed (the
 					composite case, where M(q) | M(p) for q | p and the LL sequence collapses mod M(q), never gets here), so for
@@ -2318,7 +2322,7 @@ READ_RESTART_FILE:
 					snprintf(cbuf,sizeof(cbuf), "Jacobi check at iteration %u failed with symbol 0: the residue shares a factor with the modulus, which cannot happen for a correct LL residue of a prime exponent. Aborting rather than retrying; %s savefiles left in place - please check this machine for hardware errors.\n",ihi,PSTRING);
 					mlucas_fprint(cbuf,1); ASSERT(0,cbuf);
 				} else {
-					NERR_JACOBI++; jchk_nfail++;
+					NERR_JACOBI++; jchk_nfail++; jchk_fail_iter = ihi;
 					if(jchk_nfail >= 5) {
 						snprintf(cbuf,sizeof(cbuf), "Jacobi check at iteration %u failed %u times in a row, the last after restarting from scratch - the error is not being cleared by rolling back, so it is not transient. Aborting rather than retrying without bound; %s savefiles left in place. Please check this machine for hardware errors.\n",ihi,jchk_nfail,PSTRING);
 						mlucas_fprint(cbuf,1); ASSERT(0,cbuf);

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -2842,7 +2842,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 		re-using it would kibosh subsequent stage 2 continuation runs. Safer to start with s1 residue for those:
 		*/
 		strcpy(g_cstr, RESTARTFILE); strcat(g_cstr, ".s2");
-		if(remove(g_cstr)) {
+		if(mlucas_remove(g_cstr)) {
 			snprintf(cbuf,sizeof(cbuf),"INFO: Unable to remove stage 2 savefile %s.\n",g_cstr);
 			mlucas_fprint(cbuf,1);
 		}
@@ -2869,7 +2869,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 						snprintf(cbuf,sizeof(cbuf),"ERROR: Primary savefile missing/corrupt, but unable to rename the secondary %s ==> %s ... any ensuing LL/PRP test will overwrite.\n",RESTARTFILE,g_cstr);
 						mlucas_fprint(cbuf,1);
 					}
-				} else if(remove(g_cstr))	// ...otherwise delete the secondary
+				} else if(mlucas_remove(g_cstr))	// ...otherwise delete the secondary
 					fprintf(stderr, "Unable to delete secondary restart file %s.\n",g_cstr);
 			}
 		} else
@@ -2880,7 +2880,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 	}
 	// If completion of LL/PRP run, or secondary was not used as a backup for p-1 stage 1 savefile rename, delete it now:
 	RESTARTFILE[0] = 'q';
-	if(remove(RESTARTFILE))
+	if(mlucas_remove(RESTARTFILE))
 		fprintf(stderr, "Unable to delete secondary restart file %s\n",RESTARTFILE);
 
 	RESTARTFILE[0] = ((MODULUS_TYPE == MODULUS_TYPE_MERSENNE) ? 'p' : 'f');
@@ -2910,7 +2910,7 @@ GET_NEXT_ASSIGNMENT:
 			ASSERT(0,cbuf);
 		}
 		/* Remove any WINI.TMP file that may be present: */
-		remove("WINI.TMP");
+		mlucas_remove("WINI.TMP");
 		fq = mlucas_fopen("WINI.TMP", "w");
 		if(!fq) {
 			sprintf(cbuf, "Unable to open WINI.TMP file for writing.\n");
@@ -3027,7 +3027,7 @@ GET_NEXT_ASSIGNMENT:
 
 			/*...Then remove the WINI.TMP file:	*/
 
-			remove("WINI.TMP");
+			mlucas_remove("WINI.TMP");
 		}
 		/* if one or more exponents left in rangefile, go back for more; otherwise exit. */
 		if (i > 0) {

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -2305,7 +2305,10 @@ READ_RESTART_FILE:
 			sprintf(cbuf, ".%dM", ilo/1000000);
 			strcpy(g_cstr, RESTARTFILE);
 			strcat(g_cstr, cbuf);
-			if(rename(RESTARTFILE, g_cstr)) {
+			// v21: mlucas_rename(), not rename(): the latter ignored MLUCAS_PATH (so under a nonempty prefix it
+			// renamed a nonexistent cwd-relative name and always failed) and cannot replace an existing
+			// destination on Windows. Same for the other rename() calls below:
+			if(mlucas_rename(RESTARTFILE, g_cstr)) {
 				snprintf(cbuf,sizeof(cbuf),"ERROR: unable to rename %s restart file ==> %s ... skipping every-10M-iteration restart file archiving\n",WORKFILE,g_cstr);
 				fprintf(stderr,"%s",cbuf);
 			}
@@ -2316,7 +2319,9 @@ READ_RESTART_FILE:
 		itmp64 = ihi;
 		// If Pepin test is at final iteration, change PRP base to 3 for final write to file (cf. earlier assignment at line 1214). More info: https://github.com/primesearch/Mlucas/pull/11
 		if (ihi == maxiter && TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT) PRP_BASE = 3;
-		fp = mlucas_fopen(RESTARTFILE, "wb");
+		// v21: _atomic: stage the new checkpoint in a scratch file and rename it over the savefile, so that
+		// a crash/kill/power-loss partway through the write cannot leave a truncated savefile behind:
+		fp = mlucas_fopen_atomic(RESTARTFILE, "wb");
 		if(fp) {		// In the non-PRP-test case, write_ppm1_savefiles() treats the latter 4 args as null:
 			write_ppm1_savefiles(RESTARTFILE,p,n,fp, itmp64, (uint8 *)arrtmp,Res64,Res35m1,Res36m1, (uint8 *)e_uint64_ptr,i1,i2,i3);
 			close_savefile(RESTARTFILE,fp); fp = 0x0;
@@ -2342,7 +2347,7 @@ READ_RESTART_FILE:
 			if(ihi%ITERS_BETWEEN_GCHECKS == 0) {
 				strcpy(g_cstr, RESTARTFILE);
 				strcat(g_cstr, ".G");
-				fp = mlucas_fopen(g_cstr, "wb");
+				fp = mlucas_fopen_atomic(g_cstr, "wb");	// v21: atomic-replace, as for the p/q savefiles above
 				if(fp) {
 					write_ppm1_savefiles(g_cstr,p,n,fp, itmp64, (uint8 *)arrtmp,Res64,Res35m1,Res36m1, (uint8 *)e_uint64_ptr,i1,i2,i3);
 					close_savefile(g_cstr,fp); fp = 0x0;
@@ -2852,7 +2857,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 			// If end of a regular (non-s2-continuation) p-1 run and primary good, rename it from [p|f][expo] ==> [p|f][expo].s1;
 			// if primary missing/corrupt, rename secondary q[expo] ==> [p|f][expo].s1:
 			if(TEST_TYPE == TEST_TYPE_PM1 && !s2_continuation) {
-				if(rename(RESTARTFILE, g_cstr)) {
+				if(mlucas_rename(RESTARTFILE, g_cstr)) {
 					snprintf(cbuf,sizeof(cbuf),"ERROR: unable to rename the p-1 stage 1 savefile %s ==> %s ... any ensuing LL/PRP test will overwrite.\n",RESTARTFILE,g_cstr);
 					mlucas_fprint(cbuf,1);
 				}
@@ -2860,7 +2865,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 				// If primary was missing/corrupt, i.e. we're on the secondary, rename secondary to primary-name
 				if(RESTARTFILE[0] == 'q') {
 					RESTARTFILE[0] = ((MODULUS_TYPE == MODULUS_TYPE_MERSENNE) ? 'p' : 'f');
-					if(rename(g_cstr, RESTARTFILE)) {
+					if(mlucas_rename(g_cstr, RESTARTFILE)) {
 						snprintf(cbuf,sizeof(cbuf),"ERROR: Primary savefile missing/corrupt, but unable to rename the secondary %s ==> %s ... any ensuing LL/PRP test will overwrite.\n",RESTARTFILE,g_cstr);
 						mlucas_fprint(cbuf,1);
 					}
@@ -2992,8 +2997,12 @@ GET_NEXT_ASSIGNMENT:
 		fclose(fq); fq = 0x0;
 
 		/* Now blow away the old worktodo file and rename WINI.TMP ==> worktodo.txt...	*/
-		remove(WORKFILE);
-		if(rename("WINI.TMP", WORKFILE))
+		// v21: A single atomic rename replaces the former remove()-then-rename() pair, which on POSIX left a
+		// window in which the worktodo file did not exist at all - a crash there lost the entire assignment
+		// list. mlucas_rename() also supplies the MLUCAS_PATH prefix which the bare rename() omitted (both files
+		// having been *created* through mlucas_fopen(), which prefixes) and the replace-existing semantics which
+		// the Windows CRT rename() lacks - the very reason the remove() was there in the first place:
+		if(mlucas_rename("WINI.TMP", WORKFILE))
 		{
 			sprintf(cbuf,"ERROR: unable to rename WINI.TMP file ==> %s ... attempting line-by-line copy instead.\n",WORKFILE);
 			fprintf(stderr,"%s",cbuf);
@@ -5218,7 +5227,7 @@ holds the previous good checkpoint, rather than proceed with two damaged copies 
 */
 void close_savefile(const char *fname, FILE *fp)
 {
-	if(fclose(fp) == EOF) {
+	if(mlucas_fclose_atomic(fname,fp)) {
 		snprintf(cbuf,sizeof(cbuf),"ERROR: close of savefile %s failed - filesystem full? Aborting rather than leave a silently-truncated savefile.\n",fname);
 		mlucas_fprint(cbuf,0);	ASSERT(0,cbuf);
 	}

--- a/src/Mlucas.h
+++ b/src/Mlucas.h
@@ -94,6 +94,9 @@ uint32	Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[
 	int	(*func_mod_square)(double [], int [], int, int, int, uint64, uint64, int, double *, int, double *),
 	int n, int scrnFlag, double *tdiff, char *const gcd_str);
 int		test_types_compatible(uint32 t1, uint32 t2);
+int		write_savefile_field(FILE *fp, const uint64 val, const uint32 nbyte);
+void	close_savefile(const char *fname, FILE *fp);
+int		savefile_ends_at(const char *func, const char *fname, FILE *fp, uint32 nread, uint64 expect_len, int need_gcheck);
 int		 read_ppm1_residue(const uint32 nbytes, FILE *fp,       uint8 arr_tmp[],       uint64 *Res64,       uint64 *Res35m1,       uint64 *Res36m1);
 void	write_ppm1_residue(const uint32 nbytes, FILE *fp, const uint8 arr_tmp[], const uint64 Res64, const uint64 Res35m1, const uint64 Res36m1);
 int		 read_ppm1_savefiles(const char *fname, uint64 p, uint32 *kblocks, FILE *fp, uint64 *ilo, uint8 arr1[], uint64 *Res64, uint64 *Res35m1, uint64 *Res36m1, uint8 arr2[], uint64 *i1, uint64 *i2, uint64 *i3);

--- a/src/Mlucas.h
+++ b/src/Mlucas.h
@@ -114,6 +114,9 @@ void dif1_dit1_func_name(
 uint32	extract_known_factors(uint64 p, char *fac_start);
 uint32	gcd(uint32 stage, uint64 p, uint64 *vec1, uint64 *vec2, uint32 nlimb, char *const gcd_str);
 void	modinv(uint64 p, uint64 *vec1, uint64 *vec2, uint32 nlimb);
+#define JACOBI_UNAVAILABLE	2	// v21: jacobi_check() return value when built without a usable GMP
+int		jacobi_check_available(void);
+int		jacobi_check(uint64 p, const uint64 *res, uint32 nlimb, uint32 sub, double *tsec);
 int		restart_file_valid(const char *fname, const uint64 p, uint8 *arr1, uint8 *arr2);
 uint32	filegrep(const char *fname, const char *find_str, char *p_cstr, uint32 find_before_line_number);
 void	write_fft_debug_data(double a[], int jlo, int jhi);

--- a/src/factor.c
+++ b/src/factor.c
@@ -4101,7 +4101,9 @@ MFACTOR_HELP:
 			}
 			if(fp) { fclose(fp); fp = 0x0; }
 			fclose(fq); fq = 0x0;
-			if(rename(TMPFILE,RESTARTFILE)) {
+			// v21: mlucas_rename(), not rename(): supplies the MLUCAS_PATH prefix both files were created with,
+			// and replaces an existing destination on Windows, whose CRT rename() fails with EEXIST instead:
+			if(mlucas_rename(TMPFILE,RESTARTFILE)) {
 				sprintf(g_cstr,"ERROR: unable to rename %s file ==> %s.\n",TMPFILE,RESTARTFILE);
 				ASSERT(0,g_cstr);
 			}
@@ -4724,8 +4726,10 @@ uint64 kmin, uint64 know, uint64 kmax, uint32 passmin, uint32 passnow, uint32 pa
 {
 	int itmp;
 	uint32 curr_line = 0, nerr = 0;
-	/* TF restart files are in HRF, not binary: */
-	fp = mlucas_fopen(fname,"w");	// Open in write mode
+	/* TF restart files are in HRF, not binary. v21: _atomic - stage the new contents in a scratch file and
+	rename it over the target, so that a crash partway through this write cannot leave a truncated savefile
+	where a complete one used to be: */
+	fp = mlucas_fopen_atomic(fname,"w");	// Open in write mode
 	if(!fp) {
 	#ifndef FACTOR_STANDALONE
 		fp = mlucas_fopen(STATFILE,"a");
@@ -4790,7 +4794,14 @@ uint64 kmin, uint64 know, uint64 kmax, uint32 passmin, uint32 passnow, uint32 pa
 		if(itmp <= 0) {
 			++nerr; fprintf(stderr,"ERROR: unable to write Line %d (#Q tried) of factoring restart file %s!\n",curr_line,fname);
 		}
-		fclose(fp); fp = 0x0;
+		// v21: If any of the above writes failed we have nothing worth publishing, so drop the scratch file and
+		// leave any pre-existing savefile alone; otherwise commit it, counting a failure to do so as one more error:
+		if(nerr) {
+			mlucas_discard_atomic(fname,fp);
+		} else if(mlucas_fclose_atomic(fname,fp)) {
+			++nerr; fprintf(stderr,"ERROR: unable to commit factoring restart file %s ... any previous savefile left in place.\n",fname);
+		}
+		fp = 0x0;
 		return (int)nerr;
 	}
 }

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -1502,7 +1502,7 @@ fprintf(stderr,"#1: vec1 = A^+1 checksums = %" PRIu64 ",%" PRIu64 ",%" PRIu64 ";
 		fp = mlucas_fopen(inv_file, "wb");
 		if(fp) {
 			write_ppm1_savefiles(inv_file,p,n,fp, 0ull, (uint8*)vec2,Res64,Res35m1,Res36m1, 0x0,0x0,0x0,0x0);
-			fclose(fp);	fp = 0x0;
+			close_savefile(inv_file,fp);	fp = 0x0;
 		} else {
 			snprintf(cbuf, sizeof(cbuf), "ERROR: unable to open restart file %s for write of checkpoint data.\n",inv_file);
 			mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0,cbuf);
@@ -1757,7 +1757,7 @@ MME = 0;
 	savefile[0] = ((MODULUS_TYPE == MODULUS_TYPE_MERSENNE) ? 'p' : 'f');
 	strcat(savefile, ".s2");
 	// [From the above p-1 savefile schema] 3. On entry, S2 checks for existence of ".s2" savefile:
-	fp = mlucas_fopen(savefile,"r");
+	fp = mlucas_fopen(savefile,"rb");	// v21: the .s2 savefile is binary (written "wb"); text mode mangles it on Windows
 	// o If exists, read nsquares field into uint64 qlo, mask off high byte (which stores the value of any relocation-prime
 	// psmall used for stage 2), compare vs original-assignment B2_start read (or inferred, as B2_start = B1) from worktodo entry:
 	if(fp) {												// G-check residue fields all set NULL in this call:
@@ -2514,7 +2514,7 @@ MME = 0;
 				// q won't get += bigstep until we loop, so here, (q + bigstep) is the q-value corr. to just-incremented k.
 				// Also write any relocation-prime psmall into high bit of the resulting nsquares field:
 				write_ppm1_savefiles(savefile,p,n,fp, ((uint64)psmall<<56) + q + bigstep, (uint8*)arrtmp,Res64,Res35m1,Res36m1, 0x0,0x0,0x0,0x0);
-				fclose(fp);	fp = 0x0;
+				close_savefile(savefile,fp);	fp = 0x0;
 			} else {
 				snprintf(cbuf, sizeof(cbuf), "ERROR: unable to open restart file %s for write of checkpoint data.\n",savefile);
 				mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0,cbuf);

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -544,7 +544,9 @@ PM1_S1P_READ_RETURN:
 		ASSERT(arr != 0x0, "Null arr pointer!");
 		ASSERT(strlen(fname) != 0, "Empty filename!");
 
-		FILE*fptr = mlucas_fopen(fname, "wb");
+		// v21: atomic-replace: a crash partway through this write formerly left a truncated primes-product
+		// file in place of the previous complete one, and the caller has no backup copy to fall back on:
+		FILE*fptr = mlucas_fopen_atomic(fname, "wb");
 		if(!fptr) {
 			snprintf(cbuf, sizeof(cbuf), "ERROR: Unable to open precomputed p-1 stage 1 primes-product file %s for writing.\n",fname);
 			mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0, cbuf);
@@ -582,7 +584,17 @@ PM1_S1P_READ_RETURN:
 		retval = 1;
 
 	PM1_S1P_WRITE_RETURN:
-		if(fptr) { fclose(fptr); fptr = 0x0; }
+		// v21: On the checksum-mismatch path above retval is still 0, i.e. we are abandoning this write;
+		// commit the scratch file over the target only if the data we staged in it is actually good:
+		if(fptr) {
+			if(!retval)
+				mlucas_discard_atomic(fname,fptr);
+			else if(mlucas_fclose_atomic(fname,fptr)) {
+				sprintf(cbuf,"ERROR: Unable to commit precomputed p-1 stage 1 primes-product file %s.\n",fname);
+				mlucas_fprint(cbuf,pm1_standlone+1);	retval = 0;
+			}
+			fptr = 0x0;
+		}
 		return retval;
 	}
 #endif
@@ -1499,7 +1511,7 @@ fprintf(stderr,"#1: vec1 = A^+1 checksums = %" PRIu64 ",%" PRIu64 ",%" PRIu64 ";
 		Res35m1 = mi64_div_by_scalar64(vec2,two35m1,nlimb,0x0);
 		Res36m1 = mi64_div_by_scalar64(vec2,two36m1,nlimb,0x0);
 		// Write inverse to savefile:
-		fp = mlucas_fopen(inv_file, "wb");
+		fp = mlucas_fopen_atomic(inv_file, "wb");	// v21: atomic-replace, as for the .s2 checkpoint below
 		if(fp) {
 			write_ppm1_savefiles(inv_file,p,n,fp, 0ull, (uint8*)vec2,Res64,Res35m1,Res36m1, 0x0,0x0,0x0,0x0);
 			close_savefile(inv_file,fp);	fp = 0x0;
@@ -2509,7 +2521,13 @@ MME = 0;
 				, 1000*get_time(*tdiff)/(nmodmul - nmodmul_save), Res64, AME, MME);
 			mlucas_fprint(cbuf,pm1_standlone+scrnFlag);
 			*tdiff = MME = 0.0;	// Reset timer and maxerr at end of each iteration interval
-			fp = mlucas_fopen(savefile, "wb");
+			// v21: _atomic: the .s2 checkpoint has no secondary copy standing behind it - unlike the p/q
+			// residue savefiles, where a corrupt primary is detected and the secondary used instead - so
+			// truncating it in place made every checkpoint write a window in which the *only* record of
+			// stage-2 progress on disk was a partially-written file. Killing a run in that window destroyed
+			// the last good checkpoint and cost the whole of stage 2 so far. Stage the write in a scratch
+			// file and rename it over the target, which is then never seen in a partial state:
+			fp = mlucas_fopen_atomic(savefile, "wb");
 			if(fp) {
 				// q won't get += bigstep until we loop, so here, (q + bigstep) is the q-value corr. to just-incremented k.
 				// Also write any relocation-prime psmall into high bit of the resulting nsquares field:

--- a/src/util.c
+++ b/src/util.c
@@ -36,6 +36,10 @@
 #endif
 #if defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
 	#include <windows.h>
+	#include <io.h>		// v21: _commit(), _fileno() - the Windows spellings of fsync(), fileno()
+#else
+	#include <fcntl.h>	// v21: open() of the savefile's containing directory, to fsync() a rename
+	#include <unistd.h>	// v21: fsync(), fileno(), close()
 #endif
 
 #if 0
@@ -9616,6 +9620,172 @@ FILE *mlucas_fopen(const char *path, const char *mode)
 
 	snprintf(mlucas_path, sizeof(mlucas_path), "%s%s", MLUCAS_PATH, path);
 	return fopen(mlucas_path, mode);
+}
+
+/**************************************************************************************************/
+/*** v21: Crash-safe (atomic) savefile replacement - see the mlucas_fopen_atomic() comment below ***/
+/**************************************************************************************************/
+
+/* Suffix appended to a savefile name to form the name of the scratch file its replacement is
+staged in. Deliberately a fixed string rather than a mkstemp()-style random one: it keeps the
+scratch file next to its target in the same directory (a hard requirement, since rename() is only
+atomic *within* a filesystem), it is unique per target because savefile names already are, and a
+leftover from a previous crash is simply reused rather than accumulating as litter: */
+#define SAVEFILE_TMP_SUFFIX	".new"
+
+/* MLUCAS_PATH-prefix [path] (+ optional [suffix]) into caller-supplied buffer [dest], which must
+have room for MLUCAS_PATH_BUFSIZE chars. Same length reasoning as mlucas_fopen(): */
+#define MLUCAS_PATH_BUFSIZE	(2*STR_MAX_LEN + sizeof(SAVEFILE_TMP_SUFFIX) + 1)
+
+static void mlucas_path_cat(char dest[], const char *path, const char *suffix)
+{
+	strcpy(dest, MLUCAS_PATH);
+	strcat(dest, path);
+	if(suffix) strcat(dest, suffix);
+}
+
+/* Rename [oldpath] ==> [newpath], both MLUCAS_PATH-relative, replacing [newpath] if it exists.
+Returns 0 on success, nonzero on failure. Two things this does which a bare rename() call does not:
+
+	[1] It applies the MLUCAS_PATH prefix. Every Mlucas file is *created* through mlucas_fopen(),
+	    which prefixes; the bare rename() calls this replaces did not, so under a nonempty
+	    MLUCAS_PATH (the "$HOME/.mlucas.d/" packaging layout, or the MLUCAS_PATH env var) they
+	    named files which do not exist, and the renames simply failed.
+
+	[2] It replaces an existing destination on Windows as well as POSIX. rename(2) is required to
+	    atomically replace the destination on POSIX, but the Windows CRT rename() fails with EEXIST
+	    if the destination exists - which is exactly the case here, since the whole point is to
+	    overwrite the previous savefile. MoveFileEx(...,MOVEFILE_REPLACE_EXISTING) is the Windows
+	    equivalent; MOVEFILE_WRITE_THROUGH additionally asks that the rename be flushed before the
+	    call returns, which is what makes it durable rather than merely atomic.
+
+Note the preprocessor gate: platform.h routes MinGW builds down its OS_TYPE_LINUX branch on purpose
+(see the "MinGW builds use the Linux codepath" comment there), so a bare #ifdef OS_TYPE_WINDOWS would
+miss MinGW - whose rename() is the same replace-hostile msvcrt one. Test both, as platform.h itself
+does wherever it needs "is this a Windows target?" rather than "is this an MSVC build?".
+*/
+int mlucas_rename(const char *oldpath, const char *newpath)
+{
+	char obuf[MLUCAS_PATH_BUFSIZE], nbuf[MLUCAS_PATH_BUFSIZE];
+	mlucas_path_cat(obuf, oldpath, 0x0);
+	mlucas_path_cat(nbuf, newpath, 0x0);
+#if defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
+	return !MoveFileEx(obuf, nbuf, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH);
+#else
+	return rename(obuf, nbuf);
+#endif
+}
+
+/* Open the scratch file in which a crash-safe replacement of savefile [path] is staged. Use exactly
+as mlucas_fopen(path,"wb"), but close the result with mlucas_fclose_atomic(path,fp) rather than
+fclose(fp); [path] must be the same string in both calls.
+
+Why this exists: a savefile write of the form
+
+	fp = mlucas_fopen(savefile,"wb");  ...write...  fclose(fp);
+
+truncates the target *before* writing a single byte of the replacement, so from the instant the file
+is opened until the instant the last byte lands, there is no complete copy of that checkpoint on
+disk. A crash, kill -9, power loss or full filesystem in that window leaves a short or garbage
+savefile behind and takes the previous good checkpoint with it. Measured, not theoretical: killing a
+p-1 run partway through a .s2 stage-2 checkpoint write leaves a truncated .s2 where the previous
+complete checkpoint used to be, and the next run then discards that stage-2 progress entirely and
+redoes the stage from its start. The p/q residue-savefile pair survives the same treatment only
+because there are two copies of it - the corrupt primary is detected and the secondary used instead.
+The .s2 checkpoint has no second copy, so there is nothing to fall back to.
+
+Staging the new contents in a sibling scratch file and rename()-ing it over the target closes that
+window: the target is only ever replaced by a rename, which is atomic, so at every instant the file
+on disk is either the complete old checkpoint or the complete new one - never a prefix of either.
+The scratch file must live in the same directory as its target for this to work, since rename() is
+only atomic within a filesystem; appending a suffix to the full target path guarantees that.
+*/
+FILE *mlucas_fopen_atomic(const char *path, const char *mode)
+{
+	char tmp_path[MLUCAS_PATH_BUFSIZE];
+	ASSERT(mode != 0x0 && mode[0] == 'w', "mlucas_fopen_atomic: only write ('w'/'wb') modes make sense here!");
+	mlucas_path_cat(tmp_path, path, SAVEFILE_TMP_SUFFIX);
+	return fopen(tmp_path, mode);
+}
+
+/* Abandon a crash-safe savefile write begun with mlucas_fopen_atomic(path,...): close the scratch
+file and delete it, leaving [path] untouched. For callers which discover partway through - or after
+finishing - that the data they staged is not fit to be published: */
+void mlucas_discard_atomic(const char *path, FILE *fp)
+{
+	char tmp_path[MLUCAS_PATH_BUFSIZE];
+	if(fp) fclose(fp);
+	mlucas_path_cat(tmp_path, path, SAVEFILE_TMP_SUFFIX);
+	remove(tmp_path);
+}
+
+/* Finish a crash-safe savefile write begun with mlucas_fopen_atomic(path,...): flush the stdio
+buffer, push the data to stable storage, close, then atomically rename the scratch file over [path].
+Returns 0 on success; on any failure returns nonzero having deleted the scratch file, so that [path]
+still holds the previous good checkpoint. Callers must check the return value - it is the analogue of
+a failed write, not of a failed fclose() nobody looks at.
+
+The fsync() is the difference between "a crash cannot corrupt the savefile" and "a *power loss*
+cannot corrupt the savefile". Without it the rename can reach the disk ahead of the data it is
+supposed to be publishing, leaving the target name pointing at a file whose contents never made it
+out of the page cache. Its failure is treated as a write failure, since a deferred ENOSPC/EIO is
+exactly how a filesystem reports that the data did not make it.
+*/
+int mlucas_fclose_atomic(const char *path, FILE *fp)
+{
+	char tmp_path[MLUCAS_PATH_BUFSIZE], tmp_name[STR_MAX_LEN + sizeof(SAVEFILE_TMP_SUFFIX)];
+	int err = 0;
+	if(!fp) return -1;
+	mlucas_path_cat(tmp_path, path, SAVEFILE_TMP_SUFFIX);
+	strcpy(tmp_name, path);	strcat(tmp_name, SAVEFILE_TMP_SUFFIX);	// MLUCAS_PATH-relative, for mlucas_rename()
+	/* [1] stdio buffer ==> OS: */
+	if(fflush(fp) != 0)
+		err = 1;
+	/* [2] OS page cache ==> stable storage. EINVAL/ENOTSUP mean the fd is of a type which cannot be
+	synced (a pipe, or a filesystem lacking the operation) rather than that the data was lost, so do
+	not treat those as write failures: */
+	if(!err) {
+	#if defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
+		if(_commit(_fileno(fp)) != 0 && errno != EINVAL && errno != EBADF)
+			err = 1;
+	#else
+		if(fsync(fileno(fp)) != 0 && errno != EINVAL && errno != ENOTSUP)
+			err = 1;
+	#endif
+	}
+	/* [3] Close. A failed fclose() means buffered data was dropped, i.e. the file is short: */
+	if(fclose(fp) != 0)
+		err = 1;
+	if(err) {
+		remove(tmp_path);	// Leave [path] holding the previous good checkpoint
+		return 1;
+	}
+	/* [4] Publish, atomically: */
+	if(mlucas_rename(tmp_name, path)) {
+		remove(tmp_path);
+		return 1;
+	}
+	/* [5] Make the rename itself durable by syncing the containing directory. Best-effort: a
+	failure here means the *name change* might not survive a power loss, in which case the target
+	simply still holds the previous good checkpoint - no corruption either way - so unlike the data
+	fsync above this one does not fail the write. No Windows equivalent, and none needed: the
+	MOVEFILE_WRITE_THROUGH flag passed to MoveFileEx() already covers it. */
+#if !defined(OS_TYPE_WINDOWS) && !defined(__MINGW32__)
+	{
+		char *slash;	int dfd;
+		strcpy(tmp_path, MLUCAS_PATH);	strcat(tmp_path, path);
+		slash = strrchr(tmp_path,'/');
+		if(slash == tmp_path)	// Target sits in the root directory
+			tmp_path[1] = '\0';
+		else if(slash)
+			*slash = '\0';
+		else					// No directory component at all ==> current working directory
+			strcpy(tmp_path,".");
+		dfd = open(tmp_path, O_RDONLY);
+		if(dfd >= 0) { fsync(dfd); close(dfd); }
+	}
+#endif
+	return 0;
 }
 
 /*********************/

--- a/src/util.c
+++ b/src/util.c
@@ -9835,12 +9835,19 @@ double mlucas_getOptVal(const char*fname, char*optname)
 	double result = strtod("NaN", 0x0);
 	if(fptr) {
 		while(fgets(cstr, STR_MAX_LEN, fptr)) {
-			if((cptr = strstr(cstr,optname)) != 0x0) {
-				if((cadd = strstr(cptr + strlen(optname),"=")) != 0x0) {
-				 	result = strtod(cadd+1,0x0);	// Could insert a ptr in place of 0x0 to hold ptr to any unconverted suffix, but
-				 									// in the case of an mlucas.ini entry it would typically just contain a newline.
-				 	return result;	// Return first occurrence of option in file
-				}
+			/* v21: Match the option name as a whole word, not as a substring - strstr() alone made "JacobiCheck" match a
+			"JacobiCheckHours = 0" line (returning 0 for an option that was never set). The name must start the line (after
+			any leading whitespace) and be followed by whitespace or '=': */
+			cptr = cstr;
+			while(*cptr == ' ' || *cptr == '\t') cptr++;
+			if(strncmp(cptr, optname, strlen(optname)) != 0) continue;
+			cadd = cptr + strlen(optname);
+			if(*cadd != ' ' && *cadd != '\t' && *cadd != '=') continue;
+			if((cadd = strstr(cadd,"=")) != 0x0) {
+			 	result = strtod(cadd+1,0x0);	// Could insert a ptr in place of 0x0 to hold ptr to any unconverted suffix, but
+			 									// in the case of an mlucas.ini entry it would typically just contain a newline.
+			 	fclose(fptr);
+			 	return result;	// Return first occurrence of option in file
 			}
 		}
 		fclose(fptr);	fptr = 0x0;

--- a/src/util.c
+++ b/src/util.c
@@ -9676,6 +9676,18 @@ int mlucas_rename(const char *oldpath, const char *newpath)
 #endif
 }
 
+/* remove() with the MLUCAS_PATH prefix applied, for the same reason mlucas_rename() exists: every
+savefile in the tree is created through mlucas_fopen(), which prepends MLUCAS_PATH, so a bare
+remove(name) under a nonempty prefix looks in the wrong directory. It does not fail loudly - it
+returns nonzero for "no such file", which the call sites then report as an inability to delete a
+file that was in fact never looked at. */
+int mlucas_remove(const char *path)
+{
+	char buf[MLUCAS_PATH_BUFSIZE];
+	mlucas_path_cat(buf, path, 0x0);
+	return remove(buf);
+}
+
 /* Open the scratch file in which a crash-safe replacement of savefile [path] is staged. Use exactly
 as mlucas_fopen(path,"wb"), but close the result with mlucas_fclose_atomic(path,fp) rather than
 fclose(fp); [path] must be the same string in both calls.

--- a/src/util.h
+++ b/src/util.h
@@ -198,6 +198,7 @@ int		mlucas_fclose_atomic(const char *path, FILE *fp);
 void	mlucas_discard_atomic(const char *path, FILE *fp);
 /* MLUCAS_PATH-aware, replace-existing-destination rename; 0 = success: */
 int		mlucas_rename(const char *oldpath, const char *newpath);
+int		mlucas_remove(const char *path);
 // v20: Add simple utility to print the input string to the current-assignment logfile and/or to stderr:
 void	mlucas_fprint(char*const p_cstr, uint32 echo_to_stderr);
 double	mlucas_getOptVal(const char*fname, char*optname);

--- a/src/util.h
+++ b/src/util.h
@@ -188,6 +188,16 @@ char	*quote_spaces(char *dest, char *src); /* Double-quote spaces in string  */
 int		mkdir_p(char *path); /* Emulate `mkdir -p path'  */
 char	*shell_quote(char *dest, char *src); /* Escape shell meta characters  */
 FILE	*mlucas_fopen(const char *path, const char *mode); /* fopen() wrapper  */
+/* v21: Crash-safe savefile replacement. mlucas_fopen_atomic() stages the new contents in a sibling
+scratch file; mlucas_fclose_atomic() syncs it and renames it over the target, which is thus replaced
+atomically rather than truncated in place. Both take the same MLUCAS_PATH-relative [path]; the close
+returns 0 on success and nonzero (target left holding the previous good checkpoint) on failure: */
+FILE	*mlucas_fopen_atomic(const char *path, const char *mode);
+int		mlucas_fclose_atomic(const char *path, FILE *fp);
+/* Abandon a staged write: close and delete the scratch file, leaving the target untouched: */
+void	mlucas_discard_atomic(const char *path, FILE *fp);
+/* MLUCAS_PATH-aware, replace-existing-destination rename; 0 = success: */
+int		mlucas_rename(const char *oldpath, const char *newpath);
 // v20: Add simple utility to print the input string to the current-assignment logfile and/or to stderr:
 void	mlucas_fprint(char*const p_cstr, uint32 echo_to_stderr);
 double	mlucas_getOptVal(const char*fname, char*optname);

--- a/tests/jacobi-check.sh
+++ b/tests/jacobi-check.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# End-to-end tests for the LL Jacobi residue check (help.txt sections [4], [11], [12], [14b]).
+#
+# Usage: tests/jacobi-check.sh <Mlucas binary> [<Mlucas binary built with -DMLUCAS_FAULT_INJECT>] [<mlucas.cfg>]
+#
+# Runs small LL tests in a scratch directory and asserts on the .stat file, the savefiles and the
+# results.txt JSON line. Exponents: M44497 and M216091 (known primes, whole LL in seconds) and 44501 /
+# 216103 (prime exponents with composite Mersenne numbers, so a results line is emitted). The
+# fault-injection tests need the second binary; they are skipped with a notice if it is not given.
+#
+# What is asserted, and why, is spelled out next to each test. Every expectation is one the check's
+# design makes: a check that passes at every checkpoint of a clean run; a corrupted savefile that is
+# refused on read; an injected fault caught at the next check with a rollback to the previous checkpoint
+# and a correct final result; an injected fault that passes its own checkpoint but is caught at the next
+# and recovered through the .J1 generation; and - deliberately - an injected fault that the check MISSES
+# and a run that then ends wrong. The last one documents the check's known blind spot rather than hiding
+# it: the Jacobi symbol is invariant under the LL recurrence from one iteration after a corruption on,
+# so a corruption that passes the first check after it is never caught by a later one.
+set -u -o pipefail
+
+MLUCAS=${1:?usage: $0 <Mlucas> [<Mlucas-fault-inject>] [<mlucas.cfg>]}
+MLUCAS_FI=${2:-}
+CFG=${3:-}
+MLUCAS=$(readlink -f "$MLUCAS"); [[ -n $MLUCAS_FI ]] && MLUCAS_FI=$(readlink -f "$MLUCAS_FI")
+[[ -n $CFG ]] && CFG=$(readlink -f "$CFG")
+CPU=${JACOBI_TEST_CPU:-0:3}
+WORK=${JACOBI_TEST_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/jacobi-check.XXXXXX")}
+mkdir -p "$WORK"
+PASS=0; FAIL=0; SKIP=0
+
+ok()   { echo "  ok   - $*"; PASS=$((PASS+1)); }
+bad()  { echo "  FAIL - $*"; FAIL=$((FAIL+1)); }
+skip() { echo "  skip - $*"; SKIP=$((SKIP+1)); }
+expect_grep()   { local f=$1 pat=$2 what=$3; if grep -q -- "$pat" "$f"; then ok "$what"; else bad "$what (pattern not found: $pat)"; fi; }
+expect_nogrep() { local f=$1 pat=$2 what=$3; if grep -q -- "$pat" "$f"; then bad "$what (unexpected: $(grep -m1 -- "$pat" "$f"))"; else ok "$what"; fi; }
+expect_count()  { local f=$1 pat=$2 min=$3 what=$4; local n; n=$(grep -c -- "$pat" "$f"); if (( n >= min )); then ok "$what ($n)"; else bad "$what: $n < $min"; fi; }
+
+# Fresh run directory with the binary, cfg (if any) and the mlucas.ini options the tests rely on.
+setup() {	# setup <dir> <exponent> <CheckInterval> [<binary>]
+	local d=$WORK/$1 p=$2 ci=$3 bin=${4:-$MLUCAS}
+	rm -rf "$d"; mkdir -p "$d"
+	ln -s "$bin" "$d/Mlucas"
+	[[ -n $CFG && -f $CFG ]] && cp "$CFG" "$d/mlucas.cfg"
+	printf 'Test=%s\n' "$p" > "$d/worktodo.txt"
+	printf 'CheckInterval = %s\nJacobiCheckHours = 0\n' "$ci" > "$d/mlucas.ini"
+	echo "$d"
+}
+run() {	# run <dir> [env...] : run Mlucas to completion (or until it exits) in <dir>, log to run.log
+	local d=$1; shift
+	( cd "$d" && env "$@" timeout 900 ./Mlucas -cpu "$CPU" > run.log 2>&1 ); echo $? > "$d/exit"
+}
+# Run in the background and stop it with SIGINT once the .stat file shows the given iteration.
+run_until_iter_then_interrupt() {	# <dir> <exponent> <iteration>
+	local d=$1 p=$2 it=$3 pid i
+	( cd "$d" && exec ./Mlucas -cpu "$CPU" > run.log 2>&1 ) & pid=$!
+	for i in $(seq 1 600); do
+		sleep 0.5
+		grep -q "Iter# = $it " "$d/p$p.stat" 2>/dev/null && break
+		kill -0 $pid 2>/dev/null || break
+	done
+	kill -INT $pid 2>/dev/null; wait $pid 2>/dev/null; echo $? > "$d/exit"
+}
+res64_of() { grep -o '"res64":"[0-9A-F]*"' "$1/results.txt" 2>/dev/null | tail -1 | cut -d'"' -f4; }
+
+echo "== Jacobi residue check: end-to-end tests (work dir $WORK)"
+echo "   Mlucas: $MLUCAS"; echo "   fault-inject build: ${MLUCAS_FI:-(none - fault-injection tests skipped)}"
+
+# ---------------------------------------------------------------------------------------------
+echo "-- T1: clean LL of a Mersenne prime (M44497), check at every checkpoint"
+d=$(setup t1 44497 1000); run "$d"
+S=$d/p44497.stat
+expect_grep  "$S" "M44497 is a known MERSENNE PRIME" "correct verdict"
+expect_count "$S" "Jacobi check passed" 45 "a pass logged at every checkpoint plus the final residue"
+expect_nogrep "$S" "FAILED" "no failure on a clean run"
+expect_grep  "$S" "At iteration 44495, shift = [0-9]*: Jacobi check passed" "final residue checked before the verdict"
+[[ -f $d/p44497.J && -f $d/p44497.J1 ]] && ok ".J and .J1 written" || bad ".J/.J1 missing"
+[[ -f $d/q44497 ]] && bad "q44497 left behind after completion" || ok "q44497 removed at completion"
+
+# ---------------------------------------------------------------------------------------------
+echo "-- T2: clean LL of a composite Mersenne number (M44501): results line carries the Jacobi count"
+d=$(setup t2 44501 1000); run "$d"
+S=$d/p44501.stat
+expect_grep "$S" "M44501 is not prime" "correct verdict"
+expect_count "$S" "Jacobi check passed" 45 "a pass logged at every checkpoint plus the final residue"
+[[ -f $d/results.txt ]] && ok "results.txt written" || bad "results.txt missing"
+if grep -qE '"error-code":"[0-9A-F]{6}0[0-9A-F]"' "$d/results.txt"; then ok "clean Jacobi nibble in error-code"; else bad "Jacobi nibble != 0 on a clean run"; fi
+expect_grep "$d/results.txt" '"errors":{"Roundoff":0, "jacobi":0}' "jacobi count 0 in the errors object"
+CLEAN_44501=$(res64_of "$d"); [[ ${#CLEAN_44501} -eq 16 ]] && ok "clean Res64 recorded: $CLEAN_44501" || bad "no Res64 in results.txt"
+
+# ---------------------------------------------------------------------------------------------
+echo "-- T3: interrupt and resume (M216091): the loaded residue is Jacobi-checked before use"
+d=$(setup t3 216091 10000)
+run_until_iter_then_interrupt "$d" 216091 30000
+S=$d/p216091.stat
+expect_grep "$S" "Received SIGINT signal: writing savefile" "interrupt wrote a savefile"
+if grep -q "Received SIGINT signal: writing savefile at Iter = \([0-9]*\)" "$S"; then
+	it=$(grep -o "writing savefile at Iter = [0-9]*" "$S" | grep -o "[0-9]*$")
+	# The interrupt-driven checkpoint must not run the check (shutdown must stay fast)...
+	expect_nogrep "$S" "At iteration $it, shift = [0-9]*: Jacobi check passed" "no Jacobi check on the interrupt checkpoint"
+	run "$d"
+	# ...and the resume must check the residue it loads:
+	expect_grep "$S" "Restart file p216091 (iteration $it) passed the Jacobi check" "restart-read Jacobi check of the saved residue"
+	expect_grep "$S" "Restarting M216091 at iteration = $it" "resumed at the interrupted iteration"
+	expect_grep "$S" "M216091 is a known MERSENNE PRIME" "correct verdict after resume"
+else
+	bad "could not interrupt the run in time"
+fi
+
+# ---------------------------------------------------------------------------------------------
+echo "-- T4: corrupted savefile is refused on read and the chain falls through (M216091)"
+d=$(setup t4 216091 10000)
+run_until_iter_then_interrupt "$d" 216091 30000
+S=$d/p216091.stat
+if [[ -f $d/p216091 && -f $d/q216091 && -f $d/p216091.J ]]; then
+	# Damage p and q identically in the residue body (byte 100 lives inside the residue), which
+	# breaks their checksum triplet; .J is intact and must be the file the run resumes from.
+	for f in p216091 q216091; do printf '\xff' | dd of="$d/$f" bs=1 seek=100 conv=notrunc status=none; done
+	run "$d"
+	expect_grep "$S" "read_ppm1_savefiles Failed on savefile p216091" "damaged primary rejected"
+	expect_grep "$S" "read_ppm1_savefiles Failed on savefile q216091" "damaged secondary rejected"
+	expect_grep "$S" "Restart file p216091.J (iteration [0-9]*) passed the Jacobi check" "resumed from the last Jacobi-passed checkpoint"
+	expect_grep "$S" "M216091 is a known MERSENNE PRIME" "correct verdict after falling through the chain"
+else
+	bad "expected p/q/.J savefiles after the interrupt"
+fi
+
+# ---------------------------------------------------------------------------------------------
+if [[ -z $MLUCAS_FI ]]; then
+	skip "T5: fault-injection tests need a -DMLUCAS_FAULT_INJECT build as the 2nd argument"
+else
+	echo "-- T5: fault injection at iteration 50000 (fixed, deterministic cases)"
+	# Each (exponent, iteration, digit) triple gives a deterministic verdict, so the cases are fixed rather
+	# than searched for. The injection lands exactly at a checked checkpoint, so the check sees two
+	# independent values: the symbol at the corrupted iteration itself (the check at 50000) and the one
+	# shared by every later check (from 60000 on). One case per class:
+	#   caught      - M216103 digit 0: fails at 50000; rollback to the previous checkpoint (40000), correct
+	#                 result, 1 error counted;
+	#   caught_late - M216103 digit 3: passes at 50000 (so the corrupt residue is saved to p, q and .J) but
+	#                 fails at 60000 and on every retry: the chain must walk p -> .J -> .J1 (40000, clean),
+	#                 3 errors counted;
+	#   missed      - M216091 digit 3: passes both, so no check ever fires, and the run ends with a WRONG
+	#                 verdict ("not prime" for a Mersenne prime). Asserted on purpose: it is the check's
+	#                 known limit, and this documents it rather than hiding it.
+	d=$(setup t5clean 216103 10000); run "$d"
+	CLEAN=$(res64_of "$d"); [[ ${#CLEAN} -eq 16 ]] && ok "clean M216103 run Res64 $CLEAN" || bad "clean run produced no results line"
+
+	d=$(setup t5caught 216103 10000 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_ITER=50000 MLUCAS_FAULT_WORD=0
+	S=$d/p216103.stat
+	expect_grep "$S" "FAULT INJECTION: added 1.0 to residue digit 0 at iteration 50000" "caught: injection fired"
+	expect_grep "$S" "Jacobi check at iteration 50000 FAILED" "caught: failure at the corrupted checkpoint"
+	expect_grep "$S" "Restarting from the current savefile" "caught: rollback to the current savefile announced"
+	expect_grep "$S" "Restart file p216103 (iteration 40000) passed the Jacobi check" "caught: rolled back to the previous (clean) checkpoint"
+	[[ $(res64_of "$d") == "$CLEAN" ]] && ok "caught: final Res64 matches the clean run" || bad "caught: final Res64 $(res64_of "$d") != clean $CLEAN"
+	# error-code bits 4-7 = 7th hex digit; other nibbles may legitimately be nonzero (e.g. a startup roundoff warning)
+	if grep -qE '"error-code":"[0-9A-F]{6}1[0-9A-F]"' "$d/results.txt"; then ok "caught: one Jacobi error in the error-code nibble (bits 4-7)"; else bad "caught: Jacobi nibble != 1: $(grep -o '"error-code":"[0-9A-F]*"' "$d/results.txt")"; fi
+	expect_grep "$d/results.txt" '"jacobi":1' "caught: jacobi count 1 in the errors object"
+
+	d=$(setup t5late 216103 10000 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_ITER=50000 MLUCAS_FAULT_WORD=3
+	S=$d/p216103.stat
+	expect_grep "$S" "FAULT INJECTION: added 1.0 to residue digit 3 at iteration 50000" "caught_late: injection fired"
+	expect_nogrep "$S" "Jacobi check at iteration 50000 FAILED" "caught_late: passes the check at its own checkpoint"
+	expect_count "$S" "Jacobi check at iteration 60000 FAILED" 3 "caught_late: the same failure recurs on each retry from a poisoned file"
+	expect_grep "$S" "Restart file p216103 (iteration 50000) passed the Jacobi check" "caught_late: p (poisoned) passes its on-read check, as the symbol invariance predicts"
+	expect_grep "$S" "Restart file p216103.J (iteration 50000) passed the Jacobi check" "caught_late: .J (poisoned) likewise"
+	expect_grep "$S" "Restart file p216103.J1 (iteration 40000) passed the Jacobi check" "caught_late: chain reaches .J1, the clean checkpoint"
+	[[ $(res64_of "$d") == "$CLEAN" ]] && ok "caught_late: final Res64 matches the clean run" || bad "caught_late: final Res64 $(res64_of "$d") != clean $CLEAN"
+	if grep -qE '"error-code":"[0-9A-F]{6}3[0-9A-F]"' "$d/results.txt"; then ok "caught_late: three Jacobi errors in the error-code nibble"; else bad "caught_late: Jacobi nibble != 3: $(grep -o '"error-code":"[0-9A-F]*"' "$d/results.txt")"; fi
+
+	d=$(setup t5missed 216091 10000 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_ITER=50000 MLUCAS_FAULT_WORD=3
+	S=$d/p216091.stat
+	expect_grep "$S" "FAULT INJECTION: added 1.0 to residue digit 3 at iteration 50000" "missed: injection fired"
+	expect_nogrep "$S" "FAILED" "missed: no check ever fires (symbol invariant under the recurrence)"
+	expect_grep "$S" "M216091 is not prime" "missed: run ends with a WRONG verdict for a Mersenne prime - this is the documented limit of the check"
+	expect_nogrep "$S" "known MERSENNE PRIME" "missed: (and not the correct verdict)"
+fi
+
+# ---------------------------------------------------------------------------------------------
+echo "== $PASS passed, $FAIL failed, $SKIP skipped (work dir $WORK)"
+(( FAIL == 0 ))

--- a/tests/jacobi-check.sh
+++ b/tests/jacobi-check.sh
@@ -96,8 +96,10 @@ S=$d/p216091.stat
 expect_grep "$S" "Received SIGINT signal: writing savefile" "interrupt wrote a savefile"
 if grep -q "Received SIGINT signal: writing savefile at Iter = \([0-9]*\)" "$S"; then
 	it=$(grep -o "writing savefile at Iter = [0-9]*" "$S" | grep -o "[0-9]*$")
-	# The interrupt-driven checkpoint must not run the check (shutdown must stay fast)...
-	expect_nogrep "$S" "At iteration $it, shift = [0-9]*: Jacobi check passed" "no Jacobi check on the interrupt checkpoint"
+	# The interrupt-driven checkpoint must not run the check (shutdown must stay fast). Order-aware: when the signal
+	# lands between intervals the interrupt is reported at the iteration of the regular checkpoint just written, whose
+	# own check legitimately ran *before* the signal - so look only at what follows the interrupt message:
+	if sed -n '/Received SIGINT signal/,$p' "$S" | grep -q "Jacobi check passed"; then bad "a Jacobi check ran on the interrupt checkpoint"; else ok "no Jacobi check on the interrupt checkpoint"; fi
 	run "$d"
 	# ...and the resume must check the residue it loads:
 	expect_grep "$S" "Restart file p216091 (iteration $it) passed the Jacobi check" "restart-read Jacobi check of the saved residue"
@@ -175,6 +177,26 @@ else
 	expect_nogrep "$S" "FAILED" "missed: no check ever fires (symbol invariant under the recurrence)"
 	[[ $(res64_of "$d") != "$CLEAN" ]] && ok "missed: run ends with a WRONG residue $(res64_of "$d") - this is the documented limit of the check" || bad "missed: final residue equals the clean one?!"
 	if grep -qE '"error-code":"[0-9A-F]{6}0[0-9A-F]"' "$d/results.txt"; then ok "missed: Jacobi nibble 0, as expected - nothing was detected"; else bad "missed: Jacobi nibble != 0"; fi
+fi
+
+# ---------------------------------------------------------------------------------------------
+if [[ -n $MLUCAS_FI ]]; then
+	echo "-- T6: a reproducible fault: the rollback chain is walked to the end and the run aborts rather than loop"
+	# MLUCAS_FAULT_REPEAT re-fires the injection at every visit of iteration 50000, so every retry fails there
+	# again: current savefile -> .J -> .J1 -> scratch -> fifth failure aborts with a hardware warning.
+	d=$(setup t6 216103 10000 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_ITER=50000 MLUCAS_FAULT_WORD=3 MLUCAS_FAULT_REPEAT=1 -- -shift 0
+	S=$d/p216103.stat
+	expect_count "$S" "FAULT INJECTION: added 1.0 to residue digit 3 at iteration 50000" 5 "injection re-fired on every retry"
+	expect_count "$S" "Jacobi check at iteration 50000 FAILED" 4 "four failures each followed by a rollback"
+	expect_grep "$S" "Restarting from the current savefile" "1st rollback: current savefile"
+	expect_grep "$S" "Restarting from the last Jacobi-passed savefile" "2nd rollback: .J"
+	expect_grep "$S" "Restarting from the previous Jacobi-passed savefile" "3rd rollback: .J1"
+	expect_grep "$S" "Restarting from scratch" "4th rollback: scratch"
+	expect_grep "$S" "failed 5 times in a row, the last after restarting from scratch" "5th failure aborts with the hardware warning"
+	[[ $(cat "$d/exit") != 0 ]] && ok "run stopped (exit $(cat "$d/exit"))" || bad "run did not stop"
+	[[ -f $d/p216103 && -f $d/p216103.J ]] && ok "savefiles left in place" || bad "savefiles missing after the abort"
+else
+	skip "T6 needs the -DMLUCAS_FAULT_INJECT build"
 fi
 
 # ---------------------------------------------------------------------------------------------

--- a/tests/jacobi-check.sh
+++ b/tests/jacobi-check.sh
@@ -45,9 +45,10 @@ setup() {	# setup <dir> <exponent> <CheckInterval> [<binary>]
 	printf 'CheckInterval = %s\nJacobiCheckHours = 0\n' "$ci" > "$d/mlucas.ini"
 	echo "$d"
 }
-run() {	# run <dir> [env...] : run Mlucas to completion (or until it exits) in <dir>, log to run.log
-	local d=$1; shift
-	( cd "$d" && env "$@" timeout 900 ./Mlucas -cpu "$CPU" > run.log 2>&1 ); echo $? > "$d/exit"
+run() {	# run <dir> [env...] [-- <extra Mlucas args>] : run Mlucas to completion (or until it exits) in <dir>, log to run.log
+	local d=$1; shift; local envs=() extra=()
+	while (( $# )); do if [[ $1 == -- ]]; then shift; extra=("$@"); break; fi; envs+=("$1"); shift; done
+	( cd "$d" && env "${envs[@]}" timeout 900 ./Mlucas -cpu "$CPU" "${extra[@]}" > run.log 2>&1 ); echo $? > "$d/exit"
 }
 # Run in the background and stop it with SIGINT once the .stat file shows the given iteration.
 run_until_iter_then_interrupt() {	# <dir> <exponent> <iteration>
@@ -129,24 +130,26 @@ if [[ -z $MLUCAS_FI ]]; then
 	skip "T5: fault-injection tests need a -DMLUCAS_FAULT_INJECT build as the 2nd argument"
 else
 	echo "-- T5: fault injection at iteration 50000 (fixed, deterministic cases)"
-	# Each (exponent, iteration, digit) triple gives a deterministic verdict, so the cases are fixed rather
-	# than searched for. The injection lands exactly at a checked checkpoint, so the check sees two
-	# independent values: the symbol at the corrupted iteration itself (the check at 50000) and the one
-	# shared by every later check (from 60000 on). One case per class:
-	#   caught      - M216103 digit 0: fails at 50000; rollback to the previous checkpoint (40000), correct
-	#                 result, 1 error counted;
-	#   caught_late - M216103 digit 3: passes at 50000 (so the corrupt residue is saved to p, q and .J) but
-	#                 fails at 60000 and on every retry: the chain must walk p -> .J -> .J1 (40000, clean),
+	# Each (exponent, iteration, digit, residue shift) gives a deterministic verdict, so the cases are fixed
+	# rather than searched for. The runs use -shift 0: the injector perturbs one digit of the residue *as
+	# stored*, so with a random shift the perturbed bit position - and hence the verdict - would change from
+	# run to run. The injection lands exactly at a checked checkpoint, so the check sees two independent
+	# values: the symbol at the corrupted iteration itself (the check at 50000) and the one shared by every
+	# later check (from 60000 on). One case per class, all on M216103 (digits classified with -shift 0):
+	#   caught      - digit 3: fails at 50000; rollback to the previous checkpoint (40000), correct result,
+	#                 1 error counted;
+	#   caught_late - digit 13: passes at 50000 (so the corrupt residue is saved to p, q and .J) but fails
+	#                 at 60000 and on every retry: the chain must walk p -> .J -> .J1 (40000, clean),
 	#                 3 errors counted;
-	#   missed      - M216091 digit 3: passes both, so no check ever fires, and the run ends with a WRONG
-	#                 verdict ("not prime" for a Mersenne prime). Asserted on purpose: it is the check's
-	#                 known limit, and this documents it rather than hiding it.
-	d=$(setup t5clean 216103 10000); run "$d"
+	#   missed      - digit 0: passes both, so no check ever fires, and the run ends with a WRONG residue.
+	#                 Asserted on purpose: it is the check's known limit, and this documents it rather than
+	#                 hiding it.
+	d=$(setup t5clean 216103 10000); run "$d" -- -shift 0
 	CLEAN=$(res64_of "$d"); [[ ${#CLEAN} -eq 16 ]] && ok "clean M216103 run Res64 $CLEAN" || bad "clean run produced no results line"
 
-	d=$(setup t5caught 216103 10000 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_ITER=50000 MLUCAS_FAULT_WORD=0
+	d=$(setup t5caught 216103 10000 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_ITER=50000 MLUCAS_FAULT_WORD=3 -- -shift 0
 	S=$d/p216103.stat
-	expect_grep "$S" "FAULT INJECTION: added 1.0 to residue digit 0 at iteration 50000" "caught: injection fired"
+	expect_grep "$S" "FAULT INJECTION: added 1.0 to residue digit 3 at iteration 50000" "caught: injection fired"
 	expect_grep "$S" "Jacobi check at iteration 50000 FAILED" "caught: failure at the corrupted checkpoint"
 	expect_grep "$S" "Restarting from the current savefile" "caught: rollback to the current savefile announced"
 	expect_grep "$S" "Restart file p216103 (iteration 40000) passed the Jacobi check" "caught: rolled back to the previous (clean) checkpoint"
@@ -155,9 +158,9 @@ else
 	if grep -qE '"error-code":"[0-9A-F]{6}1[0-9A-F]"' "$d/results.txt"; then ok "caught: one Jacobi error in the error-code nibble (bits 4-7)"; else bad "caught: Jacobi nibble != 1: $(grep -o '"error-code":"[0-9A-F]*"' "$d/results.txt")"; fi
 	expect_grep "$d/results.txt" '"jacobi":1' "caught: jacobi count 1 in the errors object"
 
-	d=$(setup t5late 216103 10000 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_ITER=50000 MLUCAS_FAULT_WORD=3
+	d=$(setup t5late 216103 10000 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_ITER=50000 MLUCAS_FAULT_WORD=13 -- -shift 0
 	S=$d/p216103.stat
-	expect_grep "$S" "FAULT INJECTION: added 1.0 to residue digit 3 at iteration 50000" "caught_late: injection fired"
+	expect_grep "$S" "FAULT INJECTION: added 1.0 to residue digit 13 at iteration 50000" "caught_late: injection fired"
 	expect_nogrep "$S" "Jacobi check at iteration 50000 FAILED" "caught_late: passes the check at its own checkpoint"
 	expect_count "$S" "Jacobi check at iteration 60000 FAILED" 3 "caught_late: the same failure recurs on each retry from a poisoned file"
 	expect_grep "$S" "Restart file p216103 (iteration 50000) passed the Jacobi check" "caught_late: p (poisoned) passes its on-read check, as the symbol invariance predicts"
@@ -166,12 +169,12 @@ else
 	[[ $(res64_of "$d") == "$CLEAN" ]] && ok "caught_late: final Res64 matches the clean run" || bad "caught_late: final Res64 $(res64_of "$d") != clean $CLEAN"
 	if grep -qE '"error-code":"[0-9A-F]{6}3[0-9A-F]"' "$d/results.txt"; then ok "caught_late: three Jacobi errors in the error-code nibble"; else bad "caught_late: Jacobi nibble != 3: $(grep -o '"error-code":"[0-9A-F]*"' "$d/results.txt")"; fi
 
-	d=$(setup t5missed 216091 10000 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_ITER=50000 MLUCAS_FAULT_WORD=3
-	S=$d/p216091.stat
-	expect_grep "$S" "FAULT INJECTION: added 1.0 to residue digit 3 at iteration 50000" "missed: injection fired"
+	d=$(setup t5missed 216103 10000 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_ITER=50000 MLUCAS_FAULT_WORD=0 -- -shift 0
+	S=$d/p216103.stat
+	expect_grep "$S" "FAULT INJECTION: added 1.0 to residue digit 0 at iteration 50000" "missed: injection fired"
 	expect_nogrep "$S" "FAILED" "missed: no check ever fires (symbol invariant under the recurrence)"
-	expect_grep "$S" "M216091 is not prime" "missed: run ends with a WRONG verdict for a Mersenne prime - this is the documented limit of the check"
-	expect_nogrep "$S" "known MERSENNE PRIME" "missed: (and not the correct verdict)"
+	[[ $(res64_of "$d") != "$CLEAN" ]] && ok "missed: run ends with a WRONG residue $(res64_of "$d") - this is the documented limit of the check" || bad "missed: final residue equals the clean one?!"
+	if grep -qE '"error-code":"[0-9A-F]{6}0[0-9A-F]"' "$d/results.txt"; then ok "missed: Jacobi nibble 0, as expected - nothing was detected"; else bad "missed: Jacobi nibble != 0"; fi
 fi
 
 # ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
Part of #97 - the LL half. The P-1 half (a Gerbicz check for stage 1, exact checks of the
stage 2 inputs) follows in a PR stacked on this one.

**What it checks.** For an LL test of M(p), p an odd prime, every iterate satisfies
J(s_n - 2 | M(p)) = -1 whatever M(p)'s primality (the symbol telescopes to J(3 | M(p))). A
corrupted residue satisfies it with probability 1/2. The symbol is also invariant under the
recurrence from one iteration after a corruption on, so every later check examines the same
value: a corruption that passes the first check after it is never caught by a later one. The
check catches about half of all corruption events; it is a cheap, weak check that bounds the
work lost when a corruption is caught - it does not certify the result, and LL results still
need the double-check. The residue shift is irrelevant to the symbol; the -2 is applied to the
unshifted value the savefiles hold, which `jacobi_check()` hands to GMP's `mpz_jacobi`.

**When it runs.** On every restart-file read, before anything is built on the loaded residue
(the S-H checksum triplet only proves a file is self-consistent); on the final residue; and at
checkpoints once `JacobiCheckHours` (default 12) have elapsed since the previous check, or at
every checkpoint when that is 0. Never on an interrupt-driven checkpoint, so shutdown stays
fast, and never sooner than 100x the previous check's duration, so the overhead stays near 1%
on any hardware. Hours rather than iterations because the check is scalar GMP work whose cost
relative to an FFT iteration varies by an order of magnitude across machines: 0.08 s at 1M
bits, 28 s at 100M, 146 s at 332M on an i9-10885H with GMP 6.3.

**Rollback.** A passing check keeps the two most recent Jacobi-passed checkpoints as
`p[exp].J` and `p[exp].J1`. A failure normally implies the corruption postdates the last
passing check (an earlier one that passed would go on passing), so `.J` is the natural target.
`.J1` covers an unreadable `.J`, and the one case where `.J` is poisoned: a corruption that
struck exactly at a checked checkpoint, passed that check and fails every later one - the retry
from `.J` then fails at the same iteration and the chain moves on to `.J1`. The tests produce
exactly that case. The run rolls back through p -> q -> .J -> .J1 -> scratch,
checking each file as it is read; the fifth consecutive failure aborts with a hardware
warning. The Gerbicz-restart shift mod-doubling is reused.

**Error accounting.** `error-code` bits 4-7 carry the Jacobi count, following the GIMPS
server's layout (roundoff 8-13, Gerbicz 20-23), and the `errors` object gains `"jacobi"`.
The count is appended to the savefile as a 4-byte field after the two existing counts, so
older readers - which stop after those - are unaffected; verified by resuming a new-format
savefile with a `main` binary and by reading one with AutoPrimeNet's gimps_status.py.

**mlucas.ini.** `JacobiCheck = 0|1` (default 1) and `JacobiCheckHours` (default 12; 0 = every
checkpoint). Also fixed on the way: `mlucas_getOptVal()` matched option names as substrings,
so `JacobiCheck` read the `JacobiCheckHours` line - it now matches whole names.

**Tests.** `tests/jacobi-check.sh` (wired into the Linux CI job): clean runs of M44497 and
M44501 with a check at every checkpoint; interrupt and resume; a damaged p/q pair refused on
read with the run resuming from `.J`; and fault injection via a test-only
`-DMLUCAS_FAULT_INJECT` build that perturbs one residue digit at a chosen checkpoint. Of the
digits tried, some are caught at the corrupted checkpoint (rollback to the previous checkpoint,
final residue equal to the clean run's, error-code nibble 1), some pass it and are caught at
the next check (the chain walks p -> .J -> .J1 and recovers, nibble 3), and some are missed -
and the missed run ends with a wrong residue. That last case is asserted on purpose: it is the
check's known limit, and the test documents it rather than hiding it.

**Found by the tests, fixed here.** The rollback chain's retry count was cleared by every passing check, including the earlier checkpoints passing again on the way back up after a rollback, so a *reproducible* fault at one iteration walked scratch -> pass -> fail -> rollback -> ... forever instead of aborting at the fifth failure. The count is now cleared only by a pass at or beyond the last failure point. Test T6 re-fires the injected fault on every visit of its iteration (`MLUCAS_FAULT_REPEAT`) and asserts the chain p -> .J -> .J1 -> scratch and the abort with the savefiles left in place.

**Docs.** help.txt sections [4], [7], [11], [12] and a new [14b] (log lines and what to do
about each; the JSON error-code layout, which was undocumented); README feature table.

Depends on #170, #108 and #178 (`mlucas_fopen_atomic`/`mlucas_rename`/`savefile_ends_at`,
the interrupt-safe checkpoint, `loop_exit`/`gchk_nfail`): the branch is `main` plus those three
plus four commits of its own, so until they land this diff includes their changes as well - the
feature is the last four commits. I'll rebase onto `main` once they are in. Merge order for the
whole capability is in #224.


