### PR TITLE
Clear all of main's own compiler warnings

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -6474,7 +6474,12 @@ uint32 extract_known_factors(uint64 p, char *fac_start) {
 			i = CMPEQ256(res256,q256);
 		}
 		if(!i) {
-			snprintf(g_cstr,sizeof(g_cstr),"%s: known-factor #%u [%s] of this assignment does not divide the modulus ... please correct or remove that entry.",WORKFILE,nfac,cbuf);
+			// %.*s, not %s, on cbuf: it holds the factor token as it appeared in the worktodo line,
+			// whose length is bounded only by cbuf itself (STR_MAX_LEN*3), while g_cstr is STR_MAX_LEN -
+			// so the compiler cannot rule out truncation, and a truncated factor would leave the user
+			// unable to tell which entry the message is asking them to correct. A 256-bit factor needs
+			// at most 78 digits, so a quarter of g_cstr is ample and makes the bound provable:
+			snprintf(g_cstr,sizeof(g_cstr),"%s: known-factor #%u [%.*s] of this assignment does not divide the modulus ... please correct or remove that entry.",WORKFILE,nfac,(int)(sizeof(g_cstr)/4),cbuf);
 			ASSERT(0,g_cstr);
 		}
 		// If find any duplicate-entries in input list, warn & remove:

--- a/src/factor.c
+++ b/src/factor.c
@@ -3394,24 +3394,27 @@ MFACTOR_HELP:
 							/* Make sure that q == 1 (mod 2p) and that q is a base-2 PRP: */
 							mi64_clear(u64_arr, lenQ);	// Use q2 for quotient [i.e. factor-candidate k] and u64_arr for remainder
 							mi64_div(q,two_p,lenQ,lenQ,q2,u64_arr);
-							/* The %s operands below are rendered into cbuf2, not cbuf: cbuf is snprintf's own
+							/* The %s operands below render into cbuf2, never into cbuf: cbuf is snprintf's own
 							destination, and handing snprintf a source string that lives inside its destination
-							buffer is a restrict violation - gcc says so, "'snprintf' argument 7 may overlap
-							destination object 'cbuf'". Both renderings fit in cbuf2 side by side: cbuf2 is
-							STR_MAX_LEN*2 chars and convert_mi64_base10_char passes n_alloc_chars = STR_MAX_LEN,
-							which it enforces with ASSERT(MAX_DIGITS < n_alloc_chars), so a rendering touches at
-							most the low STR_MAX_LEN chars of what it is handed. */
+							is a restrict violation - gcc says so, "'snprintf' argument 7 may overlap
+							destination object 'cbuf'".
+							That puts both renderings of the second message in cbuf2, so they need somewhere
+							separate to sit or the later one would overwrite the earlier before snprintf reads
+							it. cbuf2 is STR_MAX_LEN*2, and convert_mi64_base10_char() calls through with
+							n_alloc_chars = STR_MAX_LEN, enforced by ASSERT(MAX_DIGITS < n_alloc_chars) - so a
+							rendering touches at most STR_MAX_LEN chars and cbuf2 holds exactly two of them: */
+							char *const qstr = cbuf2, *const rstr = cbuf2 + STR_MAX_LEN;
 							if(mi64_getlen(q2, lenQ) != 1) {
 								snprintf(cbuf, sizeof(cbuf), "ERROR: Count = %u * 2^%u: k = %" PRIu64 ", Current q = %s: k must be 64-bit!\n",
-									(uint32)(count >> CMASKBITS),CMASKBITS,k,&cbuf2[convert_mi64_base10_char(cbuf2, q, lenQ, 0)]);
+									(uint32)(count >> CMASKBITS),CMASKBITS,k,&qstr[convert_mi64_base10_char(qstr, q, lenQ, 0)]);
 								fprintf(fp,"%s", cbuf);
 								ASSERT(0, cbuf);
 							}
 							if(!mi64_cmp_eq_scalar(u64_arr, 1ull, lenQ))
 							{
 								snprintf(cbuf, sizeof(cbuf), "ERROR: Count = %u * 2^%u: k = %" PRIu64 ", Current q = %s: q mod (2p) = %s != 1!\n",
-									(uint32)(count >> CMASKBITS),CMASKBITS,k,&cbuf2[convert_mi64_base10_char(cbuf2, q, lenQ, 0)],
-									&cbuf2[STR_MAX_LEN + __convert_mi64_base10_char(cbuf2+STR_MAX_LEN, STR_MAX_LEN, u64_arr, lenQ, 0)]);
+									(uint32)(count >> CMASKBITS),CMASKBITS,k,&qstr[convert_mi64_base10_char(qstr, q, lenQ, 0)],
+									&rstr[__convert_mi64_base10_char(rstr, STR_MAX_LEN, u64_arr, lenQ, 0)]);
 								fprintf(fp,"%s", cbuf);
 								ASSERT(0, cbuf);
 							}

--- a/src/factor.c
+++ b/src/factor.c
@@ -3394,17 +3394,24 @@ MFACTOR_HELP:
 							/* Make sure that q == 1 (mod 2p) and that q is a base-2 PRP: */
 							mi64_clear(u64_arr, lenQ);	// Use q2 for quotient [i.e. factor-candidate k] and u64_arr for remainder
 							mi64_div(q,two_p,lenQ,lenQ,q2,u64_arr);
+							/* The %s operands below are rendered into cbuf2, not cbuf: cbuf is snprintf's own
+							destination, and handing snprintf a source string that lives inside its destination
+							buffer is a restrict violation - gcc says so, "'snprintf' argument 7 may overlap
+							destination object 'cbuf'". Both renderings fit in cbuf2 side by side: cbuf2 is
+							STR_MAX_LEN*2 chars and convert_mi64_base10_char passes n_alloc_chars = STR_MAX_LEN,
+							which it enforces with ASSERT(MAX_DIGITS < n_alloc_chars), so a rendering touches at
+							most the low STR_MAX_LEN chars of what it is handed. */
 							if(mi64_getlen(q2, lenQ) != 1) {
 								snprintf(cbuf, sizeof(cbuf), "ERROR: Count = %u * 2^%u: k = %" PRIu64 ", Current q = %s: k must be 64-bit!\n",
-									(uint32)(count >> CMASKBITS),CMASKBITS,k,&cbuf[convert_mi64_base10_char(cbuf, q, lenQ, 0)]);
+									(uint32)(count >> CMASKBITS),CMASKBITS,k,&cbuf2[convert_mi64_base10_char(cbuf2, q, lenQ, 0)]);
 								fprintf(fp,"%s", cbuf);
 								ASSERT(0, cbuf);
 							}
 							if(!mi64_cmp_eq_scalar(u64_arr, 1ull, lenQ))
 							{
 								snprintf(cbuf, sizeof(cbuf), "ERROR: Count = %u * 2^%u: k = %" PRIu64 ", Current q = %s: q mod (2p) = %s != 1!\n",
-									(uint32)(count >> CMASKBITS),CMASKBITS,k,&cbuf[convert_mi64_base10_char(cbuf, q, lenQ, 0)],
-									&cbuf2[convert_mi64_base10_char(cbuf2, u64_arr, lenQ, 0)]);
+									(uint32)(count >> CMASKBITS),CMASKBITS,k,&cbuf2[convert_mi64_base10_char(cbuf2, q, lenQ, 0)],
+									&cbuf2[STR_MAX_LEN + __convert_mi64_base10_char(cbuf2+STR_MAX_LEN, STR_MAX_LEN, u64_arr, lenQ, 0)]);
 								fprintf(fp,"%s", cbuf);
 								ASSERT(0, cbuf);
 							}

--- a/src/mi64.c
+++ b/src/mi64.c
@@ -705,9 +705,9 @@ uint64	mi64_shl_short(const uint64 x[], uint64 y[], uint32 nshift, uint32 len)
 	int dbg = 0;
 	uint64 ref[1000];	if(len < 1000) ref[len] = mi64_shl_short_ref(x,ref,nshift,len);	// ref = x << nshift
 #endif
-  #ifdef USE_AVX2	// SSE2,AVX,AVX2 same in terms of processing 8 qwords per ASM-loop pass, but AVX2 must skip x[0:3]
+  #if defined(USE_AVX2) && defined(YES_ASM)	// SSE2,AVX,AVX2 same in terms of processing 8 qwords per ASM-loop pass, but AVX2 must skip x[0:3]
 	const uint32 BLOCKLENM1 = 7, BASEADDRMASK = 0x1F;	uint32 minlen = 9;
-  #elif defined(USE_AVX)	// SSE2/AVX - use SSE2 ASM for both cases - do 8 words per ASM-lop pass, must skip x[0:1]
+  #elif defined(USE_AVX) && defined(YES_ASM)	// SSE2/AVX - use SSE2 ASM for both cases - do 8 words per ASM-lop pass, must skip x[0:1]
 	const uint32 BLOCKLENM1 = 7, BASEADDRMASK = 0x0F;	uint32 minlen = 9;
   #elif defined(YES_ASM)
 	const uint32 BLOCKLENM1 = 3/* , BASEADDRMASK = 0x07 */;	uint32 minlen = 5;
@@ -1176,9 +1176,9 @@ uint64	mi64_shrl_short(const uint64 x[], uint64 y[], uint32 nshift, uint32 len)
 	int dbg = 0;
 	uint64 ref[1000];	if(len < 1000) ref[len] = mi64_shrl_short_ref(x,ref,nshift,len);	// ref = x << nshift
 #endif
-  #ifdef USE_AVX2	// SSE2,AVX,AVX2 same in terms of processing 8 qwords per ASM-loop pass, but AVX2 must skip x[0:3]
+  #if defined(USE_AVX2) && defined(YES_ASM)	// SSE2,AVX,AVX2 same in terms of processing 8 qwords per ASM-loop pass, but AVX2 must skip x[0:3]
 	const uint32 BLOCKLENM1 = 7, BASEADDRMASK = 0x1F;	uint32 minlen = 9;
-  #elif defined(USE_AVX)	// SSE2,AVX macros both do 8 words per ASM-lop pass, must skip x[0:1]
+  #elif defined(USE_AVX) && defined(YES_ASM)	// SSE2,AVX macros both do 8 words per ASM-lop pass, must skip x[0:1]
 	const uint32 BLOCKLENM1 = 7, BASEADDRMASK = 0x0F;	uint32 minlen = 9;
   #elif defined(YES_ASM)
 	const uint32 BLOCKLENM1 = 3, BASEADDRMASK = 0x07;	uint32 minlen = 5;
@@ -3991,7 +3991,7 @@ uint32 mi64_pprimeF(const uint64 p[], uint64 z, uint32 len)
 		const uint32 max_dim = 4096;
 		uint64 n[max_dim],ninv[max_dim], prod[2*max_dim], *lo = prod,*hi = 0x0, i64;
 		uint32 nbits, log2_numbits, wlen,wlen2, q32,qi32;
-		int i,j, start_index;
+		int j, start_index;
 	  #if MI64_PRP_DBG
 		int dbg = STREQ(&cbuf[convert_mi64_base10_char(cbuf, n, len, 0)], "0");	// Replace "0" with "[desired decimal-form debug modulus]"
 	  #endif
@@ -4040,7 +4040,10 @@ uint32 mi64_pprimeF(const uint64 p[], uint64 z, uint32 len)
 
 		where lo = converged bits, and hi = bits converged on current iteration
 		*/
-		for(i = 1, j = 6; j < log2_numbits; j++, i <<= 1) {	// I stores number of converged 64-bit words
+		// NB: the deferred optimization above also wants a running count of converged 64-bit words
+		// (i = 1, doubling per iteration). Until it is implemented this loop recomputes the full
+		// wlen-word product every pass and has no use for that count, so it is not carried here:
+		for(j = 6; j < log2_numbits; j++) {
 			mi64_mul_vector_lo_half(n, ninv,prod, wlen);
 			mi64_nega              (prod,prod, wlen);
 			i64 = mi64_add_scalar(prod, 2ull,prod, wlen);

--- a/src/radix16_dif_dit_pass.c
+++ b/src/radix16_dif_dit_pass.c
@@ -72,39 +72,39 @@
 	#error SIMD Mode requires HIACC flag to be set!
   #endif
 
-/*
-Recipe for MSVC --> GCC inline ASM conversion:
-
-Before you begin tranmslation:
-- Max. number of input variables GCC allows = 30 ... if you're using more than that,
-trying reducing the count e.g. by using var2 = var1 + memoffset in the ASM.
-DO THIS USING THE MSVC CODE, i.e. only *after* you've successfully reduced
-the inline ASM macro arg count should you proceed with syntax translation.
-That allows you to work through small chunks of inline ASM at a time, doing
-quick-build-and-debug to check the changes, i.e. greatly eases debug.
-
-0. Remove all but most-crucial comments to ease conversion, as follows:
-	[blockmode] space all "keeper" comments to extreme left
-	multistatement __asm lines --> one __asm pre line, realign __asm to left-justify, delete __asm\t
-	For non-keeper comments: /* --> @@
-	[regexp] @@ --> \t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t@@
-	(delete all @@... stuff)\
-	\t\n --> \n (repeat until no more trailing tabs)
-	[/regexp]
-	Repeat /* --> @@, [regexp] @@ --> \t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t@@ steps for keeper comments, to move out of harm's way.
-1. [...] --> (...)
-2. ALU ops [e.g. mov, add, shl] --> spaces to tabs, then append "l" [if e*x] or "q" [if r*x] to instruction name
-3. Numeric literals in above kinds of instructions: Prepend "$" [",0x" --> ",$0x"]
-4. Address offsets of form (...+0x100) --> 0x100(...), (...-0x100) --> -0x100(...)
-5. External variable names get wrapped in %[]
-6. Line up commas in vertically stacked columns, then reverse operand order columnwise [for both 2 and 3-operand instructions].
-7. Prepend "%%" to all register names
-8. Only e*x/r*x registers appear in clobber list, not special regs like mmx and xmm.
-
-Additional Notes:
-	- Need to strip off any leading white space from named vars inside [], e.g. for "movl %[  c4],%%ecx \n\t" get "undefined named operand '  c4'" error;
-	- Offsets with explicit + sign, e.g. "+0x10(%%eax)", not allowed
-*/
+//
+//Recipe for MSVC --> GCC inline ASM conversion:
+//
+//Before you begin tranmslation:
+//- Max. number of input variables GCC allows = 30 ... if you're using more than that,
+//trying reducing the count e.g. by using var2 = var1 + memoffset in the ASM.
+//DO THIS USING THE MSVC CODE, i.e. only *after* you've successfully reduced
+//the inline ASM macro arg count should you proceed with syntax translation.
+//That allows you to work through small chunks of inline ASM at a time, doing
+//quick-build-and-debug to check the changes, i.e. greatly eases debug.
+//
+//0. Remove all but most-crucial comments to ease conversion, as follows:
+//	[blockmode] space all "keeper" comments to extreme left
+//	multistatement __asm lines --> one __asm pre line, realign __asm to left-justify, delete __asm\t
+//	For non-keeper comments: /* --> @@
+//	[regexp] @@ --> \t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t@@
+//	(delete all @@... stuff)\ <- that trailing backslash is part of the recipe text
+//	\t\n --> \n (repeat until no more trailing tabs)
+//	[/regexp]
+//	Repeat /* --> @@, [regexp] @@ --> \t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t@@ steps for keeper comments, to move out of harm's way.
+//1. [...] --> (...)
+//2. ALU ops [e.g. mov, add, shl] --> spaces to tabs, then append "l" [if e*x] or "q" [if r*x] to instruction name
+//3. Numeric literals in above kinds of instructions: Prepend "$" [",0x" --> ",$0x"]
+//4. Address offsets of form (...+0x100) --> 0x100(...), (...-0x100) --> -0x100(...)
+//5. External variable names get wrapped in %[]
+//6. Line up commas in vertically stacked columns, then reverse operand order columnwise [for both 2 and 3-operand instructions].
+//7. Prepend "%%" to all register names
+//8. Only e*x/r*x registers appear in clobber list, not special regs like mmx and xmm.
+//
+//Additional Notes:
+//	- Need to strip off any leading white space from named vars inside [], e.g. for "movl %[  c4],%%ecx \n\t" get "undefined named operand '  c4'" error;
+//	- Offsets with explicit + sign, e.g. "+0x10(%%eax)", not allowed
+//
 
 	#include "radix16_dif_dit_pass_asm.h"
 

--- a/src/radix32_ditN_cy_dif1.c
+++ b/src/radix32_ditN_cy_dif1.c
@@ -198,7 +198,7 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 	static double radix_inv, n2inv;
   #ifndef MULTITHREAD
 	double *addr;
-	double *addi;	// Declared unconditionally: the MODULUS_TYPE_GENFFTMUL branch of
+	double *addi;	// Not gated on the SIMD mode: the MODULUS_TYPE_GENFFTMUL branch of
 					// radix32_main_carry_loop.h assigns and increments it in every build.
 	double temp,frac;
   #endif
@@ -255,9 +255,15 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		,*r20,*r22,*r24,*r26,*r28,*r2A,*r2C,*r2E
 		,*r30,*r32,*r34,*r36,*r38,*r3A,*r3C,*r3E */
 		,*cy_r	// Need RADIX slots for sse2 carries, RADIX/2 for avx
-		,*cy_i	// Declared unconditionally: radix32_main_carry_loop.h's MODULUS_TYPE_GENFFTMUL
-				// branch reads it in every build.
 		;
+  #ifndef MULTITHREAD
+	// Not gated on the SIMD mode - radix32_main_carry_loop.h's MODULUS_TYPE_GENFFTMUL branch reads
+	// cy_i in every build - but gated on !MULTITHREAD, because that loop is only *in* this function
+	// in a single-threaded build; a MULTITHREAD build runs it from cy32_process_chunk(), which has
+	// its own cy_i. The carry-pointer setup below already skips the AVX and AVX-512 assignments to
+	// this under !MULTITHREAD, so leaving the declaration ungated just left it unused there.
+	static vec_dbl *cy_i;
+  #endif
   #ifdef USE_AVX
 	static vec_dbl *base_negacyclic_root;
   #endif
@@ -549,7 +555,11 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		sse2_rnd= tmp + 0x01;
 		half_arr= tmp + 0x02;	/* This table needs 96 vec_dbl for Mersenne-mod, and 3.5*RADIX[avx] | RADIX[sse2] for Fermat-mod */
 	  #else
-		cy_r = tmp;	cy_i = tmp+0x10;	tmp += 0x20;	// RADIX/2 vec_dbl slots for each of cy_r and cy_i carry sub-arrays
+		cy_r = tmp;										// RADIX/2 vec_dbl slots for each of cy_r and cy_i carry sub-arrays
+	   #ifndef MULTITHREAD
+					cy_i = tmp+0x10;
+	   #endif
+										tmp += 0x20;
 		max_err = tmp + 0x00;
 		sse2_rnd= tmp + 0x01;
 		half_arr= tmp + 0x02;	/* This table needs 32 x 16 bytes for Mersenne-mod, 2 for Fermat-mod */
@@ -1988,7 +1998,9 @@ void radix32_dit_pass1(double a[], int n)
 			,*r20,*r22,*r24,*r26,*r28,*r2A,*r2C,*r2E
 			,*r30,*r32,*r34,*r36,*r38,*r3A,*r3C,*r3E */
 			,*cy_r
-			,*cy_i	// Declared unconditionally - see the same declaration in radix32_ditN_cy_dif1() above
+			,*cy_i	// Not gated on the SIMD mode: radix32_main_carry_loop.h's MODULUS_TYPE_GENFFTMUL
+					// branch reads it in every build, and this function only exists in MULTITHREAD
+					// builds - which is where that loop runs.
 			;
 	  #ifdef USE_AVX
 		vec_dbl *base_negacyclic_root;


### PR DESCRIPTION
The warning sites current `main` emits on gcc/clang × nosimd/sse2/avx2/avx512. Measured, not
estimated: **four sites**, not the ~21k in the issue — that count was the #238 integration branch
across all CI artifacts, and a raw `grep 'warning:'` is dominated by deliberate `#warning`
directives (106 of 109 lines in a nosimd build).

## `mi64.c` — `BLOCKLENM1`/`BASEADDRMASK`/`minlen`, two sites

Declared under a `USE_AVX2` / `USE_AVX` / `YES_ASM` chain, but only the asm loops consume them, so
a build that takes the portable-C path — `NO_ASM`, which `mi64.h` also selects automatically under
AddressSanitizer — declares them and never uses them. The third arm of each chain was already
`YES_ASM`-guarded; the first two now are too.

The technique that separates this from a false positive: compile the file with and without
`-DNO_ASM` and compare. That distinguishes "dead on every path, delete it" from "used only by the
portable-C arm, move it inside `#ifndef YES_ASM`" — deleting the latter breaks every non-x86 build.

## `mi64.c` — `i` in `mi64_pprimeF()`

Set by the Newton-iteration loop and never read. Not a missing use: the comment immediately above
documents an optimization that is explicitly deferred ("do this optimization later"), and the
converged-64-bit-word count is what that optimization would need. Until it exists the loop
recomputes the full `wlen`-word product every pass and has no use for the count. Removed the dead
counter and moved the note into the loop comment so the intent survives.

## `radix16_dif_dit_pass.c` — `-Wcomment`

A 33-line block comment documenting an asm-translation recipe contains two literal `/*` sequences
as part of the recipe text. Converted to line comments, which preserves the text byte-for-byte —
verified by diffing the old body against the new one with the leading `//` stripped — rather than
editing documentation to appease the compiler. One wrinkle: one line of that recipe ends in a
backslash, which in a `//` comment splices into the next line and trades `-Wcomment` for
`-Wcomment` ("multi-line comment"). The backslash is part of the recipe, so it stays and is simply
no longer line-final.

## `radix32_ditN_cy_dif1.c` — `cy_i` (second commit)

gcc reports this as `unused variable 'cy_i'` in avx/avx2/avx512 and `variable 'cy_i' set but not
used` in sse2 — and that difference is the whole explanation.

The comment on the declaration says `cy_i` is not gated on the SIMD mode because
`radix32_main_carry_loop.h`'s `MODULUS_TYPE_GENFFTMUL` branch reads it in every build. True, but
incomplete: that loop is only *inside* `radix32_ditN_cy_dif1()` in a single-threaded build. A
MULTITHREAD build runs it from `cy32_process_chunk()`, which has its own `cy_i`. The carry-pointer
setup already knew this — its AVX-512 and AVX arms guard the assignment with
`#ifndef MULTITHREAD`, so there the variable was declared and never even written ("unused"). The
SSE2 arm was the one arm missing that guard, so there it was written and never read ("set but not
used"). Gating the declaration and the SSE2 assignment the same way the other two arms already
were makes all three consistent.

Verified by preprocessing the file per mode with the `__LINE__` values baked into the `ABORT`/`WARN`
strings normalized away, and diffing against main. The complete set of changes:

| build | difference from main |
| --- | --- |
| nosimd, nosimd single-threaded | semantically identical |
| avx / avx2 / avx512 threaded | only the `*cy_i` declaration goes away |
| sse2 threaded | declaration plus `cy_i = tmp+0x10`; the `tmp += 0x20` after it stays, so the local-store layout is unchanged |
| sse2 / avx single-threaded | declaration moves out of the comma-list into its own `static vec_dbl *cy_i;`, same storage class and type; assignment retained |

Nothing else differs in any mode — so the ARM ASIMD builds, which take the same carry-pointer arm
as SSE2, are covered by the same argument.

**Residues**, sse2, `-cpu 0:3`, against the same build of main: `-s tt` gives 26 identical `Res64`
values, `-s t` gives 93 identical `Res64` values across 32 FFT lengths. Both rc=0, no
`0 of N radix-sets passed` lines either side.

## `factor.c` — `-Wrestrict` ×2 (third commit)

The two *"Current q = %s"* error messages in `PerPass_tfSieve` render their operands with
`convert_mi64_base10_char(cbuf, ...)` and then hand `snprintf` a pointer **into `cbuf`** — which is
`snprintf`'s own destination. Passing a source string that lives inside the destination violates the
`restrict` qualifiers on `snprintf`'s parameters, and gcc says so: *"'snprintf' argument 7 may
overlap destination object 'cbuf'"*. So a diagnostic whose whole job is to tell the user which `q`
failed can print anything at all.

Both renderings now go into `cbuf2`, side by side, needing no new storage: `cbuf2` is
`STR_MAX_LEN*2` chars, and `convert_mi64_base10_char` passes `n_alloc_chars = STR_MAX_LEN` and
enforces it with `ASSERT(MAX_DIGITS < n_alloc_chars)`, so one rendering touches at most the low
`STR_MAX_LEN` chars of whatever it is handed. The second operand uses the `__`-prefixed entry point
to render into `cbuf2+STR_MAX_LEN` under that same bound.

## `Mlucas.c` — `-Wformat-truncation` (third commit)

The known-factor-does-not-divide message writes into `g_cstr` (`STR_MAX_LEN`) with a `%s` for `cbuf`
(`STR_MAX_LEN*3`), which at that point holds the factor token exactly as it appeared in the worktodo
line — `strncpy`'d from it, so bounded only by `cbuf`. gcc: *"'%s' directive output may be truncated
writing up to 3071 bytes into a region of size between 992 and 993"*. Truncating there is worse than
it sounds: the message asks the user to *correct or remove that entry*, and a cut-off factor is not
identifiable. Bounded with `%.*s` at `sizeof(g_cstr)/4` — a 256-bit factor needs at most 78 digits,
so 256 chars is ample and makes the bound provable.

## Result

Measured file-by-file, gcc and clang × nosimd/sse2/avx2/avx512 at `-O3`, unique file+message pairs:

| tree | diagnostics |
| --- | --- |
| main | 21 |
| main + this PR + #272 | 11 — **all 11 in `src/test_fft_radix.c`** |

So main's *built* sources go fully warning-clean. `mi64.c` also compiles clean with **and** without
`-DNO_ASM`.

Residues, nosimd, `-cpu 0:3`, against a pristine build of main: `-s tt` 41 identical `Res64` values,
`-prp -s tt` 43 identical, both rc=0. `Mfactor -m 521 -bmax 20` completes, rc=0.

## Deliberately not touching `src/test_fft_radix.c`

It is in no build target — not in `OBJS`, not in `OBJS_MFAC` — and `src/test_fft_radix.c.txt`
documents compiling it by hand with `-DRADIX=[radix] -DTTYPE=[test type]`. Its warning set depends
on both:

| flags | diagnostics |
| --- | --- |
| default (`TTYPE=3`) | 10 |
| `-DTTYPE=0` | 19 |
| `-DTTYPE=1` | 3 |
| `-DTTYPE=2` | 3 |
| `-DRADIX=16 -DTTYPE=1` | 5 |

There is no fixed set of unused variables to delete: several are used under some `TTYPE` and not
others, so deleting what the default does not use would break the other three test modes. Same shape
as the `mi64` `NO_ASM` case above, and it wants a per-mode sweep rather than a one-config edit.

Still outstanding on #244, not in this PR: `factor.c`'s `p192`/`q192`/`t192`/`p256`/`q256`/`t256`
(#269 — a symptom of a dispatch bug, not just dead declarations), `brev64`/`reverse64`'s
strict-aliasing punning (#270), the `leadz`/`trailz` asm output operands (#271), the `[2a]` retry
check's uninitialized `iter` (#272), and the macOS/ARM/FreeBSD/old-distro-container configurations,
which I have not reproduced.

Part of #244.
