### PR TITLE
Treat an interrupt that arrives between iteration intervals as an interrupt

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -1984,6 +1984,13 @@ READ_RESTART_FILE:
 			}	// end while(!ierr && MLUCAS_KEEP_RUNNING && i < ihi)
 		} else if(MLUCAS_KEEP_RUNNING) {	// Final partial-length interval skips G-check
 			ierr = func_mod_square  (a, (int*)arrtmp, n, ilo,ihi, 0ull, p, scrnFlag, &tdiff, update_shift, 0x0);
+		} else {
+			/* v21: An interrupt that arrived *between* intervals - during the checkpoint write or the Gerbicz check - left
+			MLUCAS_KEEP_RUNNING clear with no mod-square call in flight to report it. Formerly neither branch above ran,
+			ierr stayed 0, and the loop went on "completing" interval after interval with an unchanged residue (MaxErr 0),
+			writing it to every checkpoint and, since the G-check is also gated on MLUCAS_KEEP_RUNNING, reaching maxiter
+			with a frozen, wrong residue and exit code 0. Treat it as the interrupt it is, at the last completed iteration: */
+			ierr = ERR_INTERRUPT;	ROE_ITER = ilo;
 		}
 	  } else {
 			// For straight LL-test there is (at least at this writing) no known analog of the Gerbicz check:

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -2060,7 +2060,7 @@ READ_RESTART_FILE:
 		}
 
 		/*...Done?	*/
-		if(!INTERACT) {
+		if(!INTERACT && ihi > ilo) {	// ihi == ilo only for an interrupt caught between intervals: nothing to report for a zero-length interval
 			AME /= (ihi - ilo);	// Don't /= ITERS_BETWEEN_CHECKPOINTS here since final interval is a partial one
 			/*...get a quick timestamp...	*/
 			calendar_time = time(NULL); local_time = localtime(&calendar_time);


### PR DESCRIPTION
In the Gerbicz-check dispatch (PRP and Pépin tests) both branches that run an iteration interval are gated on `MLUCAS_KEEP_RUNNING`. An interrupt that arrives *between* intervals - during the checkpoint write or the Gerbicz check itself - clears the flag with no mod-square call in flight to report it, so neither branch ran, `ierr` stayed 0, and the loop went on "completing" interval after interval with an unchanged residue (MaxErr 0.000000000 on every line), writing it to every checkpoint and, since the check is gated the same way, reaching maxiter with a frozen, wrong residue and exit code 0.

I hit it while testing the P-1 stage 1 Gerbicz check (the P-1 half of #97), where a test sent SIGINT the moment a checkpoint line appeared: the .stat file shows the same Res64 at every checkpoint from that point on with MaxErr 0, the run "finished" stage 1 normally, and the GCD ran on a residue that was frozen at 60 % of the way. Plain LL runs are unaffected because their branch always calls the mod-square, whose empty iteration loop reports the interrupt.

Fix: when neither branch runs because the flag is already clear, treat it as the interrupt it is, at the last completed iteration, so the normal savefile-and-exit path runs. Three lines plus the comment. The same fix is included in the P-1 error-check branch; landing it separately keeps PRP/Pépin users from having to wait for that.

**Second commit.** With the fix in place, the between-intervals interrupt leaves a zero-length interval (ihi == ilo), and the status line printed after every interval then divided by zero: a duplicate `Iter#` line with `inf msec/iter`, a NaN AvgMaxErr and `MaxErr = 0.000000000` - the very signature of the bug it fixes. Nothing happened in that interval, so it now prints nothing.

Both commits are exercised directly on a PRP run in #268's LL suite (T7 in `tests/jacobi-check.sh`): a test-only hook clears the run flag between intervals at iteration 50000 of a PRP test of M216091; the run must report the interrupt at 50000, write the savefile, exit 0 with no frozen-residue line, and on restart resume at 50000 and reach the correct verdict with the Gerbicz check passing.
