### PR TITLE
P-1: Gerbicz check for stage 1, Jacobi integrity checks, exact input checks for stage 2 (resolves #97)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
             # and costs slightly less than 127 did (726k trial divides vs 1.66M).
             ( cd "../obj_mfac${word:+_$word}${MSFX}" && time "./Mfactor${word:+_$word}" -m 521 -bmax 20 )
         done
-    - name: Jacobi residue check tests
+    - name: Jacobi / Gerbicz error-check tests
       run: |
         set -x
         set -o pipefail
@@ -109,6 +109,8 @@ jobs:
         make -C obj_fi -j "$(nproc --all)" Mlucas
         JACOBI_TEST_CPU="0:$(( $(nproc --all) - 1 ))" JACOBI_TEST_DIR="$PWD/obj/jacobi-tests" \
             time bash tests/jacobi-check.sh obj/Mlucas obj_fi/Mlucas obj/mlucas.cfg |& tee -a obj/test.log
+        JACOBI_TEST_CPU="0:$(( $(nproc --all) - 1 ))" JACOBI_TEST_DIR="$PWD/obj/jacobi-pm1-tests" \
+            time bash tests/jacobi-pm1.sh obj/Mlucas obj_fi/Mlucas obj/mlucas.cfg |& tee -a obj/test.log
     - uses: actions/upload-artifact@v7
       if: always()
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,18 @@ jobs:
             # and costs slightly less than 127 did (726k trial divides vs 1.66M).
             ( cd "../obj_mfac${word:+_$word}${MSFX}" && time "./Mfactor${word:+_$word}" -m 521 -bmax 20 )
         done
+    - name: Jacobi residue check tests
+      run: |
+        set -x
+        set -o pipefail
+        # A second native build with the test-only fault injector compiled in (see tests/jacobi-check.sh
+        # for what it is used for). The native obj/ Makefile is reused with one extra define; its objects
+        # were cleaned above, so this is a full compile of the native mode.
+        mkdir obj_fi
+        sed 's/^CPPFLAGS += /CPPFLAGS += -DMLUCAS_FAULT_INJECT /' obj/Makefile > obj_fi/Makefile
+        make -C obj_fi -j "$(nproc --all)" Mlucas
+        JACOBI_TEST_CPU="0:$(( $(nproc --all) - 1 ))" JACOBI_TEST_DIR="$PWD/obj/jacobi-tests" \
+            time bash tests/jacobi-check.sh obj/Mlucas obj_fi/Mlucas obj/mlucas.cfg |& tee -a obj/test.log
     - uses: actions/upload-artifact@v7
       if: always()
       with:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Feature | | Mlucas | Prime95/MPrime
 \- | Suyama | ✔️ | 
 **PRP** | Proof generation | | ✔️
 \- | Proof certification | | ✔️
-**Error Checking** | Jacobi (LL/P-1) | | LL only
+**Error Checking** | Jacobi (LL/P-1) | LL only | LL only
 \- | Gerbicz (PRP/Pépin) | ✔️ | ✔️
 **Random Shifts** | | ✔️ | ✔️
 **Interface** | CLI | ✔️ | MPrime only
@@ -106,7 +106,7 @@ This README is still in progress. For now, see the original [Mlucas README](http
 
 ## Help
 
-The [help.txt](help.txt) file includes a variety of usage information not covered in the original [README](https://mersenneforum.org/mayer/README.html), concentrating largely on the Mlucas command line options. A separate documentation page covers [Fermat numbers](docs/Fermat-testing.md).
+The [help.txt](help.txt) file includes a variety of usage information not covered in the original [README](https://mersenneforum.org/mayer/README.html), concentrating largely on the Mlucas command line options. A separate documentation page covers [Fermat numbers](docs/Fermat-testing.md). Lucas-Lehmer tests are protected by a Jacobi residue check, controlled by the `JacobiCheck` and `JacobiCheckHours` mlucas.ini options - see help.txt section [11].
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Feature | | Mlucas | Prime95/MPrime
 \- | Suyama | ✔️ | 
 **PRP** | Proof generation | | ✔️
 \- | Proof certification | | ✔️
-**Error Checking** | Jacobi (LL/P-1) | LL only | LL only
-\- | Gerbicz (PRP/Pépin) | ✔️ | ✔️
+**Error Checking** | Jacobi (LL/P-1) | LL (P-1: integrity only) | LL only
+\- | Gerbicz (PRP/Pépin) | ✔️ (also P-1 stage 1) | ✔️
 **Random Shifts** | | ✔️ | ✔️
 **Interface** | CLI | ✔️ | MPrime only
 \- | GUI | | Prime95 only

--- a/docs/gerbicz.txt
+++ b/docs/gerbicz.txt
@@ -209,3 +209,50 @@ Miscellany:
 	o Do we need to store PRP_BASE in savefiles? [Yes]
 	o
 
+
+
+===============================
+********** Gerbicz check for p-1 stage 1 (2026) **********
+
+Stage 1 is a left-to-right binary powering of the base a = 3 by the prime-powers product E:
+	x <- x^2 * a^b   per iteration, b = the next bit of E (MSB first).
+So over a block of L iterations, with c_k the value of the L-bit chunk of E consumed in block k (first-consumed
+bit most significant),
+	x_{(k+1)L} = x_{kL}^(2^L) * a^(c_k)                                   [0']
+which is [0] with an extra factor. Keep the PRP bookkeeping unchanged: b = product of the x_{kL} at every block
+boundary of the current epoch (seeded with the epoch's starting residue u0, = a from scratch), d = the copy of b
+at the previous check. Then, with P = the product up to block boundary i-L and Q = the same up to i,
+	P^(2^L) = prod_{k} x_{kL}^(2^L) = prod_{k} x_{(k+1)L} * a^(-c_k) = (Q / u0) * a^(-C),   C = sum_k c_k ,
+i.e.
+	Q = u0 * P^(2^L) * a^C                                                 [3']
+in place of [3]. C is a function of E and the iteration count only and is recomputed from the stored product at
+each check (a sum of ~i/L numbers below 2^L: about L + log2(i/L) bits); a^C is formed by the same LR powering the
+stage itself uses, and applied together with u0 as one 2-input modmul before the comparison.
+
+Two things the PRP check never meets, because there the multiply-by-base bits are all zero:
+	o the modmul that folds x_{kL} into b, the L squarings of d at the check, and the modmuls of the correction
+	  all go through the carry step, which reads the multiply-by-base bit for its iteration number from the
+	  live exponent-bit window. Each would silently multiply a stray a into its result. They must run against a
+	  private, zeroed (or C-bit-filled) bit array. The first of these was found only by comparing b against a
+	  Python product of the same residues - C and a^C matched, b did not.
+	o u0 is a full residue, not the scalar a, when an epoch starts from a loaded savefile residue rather than
+	  from scratch; it is kept as an array and multiplied in rather than folded into the exponent.
+
+bc sketch (L = 4 for readability; E any odd number; N any odd modulus):
+	define pm1_gerbicz(a,e,n,L) {
+		auto i,t,x,b,d,c,cc,nb,bit;
+		nb = length2(e);           /* #bits of e; leading bit is the seed */
+		x = a; b = a; d = a; c = 0; cc = 0; i = 0;
+		for(t = nb-2; t >= 0; t--) {
+			bit = (e / 2^t) % 2;
+			x = (x^2 * a^bit) % n; cc = 2*cc + bit; i = i + 1;
+			if(i % L == 0) {
+				if(i % (L*L) == 0) {
+					/* check: d^(2^L) * a * a^c must equal b*x */
+					d = modpow(d, 2^L, n) * a % n * modpow(a, c, n) % n;
+					if(d != b*x % n) print "mismatch at ", i, "\n";
+				}
+				b = b*x % n; d = b; c = c + cc; cc = 0;
+			}
+		}
+	}

--- a/docs/pm1.txt
+++ b/docs/pm1.txt
@@ -3949,3 +3949,30 @@ efficiently? For simply (q0 + c[i])*(q0 - c[i]) we precompute the needed square-
 Now, (A+B+C)*(A-B-C) = [A+(B+C)]*[A-(B+C)] = A^2 - (B+C)^2, so there's the rub: we need(B+C)^2 = B^2 + 2.B.C + C^2, i.e. (in terms of s1 powers)
 	(q0 + D + c[i])*(q0 - D - c[i]) = [q0 + (D + c[i])]*[q0 - (D + c[i])] = q0^2 - (D + c[i])^2, now also need D^2 and 2.D.c[i] for each increment in window multiplicity M, which costs even more storage than the current precomputed powers of the coprimes < M*D.
 
+
+
+============================================================
+Error checking (added 2026):
+
+Stage 1 gets a Gerbicz check. The stage is x <- x^2 * 3^b per exponent bit, so the PRP check-product identity
+holds with one correction: b == u0 * d^(2^L) * 3^C, C the sum of the L-bit exponent chunks consumed since the
+check epoch began (see docs/gerbicz.txt for the derivation). Detection of an arithmetic error is essentially
+certain, the cost about 0.3%. The check-product is appended to the stage 1 savefiles so a resumed run keeps its
+epoch; a file without it starts a new one from the loaded residue. LowMem = 2 has no room for the arrays and
+runs stage 1 unchecked.
+
+A Jacobi check on the stage 1 residue cannot see arithmetic errors: squaring maps every value into the
+quadratic residues, so J(x_{k+1}) = J(3)^b whatever x_k was. It is kept only as an integrity check of the
+savefile and of the FP->integer conversion path, which the Gerbicz check in turn cannot see - on every
+restart-file read (expected symbol J(3|N) if the last consumed exponent bit is 1, else +1) and on the final
+stage 1 residue before the GCD (expected +1, E being even).
+
+Stage 2: there is no cheap invariant for the accumulator. It is a product of arbitrary differences
+(A^((kD)^2) - A^(b^2)); each term's Jacobi symbol is unpredictable, a product of arbitrary terms can only be
+verified by recomputing it, and the "check the product modulo a small random prime" trick fails because the
+reduction mod N in between destroys the homomorphism (the quotient is unknown). What can be checked exactly are
+the inputs every later term is built from: the A^((kD)^2) ladder has a closed form and is recomputed from the
+stage 1 residue at checkpoints and compared bit-for-bit (same integer, same carry normalisation, same FFT);
+the A^(b^2) table is static and checksummed. The accumulator gets sanity tests (nonzero, changing). An error
+in one accumulator multiply is self-contained - it corrupts the product but nothing downstream is built on
+it - and its consequence is a missed factor, never a false claim, which caps what is worth spending on it.

--- a/help.txt
+++ b/help.txt
@@ -229,6 +229,24 @@ The (very rough) time estimates are for 1000 iterations done using 4 or more cor
 	given Mersenne number exponent on their hardware, similarly to the -fft option. Performs
 	as many iterations as specified via the -iters flag (which is required if -m is invoked).
 
+o JACOBI RESIDUE CHECK: For production (i.e. non-self-test) Lucas-Lehmer tests of Mersenne
+numbers - not PRP, not p-1, and not Fermat/Pe'pin tests - Mlucas computes the Jacobi symbol
+J(s - 2 | M(p)) of the current residue s, which must equal -1 for every LL iterate if the
+exponent p is prime. The check runs whenever a restart file is read (checking the residue
+before anything is built on it), on the final residue before a result is reported, and
+periodically at checkpoints, no more often than every JacobiCheckHours hours of wall-clock
+time (cf. section [11]). A corrupted residue passes the check with probability 1/2, and the
+symbol is invariant under the LL recurrence, so every check after the first examines the same
+value: a corruption that passes its first check is never caught by a later one. This is
+therefore a cheap, weak check that catches half of all corruption events; how often it runs
+sets how much work is lost when one is caught, not the odds of catching it. It does not
+certify a result - a reported LL result still needs an independent double-check. A symbol of
+0 should not occur for a prime exponent; it means the residue shares a factor with the
+modulus, i.e. a corruption that no rollback would clear, so Mlucas stops rather than retry.
+The check requires GMP 5.1 or later; a build without a suitable GMP prints a one-time warning
+and runs without it. See sections [11], [12] and [14] for the mlucas.ini controls, savefiles
+and log messages it produces.
+
 ======================
 
 [5]: Fermat-number primality testing:
@@ -287,6 +305,9 @@ The (very rough) time estimates are for 1000 iterations done using 4 or more cor
 	we check whether b^(N+1) == b^2 (mod N). For N = M(p) we have N+1 = 2^p, thus this variant
 	requires (p-1) pure mod-squarings. Any self-tests done in PRP mode will do the first (iters)
 	of these.
+
+PRP-testing keeps the Gerbicz error check described above; the Jacobi residue check of
+section [4] applies only to Lucas-Lehmer tests and does not run in PRP mode.
 
 ======================
 
@@ -477,12 +498,15 @@ on a low_RAM might contain
 	CheckInterval = 10000	/* I'm using the space right of the value for a C-style comment. */
 	LowMem = 1	// But one could also use C++ comment format...
 	InterimGCD = 0	# Or bash-shell and Python-style comment format...
+	JacobiCheck = 1	Redundant, since 1 is the default, but shown here for illustration...
+	JacobiCheckHours = 6	...as is halving the default Jacobi-check interval to 6 hours.
 	LowMem = 2	Or no comment delimiter at all. Note that the program uses the first entry
 			matching a given option name, so the second LowMem entry here will be ignored.
 
-This specifies savefile-writes for LL/PRP/p-1 every 10000 iterations, and allows PRP-testing
-but excludes p-1 stage 2. The InterimGCD option setting is moot in this case since it only
-applies to p-1 stage 2.
+This specifies savefile-writes for LL/PRP/p-1 every 10000 iterations, allows PRP-testing but
+excludes p-1 stage 2, and (redundantly) leaves the Jacobi residue check on while halving its
+default checkpoint interval to 6 hours. The InterimGCD option setting is moot in this case
+since it only applies to p-1 stage 2.
 
 Note that the option-name and comment formats in mlucas.ini differ from those in local.ini -
 the latter is read and updated by the several primenet.py work-management scripts described
@@ -542,6 +566,19 @@ o DISABLING INTERIM GCDs IN P-1 STAGE 2: Set InterimGCD = 0 in mlucas.ini. This 
 the program to wait until any p-1 stage 2 is finished to take a GCD (check for a factor),
 irrespective of the depth of the stage.
 
+o JACOBI RESIDUE CHECK: Set JacobiCheck = 0 in mlucas.ini to disable the LL residue check
+described in section [4] (default 1; the check is unavailable, and this setting has no
+effect, on a build without GMP >= 5.1). JacobiCheckHours = N sets how often, in wall-clock
+hours, the check additionally runs at checkpoints (default 12; fractional values are
+allowed; 0 checks at every checkpoint, mainly useful for testing).
+
+The interval is given in hours rather than iterations because the check's cost is scalar GMP
+work that does not scale with the per-iteration FFT the way iteration counts do, so a fixed
+iteration interval would impose wildly different overhead on different hardware. Hours bound
+how long a corrupted residue can survive undetected, while the built-in rule of never
+re-checking sooner than 100x the previous check's duration bounds the overhead to near 1%
+regardless of machine speed.
+
 ======================
 
 [12]: Savefile format and creation:
@@ -571,6 +608,22 @@ renamed p[exponent].s1. The reason for this is twofold:
 	Say you ran p-1 on a low-memory system, such that only stage 1 was run. Later, you install
 	more RAM, which allows for more efficient stage 2 work. At that point, it may make sense
 	to rerun some exponents to deeper stage 2 bounds. See section [9b] for how to do this.
+
+o With the Jacobi residue check enabled (cf. sections [4] and [11]), an LL run additionally
+keeps the two most recent Jacobi-passed checkpoints, saved as p[exponent].J (the latest) and
+p[exponent].J1 (the one before it), in the same format as the p/q savefiles. A failed check means
+the corruption happened after the last passing one (an earlier corruption that passed would go on
+passing, see section [4]), so .J is the natural place to roll back to; .J1 is a spare in case .J
+is unreadable or fails its own on-read check; on a failed check Mlucas rolls back through
+the chain p -> q -> .J -> .J1 -> from scratch, Jacobi-checking each file as it is read. At a
+332-million-bit exponent each savefile is 41.5 MB, so an LL run's p, q, .J and .J1 files
+together total roughly 166 MB.
+
+o Savefiles append a 4-byte Jacobi-check-failure count after the existing roundoff- and
+Gerbicz-error counts. Older Mlucas versions and third-party savefile readers ignore trailing
+fields they don't recognize, so old and new binaries can read each other's savefiles; an old
+binary that rewrites the file drops the count back to 0, exactly as the existing error counts
+already do across a v19 downgrade.
 
 o P-1 runs also store a file p[exponent].s1_prod encoding the precomputed small-prime-powers
 product used for the stage 1 left-to-right modular binary powering. This can save time on
@@ -636,6 +689,54 @@ Once you have identified the desired process IDs:
 
 For the current list of signal types which the program listens for, see the sig_handler() function near
 the top of Mlucas.c . As of this writing (v20.1.1), the program listens for INT,TERM,HUP,ALRM,USR1 and USR2.
+
+[14b]: Jacobi residue check log messages:
+
+The Jacobi residue check (cf. sections [4], [11] and [12]) writes lines to the p[exponent].stat
+file. What each means and what, if anything, to do about it:
+
+	"At iteration N, shift = S: Jacobi check passed (T sec)."
+	Normal. No action needed.
+
+	"Jacobi check at iteration N FAILED (symbol = +1, T sec)! Restarting from the current
+	savefile." (or "...the last Jacobi-passed savefile" / "...the previous Jacobi-passed
+	savefile" / "...scratch", depending on how many consecutive failures have occurred)
+	"Restart file p12345 (iteration N) passed the Jacobi check (T sec)."
+	"Restart file p12345 (iteration N) FAILED the Jacobi check (symbol = 1, T sec) - its
+	residue is corrupt; trying the next savefile in the chain."
+	"INFO: no restart file passes the Jacobi check...starting run from scratch."
+	"Jacobi-check-error restart: Mod-doubling residue shift ..."
+	Normal recovery: the check caught a corrupted residue and the program is rolling back
+	through the p -> q -> .J -> .J1 -> scratch chain to find a good one. No action needed
+	unless this recurs often, in which case see the 5-consecutive-failures entry below.
+
+	"Jacobi check at iteration N failed with symbol 0: the residue shares a factor with the
+	modulus, which cannot happen for a correct LL residue of a prime exponent. Aborting
+	rather than retrying; ... please check this machine for hardware errors."
+	Exponents are checked for primality when the worktodo entry is read, so a symbol of 0
+	means the residue itself has been corrupted in a way rollback cannot clear. Treat it
+	like the 5-consecutive-failures case below.
+
+	"Jacobi check at iteration N failed %u times in a row, the last after restarting from
+	scratch - ... Please check this machine for hardware errors."
+	Five consecutive Jacobi-check failures, the last one from a fresh restart, means the
+	corruption is not being cleared by rolling back savefiles, so it is not transient. Stop
+	the run and test the machine's RAM and CPU before restarting.
+
+A SIGINT/SIGTERM-driven checkpoint (cf. section [14a]) never runs the Jacobi check, so shutdown
+is not slowed down; the residue is instead checked when the run is next restarted.
+
+The Jacobi-check failure count is also folded into the "error-code" hex field of the JSON
+results line (cf. section [12] for the savefile-resident version of this count): bits 4-7 hold
+the (capped) Jacobi-failure count, bits 8-13 the roundoff-error count, and bits 20-23 the
+Gerbicz-check-failure count, matching the layout the GIMPS primenet server expects (which
+ignores the low byte when deciding whether a result is "clean"). The same count also appears
+as "jacobi" in the results line's "errors" object, e.g.:
+
+	{"status":"C", "exponent":44501, "worktype":"LL", "res64":"40755C45A05FA7C0",
+	"fft-length":2048, "shift-count":0, "error-code":"00000000",
+	"errors":{"Roundoff":0, "jacobi":0}, "program":{"name":"Mlucas", "version":"21.0.2"},
+	"timestamp":"2026-09-07 02:49:29"}
 
 ======================
 

--- a/help.txt
+++ b/help.txt
@@ -236,11 +236,12 @@ exponent p is prime. The check runs whenever a restart file is read (checking th
 before anything is built on it), on the final residue before a result is reported, and
 periodically at checkpoints, no more often than every JacobiCheckHours hours of wall-clock
 time (cf. section [11]). A corrupted residue passes the check with probability 1/2, and the
-symbol is invariant under the LL recurrence, so every check after the first examines the same
-value: a corruption that passes its first check is never caught by a later one. This is
-therefore a cheap, weak check that catches half of all corruption events; how often it runs
-sets how much work is lost when one is caught, not the odds of catching it. It does not
-certify a result - a reported LL result still needs an independent double-check. A symbol of
+symbol is invariant under the LL recurrence from one iteration after a corruption on, so every
+later check examines the same value: a corruption that passes the first check after it is never
+caught by a later one. This is therefore a cheap, weak check that catches about half of all
+corruption events; how often it runs sets how much work is lost when one is caught, not the
+odds of catching it. It does not certify a result - a reported LL result still needs an
+independent double-check. A symbol of
 0 should not occur for a prime exponent; it means the residue shares a factor with the
 modulus, i.e. a corruption that no rollback would clear, so Mlucas stops rather than retry.
 The check requires GMP 5.1 or later; a build without a suitable GMP prints a one-time warning
@@ -613,8 +614,10 @@ o With the Jacobi residue check enabled (cf. sections [4] and [11]), an LL run a
 keeps the two most recent Jacobi-passed checkpoints, saved as p[exponent].J (the latest) and
 p[exponent].J1 (the one before it), in the same format as the p/q savefiles. A failed check means
 the corruption happened after the last passing one (an earlier corruption that passed would go on
-passing, see section [4]), so .J is the natural place to roll back to; .J1 is a spare in case .J
-is unreadable or fails its own on-read check; on a failed check Mlucas rolls back through
+passing, see section [4]), so .J is the natural place to roll back to; .J1 covers .J being
+unreadable or failing its own on-read check, and the rare corruption that struck exactly at a
+checked checkpoint, passed that check and fails every later one - the retry from .J then fails
+at the same iteration and the rollback moves on to .J1; on a failed check Mlucas rolls back through
 the chain p -> q -> .J -> .J1 -> from scratch, Jacobi-checking each file as it is read. At a
 332-million-bit exponent each savefile is 41.5 MB, so an LL run's p, q, .J and .J1 files
 together total roughly 166 MB.

--- a/help.txt
+++ b/help.txt
@@ -22,6 +22,7 @@ Sections:
 [9]: P-1 Factoring:
 	[9a]: Setting maximum-percentage of system free-RAM to use per stage 2 instance
 	[9b]: How to run stage 2 continuation for a given stage 1 bound
+	[9c]: Error checking in P-1
 [10]: Setting threadcount and CPU core affinity
 [11]: User control options in mlucas.ini
 [12]: Savefile format and creation
@@ -401,6 +402,59 @@ where any known factors should be in form of a comma-separated list of known boo
 with "", e.g. known factors f1 and f2 appear as "f1,f2". These will not be reported if
 found in any of the GCD steps which test for a factor having been found, and the run
 will only exit if a new factor (one not appearing in the known_factors list) is found.
+When stage 2 starts from a stored stage 1 residue, that residue is first Jacobi-checked as
+described in [9c].
+
+[9c]: Error checking in P-1:
+
+o STAGE 1 - GERBICZ CHECK: Stage 1 computes x <- x^2 * 3^b per iteration, b the next bit of the
+prime-powers product, and Mlucas runs the same Gerbicz error check on it that it runs on PRP
+tests, with one correction term for the multiply-by-3 steps. Every 10^6 iterations (and at the
+last block boundary before stage 1 ends) the check-product accumulated over the interval is
+compared against an independently recomputed value; an arithmetic error anywhere in the
+interval is caught with certainty - this is not a 50% check like the LL Jacobi one - at a cost
+of about 0.3% of the stage 1 time. A passing check writes the p[exponent].G savefile; a
+failing one rolls the run back to it, logging
+	"Gerbicz check iteration N failed! Restarting from last-good-Gerbicz-check data."
+The check needs the extra residue arrays, so LowMem = 2 (section [11]) disables it, and a
+stage 1 run in that mode has NO arithmetic error check at all - it says so once at the start.
+The check-product is stored in the p/q savefiles (section [12]) so that a resumed run continues
+the check across the restart; a savefile without it starts a new check epoch from the residue
+it holds ("Savefile ... carries no Gerbicz check-product; starting a new check epoch ...").
+
+o WHY NOT A JACOBI CHECK FOR STAGE 1: squaring maps every value into the quadratic residues, so
+after an arithmetic error at iteration k the residue carries exactly the expected Jacobi symbol
+from iteration k+1 on. A Jacobi check cannot see stage 1 arithmetic errors. Mlucas uses it in
+P-1 only where it can see something - the savefile and the floating-point-to-integer conversion
+path, which the Gerbicz check in turn cannot see (both of its operands go through it):
+	- on every stage 1 restart-file read ("Restart file p12345 (stage 1 iteration N) passed the
+	  Jacobi check"); a mismatch means the file's residue is corrupt, the secondary is tried,
+	  and if that fails too the run stops and asks you to delete the exponent's p-1 savefiles;
+	- on the final stage 1 residue, the exact integer handed to the GCD and written to
+	  p[exponent].s1 ("Stage 1 final residue passed the Jacobi check"); a mismatch stops the
+	  run before the GCD with the savefiles intact, and a restart re-reads and re-checks them.
+There is no periodic Jacobi check in P-1. JacobiCheck = 0 in mlucas.ini disables these too.
+
+o STAGE 2: The stage 2 accumulator is a product of terms (A^((kD)^2) - A^(b^2)) and has no
+algebraic invariant that could be checked cheaply; Mlucas does not pretend otherwise. What it
+checks, at every stage 2 checkpoint, are the two inputs every later term is built from:
+	- the A^((kD)^2) ladder value is recomputed from the stage 1 residue and must match the
+	  running value exactly ("Stage 2 ladder check passed at q = Q (k = K, T sec)"). This costs
+	  about 130 modular multiplications, so it runs on the JacobiCheckHours clock (section [11];
+	  default every 12 hours, 0 = at every checkpoint) with the same overhead guard;
+	- the precomputed A^(b^2) table entries, which never change during stage 2, are checksummed
+	  after they are built, and a rotating 1/16 of them is re-verified at every checkpoint (all
+	  of them when JacobiCheckHours = 0);
+	- the accumulator itself gets sanity tests only: never zero, never unchanged between
+	  checkpoints.
+Every stage 2 failure stops the run with an "ERROR: ... stage 2 ..." line naming the check; the
+p[exponent].s2 checkpoint on disk is intact, and a restart rebuilds the ladder and tables from
+the stage 1 residue and resumes the accumulator from the file. A corruption of the accumulator
+itself is not caught; its consequence is a missed factor (a wasted later test), never a false
+claim, and any factor found is verified by division before it is reported.
+
+o RESULTS LINE: the P-1 JSON results line carries "error-code" (same layout as for LL and PRP,
+cf. section [14b]) and "errors":{"Roundoff":R, "gerbicz":G, "jacobi":J}.
 
 ======================
 
@@ -560,6 +614,8 @@ modes for low-RAM systems:
 	mode will use 2-4x as much working memory for PRP-tests as it does for LL-tests.
 
 	LowMem = 2 excludes both PRP-testing and p-1 stage 2. This is the minimum-memory option.
+	It also removes the p-1 stage 1 Gerbicz check (section [9c]), which needs the same extra
+	residue arrays, so stage 1 then runs with no arithmetic error check.
 	For QA-testing purposes, this allows self-tests to some modest number of iterations to
 	be done up to the maximum supported FFT length of 512M on systems with 8GB of memory.
 
@@ -572,6 +628,8 @@ described in section [4] (default 1; the check is unavailable, and this setting 
 effect, on a build without GMP >= 5.1). JacobiCheckHours = N sets how often, in wall-clock
 hours, the check additionally runs at checkpoints (default 12; fractional values are
 allowed; 0 checks at every checkpoint, mainly useful for testing).
+JacobiCheck also controls the P-1 integrity checks of section [9c], and JacobiCheckHours also
+paces the stage 2 ladder check there.
 
 The interval is given in hours rather than iterations because the check's cost is scalar GMP
 work that does not scale with the per-iteration FFT the way iteration counts do, so a fixed
@@ -627,6 +685,13 @@ Gerbicz-error counts. Older Mlucas versions and third-party savefile readers ign
 fields they don't recognize, so old and new binaries can read each other's savefiles; an old
 binary that rewrites the file drops the count back to 0, exactly as the existing error counts
 already do across a v19 downgrade.
+
+o P-1 stage 1 savefiles (p/q and the .G written at each passing Gerbicz check, cf. [9c]) carry
+the Gerbicz check-product appended after the error counts, behind an 8-byte epoch field, so
+that older Mlucas versions and third-party readers - which stop after the error counts - read
+them exactly as before; an older binary that rewrites the file drops the product, and the next
+restart starts a new check epoch from the residue. The mid-block p/q files are therefore about
+twice the size of a plain residue savefile.
 
 o P-1 runs also store a file p[exponent].s1_prod encoding the precomputed small-prime-powers
 product used for the stage 1 left-to-right modular binary powering. This can save time on
@@ -725,6 +790,34 @@ file. What each means and what, if anything, to do about it:
 	Five consecutive Jacobi-check failures, the last one from a fresh restart, means the
 	corruption is not being cleared by rolling back savefiles, so it is not transient. Stop
 	the run and test the machine's RAM and CPU before restarting.
+
+P-1 runs (section [9c]) add these lines:
+
+	"At iteration N, shift = 0: Gerbicz check passed."
+	"Stage 2 ladder check passed at q = Q (k = K, T sec)."
+	"Restart file p12345 (stage 1 iteration N) passed the Jacobi check (T sec)."
+	"Stage 1 final residue passed the Jacobi check (T sec)."
+	Normal. No action needed.
+
+	"Gerbicz check iteration N failed! Restarting from last-good-Gerbicz-check data."
+	Normal recovery from a caught arithmetic error: the run rolls back to p[exponent].G. No
+	action needed unless it recurs, in which case test the machine's RAM and CPU.
+
+	"Restart file p12345 (stage 1 iteration N) FAILED the Jacobi check (symbol = S, expected E,
+	T sec) - its residue is corrupt."
+	The savefile is damaged; the secondary is tried next. If both fail the run stops with
+	"No usable p-1 savefile ..." - delete the exponent's p-1 savefiles to start the run over.
+
+	"Stage 1 final residue FAILED the Jacobi check ... Aborting before the GCD"
+	The final residue is corrupt in the conversion or savefile path. Restart: the savefiles are
+	intact and are re-read and re-checked. If it recurs, test the hardware.
+
+	"ERROR: ... stage 2 ladder check FAILED ..." / "... stage 2 table entry I of N fails its
+	checksum ..." / "... stage 2 accumulator is identically zero ..." / "... stage 2 accumulator
+	did not change ..."
+	Memory corruption or a broken build was caught in stage 2. Restart: the p[exponent].s2
+	checkpoint is intact, the ladder and tables are rebuilt and stage 2 resumes from it. If it
+	recurs, test the hardware.
 
 A SIGINT/SIGTERM-driven checkpoint (cf. section [14a]) never runs the Jacobi check, so shutdown
 is not slowed down; the residue is instead checked when the run is next restarted.

--- a/help.txt
+++ b/help.txt
@@ -409,8 +409,10 @@ described in [9c].
 
 o STAGE 1 - GERBICZ CHECK: Stage 1 computes x <- x^2 * 3^b per iteration, b the next bit of the
 prime-powers product, and Mlucas runs the same Gerbicz error check on it that it runs on PRP
-tests, with one correction term for the multiply-by-3 steps. Every 10^6 iterations (and at the
-last block boundary before stage 1 ends) the check-product accumulated over the interval is
+tests, with one correction term for the multiply-by-3 steps. Every 10^6 iterations by default -
+see GerbiczCheckInterval in section [11] for the interval and its automatic shortening on slow
+or very large runs - and at the last block boundary before stage 1 ends, the check-product
+accumulated over the interval is
 compared against an independently recomputed value; an arithmetic error anywhere in the
 interval is caught with certainty - this is not a 50% check like the LL Jacobi one - at a cost
 of about 0.3% of the stage 1 time. A passing check writes the p[exponent].G savefile; a
@@ -431,8 +433,10 @@ path, which the Gerbicz check in turn cannot see (both of its operands go throug
 	  Jacobi check"); a mismatch means the file's residue is corrupt, the secondary is tried,
 	  and if that fails too the run stops and asks you to delete the exponent's p-1 savefiles;
 	- on the final stage 1 residue, the exact integer handed to the GCD and written to
-	  p[exponent].s1 ("Stage 1 final residue passed the Jacobi check"); a mismatch stops the
-	  run before the GCD with the savefiles intact, and a restart re-reads and re-checks them.
+	  p[exponent].s1 ("Stage 1 final residue passed the Jacobi check"). It runs on its own
+	  thread alongside the GCD, so it costs no wall time on multi-core builds; a mismatch stops
+	  the run with the savefiles intact (the GCD result, if any, is still valid - a wrong residue
+	  cannot produce a false factor), and a restart re-reads and re-checks them.
 There is no periodic Jacobi check in P-1. JacobiCheck = 0 in mlucas.ini disables these too.
 
 o STAGE 2: The stage 2 accumulator is a product of terms (A^((kD)^2) - A^(b^2)) and has no
@@ -630,6 +634,18 @@ hours, the check additionally runs at checkpoints (default 12; fractional values
 allowed; 0 checks at every checkpoint, mainly useful for testing).
 JacobiCheck also controls the P-1 integrity checks of section [9c], and JacobiCheckHours also
 paces the stage 2 ladder check there.
+
+o GERBICZ CHECK INTERVAL FOR P-1: GerbiczCheckInterval = N sets how many stage 1 iterations lie
+between Gerbicz checks in P-1 (section [9c]); PRP tests keep their fixed 10^6. N must be L^2 for
+a block length L that divides CheckInterval and whose square CheckInterval divides (e.g. with
+CheckInterval = 10000: 10000, 40000, 160000, 250000, 1000000, ...); an unusable value is
+reported together with the admissible ones and the automatic choice is used instead. The
+automatic choice is the smallest admissible L >= 100 whose L^2 iterations take at least about
+two hours at the per-iteration time recorded in mlucas.cfg, capped at L = 1000 (the PRP value) -
+it only ever shortens the interval, on slow or very large runs. Overhead is about 2/L whatever
+the interval, so the setting trades rollback exposure against that. Because the >4-thread
+CheckInterval default of 100000 admits only L = 1000, P-1 uses CheckInterval = 10000 unless you
+set CheckInterval yourself.
 
 The interval is given in hours rather than iterations because the check's cost is scalar GMP
 work that does not scale with the per-iteration FFT the way iteration counts do, so a fixed

--- a/src/Mdata.h
+++ b/src/Mdata.h
@@ -108,6 +108,9 @@ extern int DO_GCHECK;	// Mersenne/PRP or Fermat/Pepin case
 extern int ITERS_BETWEEN_GCHECK_UPDATES;	// #iterations between Gerbicz-checksum updates
 extern int ITERS_BETWEEN_GCHECKS;			// #iterations between Gerbicz-checksum residue-integrity checks
 extern uint32 NERR_GCHECK;	// v20: Add counter for Gerbicz-check errors encountered during test
+extern uint32 NERR_JACOBI;	// v21: Counter for Jacobi-check failures encountered during test
+extern int JACOBI_CHECK;	// v21: mlucas.ini JacobiCheck - 0 disables the LL Jacobi residue check (default on)
+extern double JACOBI_CHECK_HOURS;	// v21: mlucas.ini JacobiCheckHours - wall-clock hours between periodic checks (0 = every checkpoint)
 
 #undef	FACTOR_PASS_MAX
 #define	FACTOR_PASS_MAX	16
@@ -194,7 +197,8 @@ All but the "else" stuff below is specific to factor.c built in standalone mode:
 #define ERR_SKIP_RADIX_SET			14	// In context of self-testing, not fatal for run overall but skip the current set of FFT radices
 #define ERR_INTERRUPT				15	// On one of several interrupt SIGs, exit iteration loop prematurely, write savefiles and exit
 #define ERR_GERBICZ_CHECK			16
-#define ERR_MAX		ERR_GERBICZ_CHECK
+#define ERR_JACOBI_CHECK			17	// v21: LL Jacobi-symbol residue check failed - roll back to a Jacobi-passed savefile
+#define ERR_MAX		ERR_JACOBI_CHECK
 
 /***********************************************************************************************/
 /* Globals. Unless specified otherwise, these are declared in Mdata.h and defined in Mlucas.c: */

--- a/src/Mdata.h
+++ b/src/Mdata.h
@@ -109,6 +109,8 @@ extern int ITERS_BETWEEN_GCHECK_UPDATES;	// #iterations between Gerbicz-checksum
 extern int ITERS_BETWEEN_GCHECKS;			// #iterations between Gerbicz-checksum residue-integrity checks
 extern uint32 NERR_GCHECK;	// v20: Add counter for Gerbicz-check errors encountered during test
 extern uint32 NERR_JACOBI;	// v21: Counter for Jacobi-check failures encountered during test
+extern uint32 PM1_GCHECK_EPOCH_START;	// v21: p-1 stage 1 Gerbicz check: iteration the current check-product epoch started at (0 = from the seed)
+extern uint32 PM1_GCHECK_FILE_HAS_PRODUCT;	// v21: set by read_ppm1_savefiles() when a p-1 savefile carried an appended check-product
 extern int JACOBI_CHECK;	// v21: mlucas.ini JacobiCheck - 0 disables the LL Jacobi residue check (default on)
 extern double JACOBI_CHECK_HOURS;	// v21: mlucas.ini JacobiCheckHours - wall-clock hours between periodic checks (0 = every checkpoint)
 

--- a/src/Mdata.h
+++ b/src/Mdata.h
@@ -109,6 +109,8 @@ extern int ITERS_BETWEEN_GCHECK_UPDATES;	// #iterations between Gerbicz-checksum
 extern int ITERS_BETWEEN_GCHECKS;			// #iterations between Gerbicz-checksum residue-integrity checks
 extern uint32 NERR_GCHECK;	// v20: Add counter for Gerbicz-check errors encountered during test
 extern uint32 NERR_JACOBI;	// v21: Counter for Jacobi-check failures encountered during test
+extern int PM1_GCHECK_INTERVAL;	// v21: mlucas.ini GerbiczCheckInterval for p-1 stage 1 (0 = automatic)
+extern double CFG_MSEC_PER_ITER;	// v21: msec/iter of the chosen radix set, from mlucas.cfg (0 if unknown)
 extern uint32 PM1_GCHECK_EPOCH_START;	// v21: p-1 stage 1 Gerbicz check: iteration the current check-product epoch started at (0 = from the seed)
 extern uint32 PM1_GCHECK_FILE_HAS_PRODUCT;	// v21: set by read_ppm1_savefiles() when a p-1 savefile carried an appended check-product
 extern int JACOBI_CHECK;	// v21: mlucas.ini JacobiCheck - 0 disables the LL Jacobi residue check (default on)

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -86,6 +86,9 @@ int USE_SHORT_CY_CHAIN = 0;
 int ITERS_BETWEEN_CHECKPOINTS;	/* number of iterations between checkpoints */
 int DO_GCHECK = FALSE;	// If Mersenne/PRP or Fermat/Peoin test, Toggle to TRUE at runtime
 uint32 NERR_GCHECK = 0;	// v20: Add counter for Gerbicz-check errors encountered during test
+uint32 NERR_JACOBI = 0;	// v21: Counter for Jacobi-check failures encountered during test
+int JACOBI_CHECK = TRUE;	// v21: mlucas.ini JacobiCheck; forced FALSE when no usable GMP is compiled in
+double JACOBI_CHECK_HOURS = 12.0;	// v21: mlucas.ini JacobiCheckHours; 0 = check at every checkpoint
 int ITERS_BETWEEN_GCHECK_UPDATES = 1000;	// iterations between Gerbicz-checkproduct updates
 int ITERS_BETWEEN_GCHECKS     = 1000000;	// #iterations between Gerbicz-checksum residue-integrity checks
 
@@ -143,7 +146,8 @@ const char *err_code[ERR_MAX] = {
 	"ERR_UNKNOWN_FATAL",
 	"ERR_SKIP_RADIX_SET",
 	"ERR_INTERRUPT",
-	"ERR_GERBICZ_CHECK"
+	"ERR_GERBICZ_CHECK",
+	"ERR_JACOBI_CHECK"
 };
 
 // Shift count and auxiliary arrays used to support rotated-residue computations:
@@ -405,6 +409,15 @@ uint32	ernstMain
 	that point (needed for the [d] mode_flag, since the update may not be in the final iteration interval).
 	gchk_nfail bounds the retry count, so a persistent (non-transient) final-check failure cannot spin: */
 	uint32 gchk_final = FALSE, gchk_iter = 0, gchk_first_sub = 0, gchk_nfail = 0, loop_exit = 0;
+	/* v21: LL Jacobi-check state (cf. jacobi_check()). do_jcheck: enabled for this assignment. jchk_tlast/jchk_tdur:
+	wall time of, and taken by, the previous check - the next waits JACOBI_CHECK_HOURS and at least 100x jchk_tdur, so the
+	check never exceeds ~1% of the run however slow the host. jchk_nfail: consecutive failures; selects the rollback
+	target (p/q, then .J, then .J1, then scratch) and bounds the retries. jchk_file: position in that chain during a
+	restart-file read. jchk_passed: this checkpoint passed, so the .J/.J1 files get updated after the p/q write: */
+	int do_jcheck = FALSE, jchk_passed = FALSE, jchk_file = 0, jsym = 0;
+	uint32 jchk_nfail = 0;
+	double jchk_tlast = 0.0, jchk_tdur = 0.0, jchk_tsec = 0.0;
+	char jchk_fname[STR_MAX_LEN];
 	/* Exponent of number to be tested - note that for trial-factoring, we represent p
 	strictly in string[STR_MAX_LEN] form in this module, only converting it to numeric
 	form in the factoring module. For all other types of assignments uint64 should suffice: */
@@ -463,10 +476,11 @@ RANGE_BEG:
 	p = 0ull; ierr = 0;
 	USE_SHORT_CY_CHAIN = 0;		// v19: Reset carry-chain length fiddler to default (faster/lower-accuracy) at start of each run:
 	ROE_ITER = 0; ROE_VAL = 0.0;
-	NERR_GCHECK = NERR_ROE = 0;	// v20: Add counters for Gerbicz-check errors and dangerously high ROEs encountered
+	NERR_GCHECK = NERR_ROE = NERR_JACOBI = 0;	// v20: Add counters for Gerbicz-check errors and dangerously high ROEs encountered
 								// during test - if a restart, will re-read actual cumulative values from checkpoint file.
 	gchk_final = FALSE; gchk_nfail = 0;	// v21: End-of-run G-check state. Reset here, i.e. once per assignment - NOT on the
 										// READ_RESTART_FILE rollback path, else a repeating failure could retry without bound.
+	jchk_nfail = 0; jchk_file = 0; jchk_passed = FALSE; jchk_tdur = 0.0; jchk_tlast = getRealTime();	// v21: ditto for the Jacobi check
 	// Clear out any FFT-radix or known-factor data that might remain from a just-completed run:
 	for(i = 0; i < 10; i++) { RADIX_VEC[i] = 0; }
 	nfac = 0; mi64_clear(KNOWN_FACTORS,40);
@@ -502,6 +516,33 @@ RANGE_BEG:
 			sprintf(cbuf,"User set CheckInterval = %d in %s.\n",(int)dtmp,MLUCAS_INI_FILE);	check_interval = (int)dtmp;
 		}
 		mlucas_fprint(cbuf,1);
+	}
+	// v21: LL Jacobi residue check controls - cf. jacobi_check(). Defaults re-established before each read so an
+	// entry removed from the file between assignments does not linger:
+	JACOBI_CHECK = TRUE;	JACOBI_CHECK_HOURS = 12.0;
+	dtmp = mlucas_getOptVal(MLUCAS_INI_FILE,"JacobiCheck");
+	if(dtmp == dtmp) {	// NaN means "not set" - keep the default
+		if(dtmp == 0.0 || dtmp == 1.0) {
+			JACOBI_CHECK = (int)dtmp;
+			sprintf(cbuf,"User set JacobiCheck = %d in %s.\n",JACOBI_CHECK,MLUCAS_INI_FILE);
+		} else {
+			sprintf(cbuf,"User set unsupported value JacobiCheck = %f in %s ... must be 0 or 1, ignoring.\n",dtmp,MLUCAS_INI_FILE);
+		}
+		mlucas_fprint(cbuf,1);
+	}
+	dtmp = mlucas_getOptVal(MLUCAS_INI_FILE,"JacobiCheckHours");
+	if(dtmp == dtmp) {
+		if(dtmp < 0.0 || dtmp > 8760.0) {
+			sprintf(cbuf,"User set JacobiCheckHours = %f in %s ... must be in [0, 8760], ignoring.\n",dtmp,MLUCAS_INI_FILE);
+		} else {
+			JACOBI_CHECK_HOURS = dtmp;
+			sprintf(cbuf,"User set JacobiCheckHours = %g in %s%s.\n",dtmp,MLUCAS_INI_FILE,(dtmp == 0.0) ? " (Jacobi check at every checkpoint)" : "");
+		}
+		mlucas_fprint(cbuf,1);
+	}
+	if(JACOBI_CHECK && !jacobi_check_available()) {
+		sprintf(cbuf,"WARN: The Jacobi residue check needs Mlucas built against GMP >= 5.1 ... disabling it for this run.\n");
+		mlucas_fprint(cbuf,1);	JACOBI_CHECK = FALSE;
 	}
 
 /*  ...If multithreading enabled, set max. # of threads based on # of available (logical) processors,
@@ -1507,6 +1548,8 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 		ASSERT(i == j*j, "#iterations between Gerbicz-checksum updates must = sqrt(#iterations between residue-integrity checks)");
 		ASSERT(i%k == 0 && k%j == 0, "G-checkproduct update interval must divide savefile-update one, which must divide the G-check interval");
 	}
+	// v21: The Jacobi residue check applies to production (non-selftest) LL tests of Mersenne numbers - cf. jacobi_check():
+	do_jcheck = JACOBI_CHECK && !INTERACT && (TEST_TYPE == TEST_TYPE_PRIMALITY) && (MODULUS_TYPE == MODULUS_TYPE_MERSENNE);
 
 	// PRP-test: Init bitwise multiply-by-base array - cf. comment re. modified Fermat-PRP needed by Gerbicz check
 	// above ==> all bits = 0 for Mersenne-PRP-test, rather than all-ones-with-least-significant-bit-0 as for the
@@ -1524,9 +1567,22 @@ READ_RESTART_FILE:
 			strcpy(g_cstr, RESTARTFILE); strcat(g_cstr, ".G");
 		} else if(s2_continuation) {
 			strcpy(g_cstr, RESTARTFILE); strcat(g_cstr, ".s1");
+		} else if(do_jcheck) {
+			/* v21: With the Jacobi check on, every restart-file read walks the chain p -> q -> .J -> .J1 -> scratch, indexed by
+			jchk_file: a file that fails to read, fails to convert, or fails the Jacobi check on read is skipped for the next.
+			On a checkpoint-time Jacobi failure the failure site sets the starting position from the consecutive-failure count,
+			so a file which passed on read but led straight to another failure (a corrupt residue passes the check with
+			probability 1/2) is not tried twice. Reaching the end of the chain starts the run from scratch: */
+			strcpy(g_cstr, RESTARTFILE); g_cstr[0] = ((MODULUS_TYPE == MODULUS_TYPE_MERSENNE) ? 'p' : 'f');
+			if(jchk_file == 1) { g_cstr[0] = 'q'; }
+			else if(jchk_file == 2) { strcat(g_cstr, ".J"); }
+			else if(jchk_file == 3) { strcat(g_cstr, ".J1"); }
 		}
 		/* See if there's a restart file: */
-		fp = mlucas_fopen(g_cstr, "rb");
+		if(do_jcheck && jchk_file >= 4)
+			fp = 0x0;	// v21: Jacobi rollback chain exhausted - handled as "no restart file" below
+		else
+			fp = mlucas_fopen(g_cstr, "rb");
 		/* If so, read the savefile: */
 		if(fp) {
 			if(TEST_TYPE == TEST_TYPE_PRP) {
@@ -1549,11 +1605,30 @@ READ_RESTART_FILE:
 				if(ierr == ERR_GERBICZ_CHECK) {
 					sprintf(cbuf,"Failed to correctly read last-good-Gerbicz-check data savefile!");
 					mlucas_fprint(cbuf,0); ASSERT(0,cbuf);
+				} else if(do_jcheck) {	// v21: next file in the Jacobi rollback chain
+					jchk_file++;	goto READ_RESTART_FILE;
 				} else if(g_cstr[0] != 'q') {
 					g_cstr[0] = 'q';	goto READ_RESTART_FILE;
 				} else {
 					sprintf(cbuf,"Failed to correctly read both primary or secondary savefile!");
 					mlucas_fprint(cbuf,0); ASSERT(0,cbuf);
+				}
+			}
+			/* v21: Jacobi-check the residue just read, before anything is built on it. This is the one check a freshly loaded
+			residue gets: it catches a savefile written from an already-corrupt residue (the S-H checksum triplet only proves the
+			file is self-consistent), and it is what makes rolling back through the chain safe. Not counted in NERR_JACOBI - the
+			checkpoint-time failure that led here (if any) already was: */
+			if(do_jcheck) {
+				jsym = jacobi_check(p, arrtmp, (uint32)((p+63)>>6), 2, &jchk_tsec);
+				jchk_tlast = getRealTime(); jchk_tdur = jchk_tsec;
+				if(jsym == -1) {
+					snprintf(cbuf,sizeof(cbuf), "Restart file %s (iteration %" PRIu64 ") passed the Jacobi check (%.1f sec).\n",g_cstr,itmp64,jchk_tsec);
+					mlucas_fprint(cbuf,1);
+				} else {
+					snprintf(cbuf,sizeof(cbuf), "Restart file %s (iteration %" PRIu64 ") FAILED the Jacobi check (symbol = %d, %.1f sec) - its residue is corrupt; trying the next savefile in the chain.\n",g_cstr,itmp64,jsym,jchk_tsec);
+					mlucas_fprint(cbuf,1);
+					// q is a byte-for-byte copy of p, so a p that read fine but fails the check means q would too - skip it:
+					jchk_file = (jchk_file == 0) ? 2 : jchk_file + 1;	goto READ_RESTART_FILE;
 				}
 			}
 			// If user attempts to restart run with different PRP base than it was started with, ignore the new value and continue with the initial one:
@@ -1592,9 +1667,9 @@ READ_RESTART_FILE:
 			deadly" aliased-ROE type are negligibly small. Even should such an improbability occur, if it does the program will once
 			more pseudorandomize the FFT inputs by again mod-doubling the shift count, i.e. we'll never get stuck:
 			*/
-			if(ierr == ERR_GERBICZ_CHECK) {
+			if(ierr == ERR_GERBICZ_CHECK || ierr == ERR_JACOBI_CHECK) {	// v21: same reasoning applies to a Jacobi-check rollback
 				MOD_ADD64(RES_SHIFT,RES_SHIFT,p,RES_SHIFT);
-				snprintf(cbuf,sizeof(cbuf), "Gerbicz-check-error restart: Mod-doubling residue shift to avoid repeating any possible fractional-error aliasing in retry, new shift = %" PRIu64 "\n",RES_SHIFT);
+				snprintf(cbuf,sizeof(cbuf), "%s-check-error restart: Mod-doubling residue shift to avoid repeating any possible fractional-error aliasing in retry, new shift = %" PRIu64 "\n",(ierr == ERR_GERBICZ_CHECK) ? "Gerbicz" : "Jacobi",RES_SHIFT);
 				mlucas_fprint(cbuf,1);
 			}
 			/* Allocate floating-point residue array and convert savefile bytewise residue to floating-point form, after
@@ -1603,7 +1678,9 @@ READ_RESTART_FILE:
 			if(!convert_res_bytewise_FP((uint8 *)arrtmp, a, n, p)) {
 				snprintf(cbuf,sizeof(cbuf), "ERROR: convert_res_bytewise_FP Failed on primality-test residue read from savefile %s!\n",g_cstr);
 				mlucas_fprint(cbuf,0);
-				if(g_cstr[0] != 'q' && !(ierr == ERR_GERBICZ_CHECK)) {	// Secondary savefile only exists for regular checkpoint files
+				if(do_jcheck) {	// v21: next file in the Jacobi rollback chain
+					jchk_file++;	goto READ_RESTART_FILE;
+				} else if(g_cstr[0] != 'q' && !(ierr == ERR_GERBICZ_CHECK)) {	// Secondary savefile only exists for regular checkpoint files
 					g_cstr[0] = 'q';
 					goto READ_RESTART_FILE;
 				} else {
@@ -1620,6 +1697,8 @@ READ_RESTART_FILE:
 				s1 = sum64(b_uint64_ptr, n); s2 = s3 = s1;	// Init triply-redundant checksum of G-checkproduct
 			}
 		  }
+			if(ierr == ERR_JACOBI_CHECK) ierr = 0;	// v21: Jacobi rollback target read and vetted - resume from it
+			jchk_file = 0;	// v21: any later restart-file read starts from the primary savefile again
 			ASSERT(ilo > 0,"Require ilo > 0!");
 			ihi = ilo+ITERS_BETWEEN_CHECKPOINTS;
 			/* If for some reason last checkpoint was at a non-multiple of ITERS_BETWEEN_CHECKPOINTS, round down: */
@@ -1635,6 +1714,19 @@ READ_RESTART_FILE:
 				snprintf(cbuf,sizeof(cbuf), "INFO: Needed restart file %s not found...moving on to next assignment in %s.\n",g_cstr,WORKFILE);
 				mlucas_fprint(cbuf,1);
 				goto GET_NEXT_ASSIGNMENT;
+			} else if(do_jcheck && jchk_file < 4) {	// v21: Jacobi rollback chain: this file is absent, try the next
+				if(jchk_file <= 1 || ierr == ERR_JACOBI_CHECK) {	// .J/.J1 are normally absent on a fresh start - don't mention them then
+					snprintf(cbuf,sizeof(cbuf), "INFO: restart file %s not found...looking for the next one.\n",g_cstr);
+					mlucas_fprint(cbuf,1);
+				}
+				jchk_file++;	goto READ_RESTART_FILE;
+			} else if(do_jcheck) {	// v21: chain exhausted
+				if(ierr == ERR_JACOBI_CHECK)
+					sprintf(cbuf, "INFO: no restart file passes the Jacobi check...starting run from scratch.\n");
+				else
+					sprintf(cbuf, "INFO: no restart file found...starting run from scratch.\n");
+				mlucas_fprint(cbuf,1);
+				ierr = 0; restart = FALSE; jchk_file = 0;
 			} else if(g_cstr[0] != 'q') {
 				snprintf(cbuf,sizeof(cbuf), "INFO: primary restart file %s not found...looking for secondary...\n",g_cstr);
 				mlucas_fprint(cbuf,1);
@@ -2122,6 +2214,33 @@ READ_RESTART_FILE:
 		// Zero high uint64s of target arrays, since double-to-int residue conversion is bytewise & may leave >=1 MSBs in high word untouched:
 		// Fermat-mod residue formally needs an extra bit, though said bit should == 1
 		// only in the highly unlikely case of a prime-Fermat Pepin-test result:
+	#ifdef MLUCAS_FAULT_INJECT
+		/* Test-only fault injector - build with -DMLUCAS_FAULT_INJECT, never in a release build. At the checkpoint whose
+		iteration count equals $MLUCAS_FAULT_ITER, add 1.0 to balanced digit $MLUCAS_FAULT_WORD (default 0) of the residue,
+		i.e. perturb the residue by 2^(bit offset of that digit). The perturbed value is what gets checked, saved and iterated
+		on from here, exactly as a memory fault in the residue array would be - which makes the ensuing check/rollback path
+		testable deterministically (a given (iteration, digit) always yields the same verdict). Fires once per process, so
+		the retry after a rollback runs clean. Iterations below 64 are refused: the residue is not full-size before
+		~log2(p) iterations, so an early injection tests nothing about the real arithmetic path: */
+		{
+			static int fi_parsed = 0, fi_done = 0; static uint32 fi_iter = 0, fi_word = 0;
+			if(!fi_parsed) {
+				const char *fi_e = getenv("MLUCAS_FAULT_ITER"), *fi_w = getenv("MLUCAS_FAULT_WORD");
+				fi_parsed = 1;
+				if(fi_e) {
+					fi_iter = (uint32)strtoul(fi_e,0x0,10);	if(fi_w) fi_word = (uint32)strtoul(fi_w,0x0,10);
+					ASSERT(fi_iter >= 64, "MLUCAS_FAULT_ITER must be >= 64: the residue is not full-size before ~log2(p) iterations.");
+					ASSERT(fi_word < (uint32)n, "MLUCAS_FAULT_WORD must be less than the FFT length.");
+				}
+			}
+			if(fi_iter && !fi_done && ihi == fi_iter && ierr == 0 && !INTERACT) {
+				uint32 fi_j1 = fi_word + ((fi_word >> DAT_BITS) << PAD_BITS);	// padded-array index of digit fi_word
+				a[fi_j1] += 1.0;	fi_done = 1;
+				snprintf(cbuf,sizeof(cbuf), "FAULT INJECTION: added 1.0 to residue digit %u at iteration %u.\n",fi_word,ihi);
+				mlucas_fprint(cbuf,1);
+			}
+		}
+	#endif
 		j = (p+63+(MODULUS_TYPE == MODULUS_TYPE_FERMAT))>>6;	arrtmp[j-1] = 0ull;
 		convert_res_FP_bytewise(	a, (uint8 *)      arrtmp, n, p, &Res64, &Res35m1, &Res36m1);	// LL/PRP-test/[p-1 stage 1] residue
 		// G-check residue...must not touch i1,i2,i3 again until ensuing write_ppm1_savefiles call!
@@ -2172,6 +2291,48 @@ READ_RESTART_FILE:
 				, timebuffer, PSTRING, iter_or_stage[TEST_TYPE == TEST_TYPE_PM1], ihi, (float)ihi / (float)maxiter * 100,get_time_str(tdiff)
 				, 1000*get_time(tdiff)/(ihi - ilo), Res64, AME, MME, RES_SHIFT);
 			mlucas_fprint(cbuf,scrnFlag);
+		}
+
+		/* v21: LL Jacobi residue check on the shift-removed residue just converted into arrtmp[] (cf. jacobi_check()).
+		Runs on the final residue - the value about to be reported - and otherwise once JACOBI_CHECK_HOURS have elapsed
+		since the previous check (at every checkpoint if that is 0), but never on an interrupt-driven checkpoint (a
+		shutdown must not stall for the ~30 sec a 100M-bit check takes; the residue is checked on the ensuing restart
+		instead), and never sooner than 100x the previous check's duration, which caps the overhead near 1% however
+		slow the host. Must precede the loop_exit break below, since LL writes no final savefile: */
+		jchk_passed = FALSE;
+		if(do_jcheck && ierr == 0) {
+			double tnow = getRealTime(), twait = MAX(JACOBI_CHECK_HOURS*3600.0, 100.0*jchk_tdur);
+			if(ihi == maxiter || JACOBI_CHECK_HOURS == 0.0 || (tnow - jchk_tlast) >= twait) {
+				jsym = jacobi_check(p, arrtmp, j, 2, &jchk_tsec);
+				jchk_tlast = getRealTime(); jchk_tdur = jchk_tsec;
+				if(jsym == -1) {
+					snprintf(cbuf,sizeof(cbuf), "At iteration %u, shift = %" PRIu64 ": Jacobi check passed (%.1f sec).\n",ihi,RES_SHIFT,jchk_tsec);
+					mlucas_fprint(cbuf,scrnFlag);
+					jchk_nfail = 0; jchk_passed = TRUE;
+				} else if(jsym == 0) {
+					/* Symbol 0 means gcd(s - 2, M(p)) > 1. Exponents are checked prime when the worktodo entry is parsed (the
+					composite case, where M(q) | M(p) for q | p and the LL sequence collapses mod M(q), never gets here), so for
+					a genuine LL residue this has probability ~1/q per iteration over the factors q of M(p) - i.e. it does not
+					happen. A residue that lands on it is corrupt in a way no rollback is likely to clear, so stop rather than
+					retry, and say what was seen: */
+					snprintf(cbuf,sizeof(cbuf), "Jacobi check at iteration %u failed with symbol 0: the residue shares a factor with the modulus, which cannot happen for a correct LL residue of a prime exponent. Aborting rather than retrying; %s savefiles left in place - please check this machine for hardware errors.\n",ihi,PSTRING);
+					mlucas_fprint(cbuf,1); ASSERT(0,cbuf);
+				} else {
+					NERR_JACOBI++; jchk_nfail++;
+					if(jchk_nfail >= 5) {
+						snprintf(cbuf,sizeof(cbuf), "Jacobi check at iteration %u failed %u times in a row, the last after restarting from scratch - the error is not being cleared by rolling back, so it is not transient. Aborting rather than retrying without bound; %s savefiles left in place. Please check this machine for hardware errors.\n",ihi,jchk_nfail,PSTRING);
+						mlucas_fprint(cbuf,1); ASSERT(0,cbuf);
+					}
+					/* Rollback target from the failure count: the current savefiles first (the corruption may postdate them);
+					then the two Jacobi-passed checkpoints; then scratch. Each candidate is itself Jacobi-checked on read: */
+					jchk_file = (jchk_nfail == 1) ? 0 : (jchk_nfail == 2) ? 2 : (jchk_nfail == 3) ? 3 : 4;
+					snprintf(cbuf,sizeof(cbuf), "Jacobi check at iteration %u FAILED (symbol = %+d, %.1f sec)! Restarting from %s.\n",ihi,jsym,jchk_tsec,
+						(jchk_file == 0) ? "the current savefile" : (jchk_file == 2) ? "the last Jacobi-passed savefile" : (jchk_file == 3) ? "the previous Jacobi-passed savefile" : "scratch");
+					mlucas_fprint(cbuf,1);
+					ierr = ERR_JACOBI_CHECK;
+					goto READ_RESTART_FILE;
+				}
+			}
 		}
 
 		// Do not save a final residue unless p-1 (if not, still leave penultimate residue file intact).
@@ -2413,6 +2574,33 @@ READ_RESTART_FILE:
 					mlucas_fprint(cbuf,1);
 				}
 			}	// ihi a multiple of ITERS_BETWEEN_GCHECKS?
+		}
+
+		/* v21: LL Jacobi check - on a passing check keep the two most recent Jacobi-passed checkpoints, p[exp].J (this one)
+		and p[exp].J1 (the previous). A failing check normally implies the corruption postdates the last passing one (the
+		symbol is invariant under the recurrence, so an earlier corruption that passed would go on passing), which makes .J
+		the natural rollback target. .J1 covers the two ways that can fail: .J unreadable or failing its on-read check, and
+		a corruption that landed exactly at a checked checkpoint, passed that check (so .J holds it) and fails every later
+		one - the retry from .J then fails at the same iteration and the chain advances to .J1. Both exercised in tests: */
+		if(do_jcheck && jchk_passed) {
+			strcpy(g_cstr, RESTARTFILE);	strcat(g_cstr, ".J");
+			snprintf(jchk_fname,STR_MAX_LEN, "%s.J1",RESTARTFILE);
+			fp = mlucas_fopen(g_cstr, "rb");	// Only rotate if a .J exists yet (rename would just fail noisily otherwise)
+			if(fp) {
+				fclose(fp); fp = 0x0;
+				if(mlucas_rename(g_cstr, jchk_fname)) {
+					snprintf(cbuf,sizeof(cbuf), "WARN: unable to rename %s ==> %s; the previous Jacobi-passed checkpoint is lost.\n",g_cstr,jchk_fname);
+					mlucas_fprint(cbuf,1);
+				}
+			}
+			fp = mlucas_fopen_atomic(g_cstr, "wb");
+			if(fp) {
+				write_ppm1_savefiles(g_cstr,p,n,fp, itmp64, (uint8 *)arrtmp,Res64,Res35m1,Res36m1, (uint8 *)e_uint64_ptr,i1,i2,i3);
+				close_savefile(g_cstr,fp); fp = 0x0;
+			} else {
+				snprintf(cbuf,sizeof(cbuf), "ERROR: unable to open Jacobi-check savefile %s for write of checkpoint data.\n",g_cstr);
+				mlucas_fprint(cbuf,1);
+			}
 		}
 
 		if(ierr == ERR_INTERRUPT) exit(0);
@@ -5443,8 +5631,8 @@ int read_ppm1_savefiles(const char *fname, uint64 p, uint32 *kblocks, FILE *fp, 
 	reported to the server as a maximal hardware-error code. Init from the globals so that fields which
 	the file does not contain (older formats) are left as-is, exactly as before:
 	*/
-	uint32 prp_base = PRP_BASE, nerr_roe = NERR_ROE, nerr_gcheck = NERR_GCHECK;
-	uint64 res_shift = 0ull, gcheck_shift = GCHECK_SHIFT, len_v17,len_v19;
+	uint32 prp_base = PRP_BASE, nerr_roe = NERR_ROE, nerr_gcheck = NERR_GCHECK, nerr_jacobi = NERR_JACOBI;
+	uint64 res_shift = 0ull, gcheck_shift = GCHECK_SHIFT, len_v17,len_v19,len_v20;
 	uint128 ui128,vi128; uint192 ui192,vi192; uint256 ui256,vi256;	// Fixed-length 2/3/4-word ints for stashing results of multiword modexp.
 	*Res64 = 0ull;	// 0 value on return indicates failure of some kind
 	mi64_clear(pow,4); mi64_clear(rem,4);
@@ -5511,6 +5699,7 @@ int read_ppm1_savefiles(const char *fname, uint64 p, uint32 *kblocks, FILE *fp, 
 	*/
 	len_v17 = (uint64)nbytes + 28;
 	len_v19 = len_v17 + 11 + (DO_GCHECK ? (uint64)nbytes + 30 : 0ull);
+	len_v20 = len_v19 + 8;	// v21: + the two 4-byte error counts (NERR_ROE, NERR_GCHECK)
 
 	i = read_ppm1_residue(nbytes, fp, arr1, Res64,Res35m1,Res36m1);
 	if(!i) return 0;
@@ -5685,11 +5874,29 @@ Thus if we use a negative-power algo, to recover 2^p (mod q = 2^k.qodd):
 		nerr += i << (8*j);
 	}
 	nerr_gcheck = MAX(nerr,nerr_gcheck);
+	/* v21: Jacobi-check failure count, appended after the v20 fields so that older readers - which stop after the two
+	counts above - are unaffected. Absent from v20/v21-format savefiles: EOF on its first byte, with the file length
+	confirming a complete v20-format file, means "not tracked yet" and the count continues from its current value: */
+	nerr = 0ull;
+	for(j = 0; j < 4; j++) {
+		i = fgetc(fp);
+		if(i == EOF) {
+			if(!j) {
+				if(!savefile_ends_at(func,fname,fp,1,len_v20,FALSE)) return 0;
+				goto SAVEFILE_READ_DONE;
+			} else {
+				sprintf(cbuf, "%s: Expected 4 Jacobi-check-error-count bytes in savefile %s!\n",func,fname);
+				fprintf(stderr,"%s", cbuf);	return 0;
+			}
+		}
+		nerr += i << (8*j);
+	}
+	nerr_jacobi = MAX(nerr,nerr_jacobi);
 
 SAVEFILE_READ_DONE:
 	// v21: Read succeeded - only now commit the parsed values to their globals:
 	RES_SHIFT = res_shift;	PRP_BASE = prp_base;	GCHECK_SHIFT = gcheck_shift;
-	NERR_ROE = nerr_roe;	NERR_GCHECK = nerr_gcheck;
+	NERR_ROE = nerr_roe;	NERR_GCHECK = nerr_gcheck;	NERR_JACOBI = nerr_jacobi;
 	/* Don't deallocate arr1 here, since we'll need it later for savefile writes. */
 	return 1;
 }
@@ -5764,6 +5971,7 @@ void write_ppm1_savefiles(const char *fname, uint64 p, int n, FILE *fp, uint64 i
 	// v20: Write cumulative #errs for ROE >= 0.4375 (>= for LL, > for PRP) and Gerbicz-check for the test in question:
 	i  = write_savefile_field(fp,NERR_ROE   ,4);
 	i &= write_savefile_field(fp,NERR_GCHECK,4);
+	i &= write_savefile_field(fp,NERR_JACOBI,4);	// v21: appended last, so older readers can ignore it
 	if(!i) goto SAVEFILE_WRITE_ERR;
 	return;
 
@@ -6524,14 +6732,15 @@ void generate_JSON_report(
 		if(is_hex_string(char_addr, 32) && STRNEQN(char_addr,"00000000000000000000000000000000",32))
 			strncpy(aid,char_addr,32);
 	}
-	const uint32 error_code = (MIN(NERR_ROE, 0x3F) << 8) | (MIN(NERR_GCHECK, 0xF) << 20);
+	// Bit layout follows the GIMPS server's convention: Jacobi-check failures in bits 4-7, roundoff in 8-13, Gerbicz in 20-23:
+	const uint32 error_code = (MIN(NERR_JACOBI, 0xF) << 4) | (MIN(NERR_ROE, 0x3F) << 8) | (MIN(NERR_GCHECK, 0xF) << 20);
 	// Write the result line. The 2 nested conditionals here are LL-or-PRP and has-AID-or-not:
 	if(TEST_TYPE == TEST_TYPE_PRIMALITY) {
 		snprintf(ttype,10,"LL");
 		if(*aid) {
-			snprintf(p_cstr,STR_MAX_LEN,"{\"status\":\"%c\", \"exponent\":%" PRIu64 ", \"worktype\":\"%s\", \"res64\":\"%016" PRIX64 "\", \"fft-length\":%u, \"shift-count\":%" PRIu64 ", \"error-code\":\"%08X\", \"errors\":{\"Roundoff\":%u}, \"program\":{\"name\":\"Mlucas\", \"version\":\"%s\"}, \"timestamp\":\"%s\", \"aid\":\"%s\"}\n",prp_status[isprime],p,ttype,Res64,n,RES_SHIFT,error_code,NERR_ROE,VERSION,timebuffer,aid);
+			snprintf(p_cstr,STR_MAX_LEN,"{\"status\":\"%c\", \"exponent\":%" PRIu64 ", \"worktype\":\"%s\", \"res64\":\"%016" PRIX64 "\", \"fft-length\":%u, \"shift-count\":%" PRIu64 ", \"error-code\":\"%08X\", \"errors\":{\"Roundoff\":%u, \"jacobi\":%u}, \"program\":{\"name\":\"Mlucas\", \"version\":\"%s\"}, \"timestamp\":\"%s\", \"aid\":\"%s\"}\n",prp_status[isprime],p,ttype,Res64,n,RES_SHIFT,error_code,NERR_ROE,NERR_JACOBI,VERSION,timebuffer,aid);
 		} else {
-			snprintf(p_cstr,STR_MAX_LEN,"{\"status\":\"%c\", \"exponent\":%" PRIu64 ", \"worktype\":\"%s\", \"res64\":\"%016" PRIX64 "\", \"fft-length\":%u, \"shift-count\":%" PRIu64 ", \"error-code\":\"%08X\", \"errors\":{\"Roundoff\":%u}, \"program\":{\"name\":\"Mlucas\", \"version\":\"%s\"}, \"timestamp\":\"%s\"}\n",prp_status[isprime],p,ttype,Res64,n,RES_SHIFT,error_code,NERR_ROE,VERSION,timebuffer);
+			snprintf(p_cstr,STR_MAX_LEN,"{\"status\":\"%c\", \"exponent\":%" PRIu64 ", \"worktype\":\"%s\", \"res64\":\"%016" PRIX64 "\", \"fft-length\":%u, \"shift-count\":%" PRIu64 ", \"error-code\":\"%08X\", \"errors\":{\"Roundoff\":%u, \"jacobi\":%u}, \"program\":{\"name\":\"Mlucas\", \"version\":\"%s\"}, \"timestamp\":\"%s\"}\n",prp_status[isprime],p,ttype,Res64,n,RES_SHIFT,error_code,NERR_ROE,NERR_JACOBI,VERSION,timebuffer);
 		}
 	} else if(TEST_TYPE == TEST_TYPE_PRP && KNOWN_FACTORS[0]) {	// PRP-CF result
 		// Print list of known factors used for CF test. Unlike the Primenet assignment formtting on the input side,
@@ -6961,6 +7170,71 @@ void modinv(uint64 p, uint64 *vec1, uint64 *vec2, uint32 nlimb) {
 	// Done with the GMP arrays ... gmp_one needs clearing as well, cf. the comment in gcd():
 	mpz_clear(gmp_arr1); mpz_clear(gmp_arr2); mpz_clear(gmp_one);
 #endif	// INCLUDE_GMP ?
+}
+
+/*********************/
+
+/* v21: Jacobi-symbol residue check.
+
+For an LL test of M(p) = 2^p - 1, p an odd prime, the iterates s_n satisfy J(s_n - 2 | M(p)) = -1 for every
+n >= 1 whatever M(p)'s primality: s_n - 2 = (s_{n-1} - 2)(s_{n-1} + 2) with s_{n-1} + 2 = s_{n-2}^2 a square,
+so the symbol telescopes to J(s_1 - 2 | M(p)) = J(12 | M(p)) = J(3 | M(p)) = -1 (M(p) = 1 mod 3, 3 mod 4).
+A corrupted residue satisfies it with probability 1/2 - and the symbol is *invariant* under the recurrence from
+one iteration after a corruption on (J(s_{n+1} - 2) = J(s_n - 2) J(s_{n-1}^2) = J(s_n - 2) once s_{n-1} is itself
+an iterate of the corrupted value). So the checks see at most two independent values per corruption: the symbol
+at the corrupted iteration itself, only if a check happens to run exactly there, and one further value shared
+by every later check. A corruption mid-interval - the realistic case - gets one coin: caught with probability
+1/2 by the first check after it, or never. This is therefore a cheap, weak check; the check cadence sets how
+much work is lost when a corruption is caught, not the odds of catching it. It does not certify the result.
+The circular residue shift is irrelevant to the symbol (J(2 | M(p)) = +1), but the -2 must be applied to the
+unshifted value, i.e. the form convert_res_FP_bytewise() leaves in arrtmp[] and the savefiles hold.
+
+Computes J(res - sub | N), N = 2^p -+ 1 per MODULUS_TYPE, res[] the shift-removed residue in little-endian
+bytewise form. Only the low ceil(p/8) bytes are read, so stale high bytes in the top limb are harmless.
+Returns +1, -1 or 0 and sets *tsec to the wall time taken. GMP's mpz_jacobi became subquadratic in 5.1.0;
+the older quadratic version would take hours at 100M bits, so a build against an older GMP (or without GMP)
+reports the check unavailable rather than run it. Measured (i9-10885H, GMP 6.3): 0.08 s at 1M bits, 28 s at
+100M, 146 s at 332M, 259 s at 595M.
+*/
+int jacobi_check_available(void) {
+#if INCLUDE_GMP && defined(__GNU_MP_RELEASE) && (__GNU_MP_RELEASE >= 50100)
+	return 1;
+#else
+	return 0;
+#endif
+}
+
+int jacobi_check(uint64 p, const uint64 *res, uint32 nlimb, uint32 sub, double *tsec) {
+#if !(INCLUDE_GMP && defined(__GNU_MP_RELEASE) && (__GNU_MP_RELEASE >= 50100))
+	if(tsec) *tsec = 0.0;
+	return JACOBI_UNAVAILABLE;
+#else
+	// Unlike standard types and Mlucas internal structs, GMP objects must be declared before any expressions:
+	mpz_t gmp_a, gmp_n;
+	int jsym;
+	double clock1, clock2;
+	size_t nbytes;
+	ASSERT(res != 0x0, "Null residue pointer input to jacobi_check()!");
+	ASSERT(MODULUS_TYPE == MODULUS_TYPE_MERSENNE || MODULUS_TYPE == MODULUS_TYPE_FERMAT, "jacobi_check(): unsupported modulus type!");
+	ASSERT(nlimb >= (uint32)((p+63+(MODULUS_TYPE == MODULUS_TYPE_FERMAT))>>6), "jacobi_check(): nlimb too small for the exponent!");
+	nbytes = (size_t)((p + (MODULUS_TYPE == MODULUS_TYPE_FERMAT) + 7)>>3);	// Fermat-mod residue may need the extra bit
+	clock1 = getRealTime();
+	mpz_init(gmp_a); mpz_init(gmp_n);
+	mpz_import(gmp_a, nbytes, -1, 1, 0, 0, res);	// least-significant byte first, host byte order within each byte
+	mpz_ui_pow_ui(gmp_n, 2ul, (unsigned long)p);
+	if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE)
+		mpz_sub_ui(gmp_n, gmp_n, 1ul);
+	else
+		mpz_add_ui(gmp_n, gmp_n, 1ul);
+	mpz_sub_ui(gmp_a, gmp_a, (unsigned long)sub);
+	if(mpz_sgn(gmp_a) < 0)
+		mpz_add(gmp_a, gmp_a, gmp_n);
+	jsym = mpz_jacobi(gmp_a, gmp_n);
+	mpz_clear(gmp_a); mpz_clear(gmp_n);
+	clock2 = getRealTime();
+	if(tsec) *tsec = clock2 - clock1;
+	return jsym;
+#endif
 }
 
 /*********************/

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -398,6 +398,13 @@ uint32	ernstMain
 	uint32 dum = 0,findex = 0,ierr = 0,ilo = 0,ihi = 0,iseed,isprime,kblocks = 0,maxiter = 0,n = 0,npad = 0;
 	uint64 itmp64,cy, s1 = 0ull,s2 = 0ull,s3 = 0ull;	// s1,2,3: Triply-redundant whole-array checksum on b,c-arrays used in the G-check
 	uint32 mode_flag = 0, first_sub = 0, last_sub;
+	/* v21: End-of-run Gerbicz check. The regular check only fires at multiples of ITERS_BETWEEN_GCHECKS,
+	which maxiter (= p for a Mersenne PRP, = 2^m-1 for a Pepin test) never is, so the tail of every run
+	went unchecked. gchk_final is set when the checkproduct receives its last update of the run; gchk_iter
+	is the iteration count that update corresponds to, and gchk_first_sub the first_sub value in effect at
+	that point (needed for the [d] mode_flag, since the update may not be in the final iteration interval).
+	gchk_nfail bounds the retry count, so a persistent (non-transient) final-check failure cannot spin: */
+	uint32 gchk_final = FALSE, gchk_iter = 0, gchk_first_sub = 0, gchk_nfail = 0, loop_exit = 0;
 	/* Exponent of number to be tested - note that for trial-factoring, we represent p
 	strictly in string[STR_MAX_LEN] form in this module, only converting it to numeric
 	form in the factoring module. For all other types of assignments uint64 should suffice: */
@@ -458,6 +465,8 @@ RANGE_BEG:
 	ROE_ITER = 0; ROE_VAL = 0.0;
 	NERR_GCHECK = NERR_ROE = 0;	// v20: Add counters for Gerbicz-check errors and dangerously high ROEs encountered
 								// during test - if a restart, will re-read actual cumulative values from checkpoint file.
+	gchk_final = FALSE; gchk_nfail = 0;	// v21: End-of-run G-check state. Reset here, i.e. once per assignment - NOT on the
+										// READ_RESTART_FILE rollback path, else a repeating failure could retry without bound.
 	// Clear out any FFT-radix or known-factor data that might remain from a just-completed run:
 	for(i = 0; i < 10; i++) { RADIX_VEC[i] = 0; }
 	nfac = 0; mi64_clear(KNOWN_FACTORS,40);
@@ -1846,6 +1855,10 @@ READ_RESTART_FILE:
 		ASSERT(maxiter > 0,"Require (uint32)maxiter > 0");
 		if(ihi > maxiter)
 			ihi = maxiter;
+		/* v21: The end-of-run G-check flag is set and consumed within a single iteration interval, so clear it here.
+		This also keeps it from going stale across the various mid-interval error-recovery gotos (ROE FFT-length
+		bump, ERR_CARRY savefile-rollback), any of which can restart an interval in which it had already been set: */
+		gchk_final = FALSE;
 		// If p-1: start of each iteration cycle, copy bits ilo:ihi-1 of PM1_S1_PRODUCT into low bits of BASE_MULTIPLIER_BITS vector:
 		if(TEST_TYPE == TEST_TYPE_PM1) {
 			k = (ihi+63)>>6;// #limbs of PM1_S1_PRODUCT needed, INCL. BITS 0:ILO-1 WHICH WILL BE GETTING OFF-SHIFTED - only extract ilo:ihi-1
@@ -1926,11 +1939,26 @@ READ_RESTART_FILE:
 				compute b *= c (mod n). But again wasteful, would rather just complete the fwd-FFT of c[] instead of undoing and then immediately
 				redoing the initial fwd-FFT-radix pass of it. But, we do this infrequently enough that we don't care!
 				[EWM: Update: Added the FFT mode_flag control mechanism to eliminate this redundant work] */
+				i += itodo;
+				/* v21: Only iteration counts which are multiples of L = ITERS_BETWEEN_GCHECK_UPDATES may be folded
+				into the checkproduct: the Gerbicz identity [b == u0.d^(2^L)] holds only if the update points are
+				equally spaced L apart. The sole non-multiple-of-L endpoint is that of the final partial subinterval
+				(itodo clipped to maxiter-i above), so skip the b[]-update for it. Instead the run's final G-check is
+				done at the last L-aligned update point, i.e. at iteration L*(maxiter/L) - see the G-check block below.
+				(Self-tests never reach that check, so leave their b[]-handling exactly as it was.)
+				*/
+				if(!INTERACT && (i % ITERS_BETWEEN_GCHECK_UPDATES)) continue;
+				/* Is this the last checkproduct update of the run, i.e. the one our end-of-run G-check must use?
+				(No further update can occur, since the next L-aligned iteration count exceeds maxiter.) Snapshot the
+				iteration count and first_sub, since the check itself may not run until a later iteration interval: */
+				gchk_final = !INTERACT && (i + ITERS_BETWEEN_GCHECK_UPDATES > maxiter);
+				if(gchk_final) {
+					gchk_iter = i; gchk_first_sub = first_sub;
+				}
 				memcpy(c, a, nbytes);	// Copy a into c and do fwd-FFT-only of c:
 				// If going to proceed to actual Gerbicz-check, need to save an un-updated copy of the checkproduct:
-				i += itodo;
 			//	fprintf(stderr,"At Iter %u: copy a[] -> c[]\n",i);
-				if(i % ITERS_BETWEEN_GCHECKS == 0) {
+				if(i % ITERS_BETWEEN_GCHECKS == 0 || gchk_final) {
 					memcpy(d, b, nbytes);
 				}
 			// All-but-Last  sub: [c] !need fwd-weighting and initial-fwd-FFT-pass done on entry, exit moot since fwd-FFT-only: mode_flag = 01_2:
@@ -1966,7 +1994,9 @@ READ_RESTART_FILE:
 			// Last  subinterval: [b] !need fwd-weighting and initial-fwd-FFT-pass done on entry,  undone on exit: mode_flag = 01_2
 			/* Note: Interrupt during this step should not be a problem, the handling code in func_mod_square will complete the FFT-mul
 			step and force the undo-initial-FFT-pass-and-DWT-weighting step, leaving a pure-int G-check residue ready for savefile-writing: */
-				mode_flag = 3 - first_sub - (last_sub<<1);
+			// v21: If this is the run's last checkproduct update, b[] gets no further FFT ops, so it must be returned
+			// to pure-int form here - the skipped final-partial-subinterval update would otherwise have done that:
+				mode_flag = 3 - first_sub - ((last_sub || gchk_final)<<1);
 			//	printf("Iter %u: FFT(b)*FFT(c) step.\n",i);
 				ierr = func_mod_square  (b, (int*)arrtmp, n, i,i+1, (uint64)c + (uint64)mode_flag, p, scrnFlag, &tdif2, FALSE, 0x0);
 				if(ierr) {
@@ -1982,7 +2012,7 @@ READ_RESTART_FILE:
 			//	fprintf(stderr,"FFT(b)*FFT(c), mode = %u\n",mode_flag);
 				// If not going to proceed to actual Gerbicz-check, save a post-updated copy of the checkproduct,
 				// in order to guard against single-bit or other data corruption in b[] (h/t George Woltman):
-				if(i % ITERS_BETWEEN_GCHECKS != 0) {
+				if(i % ITERS_BETWEEN_GCHECKS != 0 && !gchk_final) {
 					memcpy(d, b, nbytes);
 					s1 = sum64(b_uint64_ptr, n); s2 = s3 = s1;	// Init triply-redundant checksum of G-checkproduct
 				}
@@ -2148,7 +2178,10 @@ READ_RESTART_FILE:
 		// We don't save "final residue" in cofactor-PRP mode, since in the (mod M(p)) case this is for p+1 squarings (G-check needs this),
 		// i.e. needs a mod-div-by-base^2 postprocessing step to put in form of the p-1 squarings of the standard Fermat-PRP test:
 		// Comment by Catherine Cowie, 2024: for Pepin tests we actually do need a final residue saved, as the worktodo format for a Pepin test does not include possibility of cofactor testing. See https://github.com/primesearch/Mlucas/pull/11 for more information.
-		if ((ihi == maxiter) && (INTERACT || (TEST_TYPE != TEST_TYPE_PM1 && !(TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT))))
+		// v21: ...but if the run's final Gerbicz check is still pending, defer this exit until after the G-check
+		// block below has done it. (Without this deferral no Mersenne-PRP run ever performs a final G-check.)
+		loop_exit = (ihi == maxiter) && (INTERACT || (TEST_TYPE != TEST_TYPE_PM1 && !(TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT)));
+		if(loop_exit && !gchk_final)
 				break;
 
 		/* If Mersenne/PRP or Fermat test, do Gerbicz-check every million squarings. Make sure current run has done at least
@@ -2158,8 +2191,14 @@ READ_RESTART_FILE:
 		o ilo = 0, ihi = 1000: integer divide gives ilo/1000 = 0, ihi/1000 = 1 difference > 0, thus contains an update
 		o ilo = 1000, ihi = 1507: ilo/1000 = 1, ihi/1000 = 1 difference = 0, thus !contains an update
 		*/
+		/* v21: gchk_final adds the run's last check, at iteration gchk_iter = L*(maxiter/L) <= ihi - the latest
+		iteration count at which the Gerbicz identity is applicable, since it needs L-aligned update points. That
+		update was made during the current iteration interval, so the (ilo/j < ihi/j) precondition is met by
+		construction; and gchk_iter need not equal ihi, so use it in place of ihi throughout the block below.
+		*/
 		i = ITERS_BETWEEN_GCHECKS; j = ITERS_BETWEEN_GCHECK_UPDATES;
-		if(MLUCAS_KEEP_RUNNING && DO_GCHECK && (ilo/j < ihi/j) && (ihi % i) == 0) {
+		if(!gchk_final) gchk_iter = ihi;
+		if(MLUCAS_KEEP_RUNNING && DO_GCHECK && (gchk_final || ((ilo/j < ihi/j) && (ihi % i) == 0))) {
 			// Un-updated copy of the checkproduct saved in [d]; square that ITERS_BETWEEN_GCHECK_UPDATES times...
 			/*
 			Mar 2022: User hit assertion-exit below ... had set CheckInterval = 1000 = ITERS_BETWEEN_GCHECK_UPDATES,
@@ -2171,8 +2210,9 @@ READ_RESTART_FILE:
 			// If First subinterval also TRUE, [d] needs fwd-weighting and initial-fwd-FFT-pass done on entry: mode_flag = 00_2.
 			/* Note: Interrupt during this step should not be a problem, the handling code in func_mod_square will complete the FFT-mul
 			step and force the undo-initial-FFT-pass-and-DWT-weighting step, leaving a pure-int G-check residue ready for savefile-writing: */
-			mode_flag = 1 - first_sub;
-			ierr = func_mod_square  (d,0x0, n, ihi,ihi+ITERS_BETWEEN_GCHECK_UPDATES, (uint64)mode_flag, p, scrnFlag, &tdiff, FALSE, 0x0);
+			// v21: for the end-of-run check, use the first_sub value in effect when [d] was snapshotted:
+			mode_flag = 1 - (gchk_final ? gchk_first_sub : first_sub);
+			ierr = func_mod_square  (d,0x0, n, gchk_iter,gchk_iter+ITERS_BETWEEN_GCHECK_UPDATES, (uint64)mode_flag, p, scrnFlag, &tdiff, FALSE, 0x0);
 			if(ierr) {
 				if(ierr == ERR_INTERRUPT) {
 					fprintf(stderr,"Caught interrupt in Gerbicz-checkproduct mod-squaring update ... skipping G-check and savefile-update and performing immediate-exit.\n");
@@ -2190,8 +2230,10 @@ READ_RESTART_FILE:
 			c_uint64_ptr[j-1] = 0ull;
 			// [1] Convert b[],d[] to bytewise form, former assumed already in e[] doubles-array, latter into currently-unused c[] doubles-array:
 			convert_res_FP_bytewise(d, (uint8 *)c_uint64_ptr, n, p, 0x0,0x0,0x0);
-			// Only need to compute this for initial interval - after that the needed adjustment-shift remains constant
-			if(ihi == ITERS_BETWEEN_GCHECKS && RES_SHIFT) {
+			// Only need to compute this for initial interval - after that the needed adjustment-shift remains constant.
+			// v21: '<=' rather than '==' so that a run too short to ever hit iteration ITERS_BETWEEN_GCHECKS - for which
+			// the end-of-run check below is the *only* check, hence the first - also gets GCHECK_SHIFT computed:
+			if(gchk_iter <= ITERS_BETWEEN_GCHECKS && RES_SHIFT) {
 				if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE) {
 					/* d[] needs initial-shift applied prior to final scalar multiply, but don't explicitly,
 					store the initial shift, so need to recompute it from a current value s at iteration i:
@@ -2201,7 +2243,9 @@ READ_RESTART_FILE:
 						y odd : y = (y+p)>>1
 					*/
 					itmp64 = RES_SHIFT;
-					for(i = ITERS_BETWEEN_GCHECK_UPDATES; i < ITERS_BETWEEN_GCHECKS; i++) {	// Recover shift at initial ITERS_BETWEEN_GCHECK_UPDATES-iteration subinterval from that at initial savefile-checkpoint
+					// v21: halve down from iteration ihi, at which RES_SHIFT currently stands (== ITERS_BETWEEN_GCHECKS
+					// for the regular first-interval check, but > gchk_iter for an end-of-run one):
+					for(i = ITERS_BETWEEN_GCHECK_UPDATES; i < ihi; i++) {	// Recover shift at initial ITERS_BETWEEN_GCHECK_UPDATES-iteration subinterval from that at initial savefile-checkpoint
 						if(itmp64 & 1)	// y odd
 							itmp64 = (itmp64+p)>>1;
 						else			// y even
@@ -2265,7 +2309,7 @@ READ_RESTART_FILE:
 			}
 			ASSERT(mi64_cmpult(c_uint64_ptr,d_uint64_ptr,j), "Gerbicz checkproduct reduction (mod 2^p-1) failed!");
 			if(mi64_cmp_eq(e_uint64_ptr,c_uint64_ptr,j)) {
-				sprintf(cbuf,"At iteration %u, shift = %" PRIu64 ": Gerbicz check passed.\n",ihi,RES_SHIFT);
+				sprintf(cbuf,"At iteration %u, shift = %" PRIu64 ": Gerbicz check passed.\n",gchk_iter,RES_SHIFT);
 				mlucas_fprint(cbuf,0);
 				// In G-check case we need b[] for that, thus skipped the d = b redundancy-copy ... do that now:
 				memcpy(d, b, nbytes);
@@ -2279,10 +2323,19 @@ READ_RESTART_FILE:
 					memcpy(d, b, nbytes);
 					s1 = sum64(b_uint64_ptr, n); s2 = s3 = s1;	// Init triply-redundant checksum of G-checkproduct
 				} else {
-					if(ihi == ITERS_BETWEEN_GCHECKS)
-						sprintf(cbuf,"Gerbicz check iteration %u failed! Restarting from scratch.\n",ihi);
+					/* v21: A failure of the end-of-run check rolls back exactly as any other G-check failure does, but
+					since it recurs at the very end of every retry, an error which the rollback cannot clear (i.e. a
+					reproducible one, not the transient data corruption this machinery targets) would retry forever
+					and the run would never terminate. So bound the retries and hard-exit with a diagnostic instead of
+					looping - the savefiles and the worktodo entry are left intact, and no result is emitted: */
+					if(gchk_final && ++gchk_nfail > 3) {
+						snprintf(cbuf,sizeof(cbuf),"Final Gerbicz check at iteration %u failed %u times in a row - the error is not being cleared by restarting from the last-good-Gerbicz-check data, so it is not transient. Aborting rather than retrying without bound; %s savefiles left in place. Please check this machine for hardware errors.\n",gchk_iter,gchk_nfail,PSTRING);
+						mlucas_fprint(cbuf,1); ASSERT(0,cbuf);
+					}
+					if(gchk_iter <= ITERS_BETWEEN_GCHECKS)
+						sprintf(cbuf,"Gerbicz check iteration %u failed! Restarting from scratch.\n",gchk_iter);
 					else
-						sprintf(cbuf,"Gerbicz check iteration %u failed! Restarting from last-good-Gerbicz-check data.\n",ihi);
+						sprintf(cbuf,"Gerbicz check iteration %u failed! Restarting from last-good-Gerbicz-check data.\n",gchk_iter);
 					mlucas_fprint(cbuf,0);
 					ierr = ERR_GERBICZ_CHECK;
 					NERR_GCHECK++;
@@ -2290,6 +2343,10 @@ READ_RESTART_FILE:
 				}
 			}
 		}
+		// v21: Deferred loop-exit: the final Gerbicz check has now been done, so leave without a final-residue write,
+		// exactly as the pre-check exit above would have. (No-op unless the check just done was the end-of-run one.)
+		if(loop_exit)
+			break;
 
 		/* Make sure we start with primary restart file: */
 		RESTARTFILE[0] = ((MODULUS_TYPE == MODULUS_TYPE_MERSENNE) ? 'p' : 'f');

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -87,6 +87,8 @@ int ITERS_BETWEEN_CHECKPOINTS;	/* number of iterations between checkpoints */
 int DO_GCHECK = FALSE;	// If Mersenne/PRP or Fermat/Peoin test, Toggle to TRUE at runtime
 uint32 NERR_GCHECK = 0;	// v20: Add counter for Gerbicz-check errors encountered during test
 uint32 NERR_JACOBI = 0;	// v21: Counter for Jacobi-check failures encountered during test
+uint32 PM1_GCHECK_EPOCH_START = 0;	// v21: p-1 stage 1 Gerbicz check - see the "Gerbicz check for p-1 stage 1" comment in ernstMain()
+uint32 PM1_GCHECK_FILE_HAS_PRODUCT = 0;	// v21: read_ppm1_savefiles() output: a p-1 savefile carried an appended check-product
 int JACOBI_CHECK = TRUE;	// v21: mlucas.ini JacobiCheck; forced FALSE when no usable GMP is compiled in
 double JACOBI_CHECK_HOURS = 12.0;	// v21: mlucas.ini JacobiCheckHours; 0 = check at every checkpoint
 int ITERS_BETWEEN_GCHECK_UPDATES = 1000;	// iterations between Gerbicz-checkproduct updates
@@ -449,6 +451,13 @@ uint32	ernstMain
 /*...allocatable data arrays and associated params: */
 	static uint64 nbytes = 0, nalloc = 0, arrtmp_alloc = 0, s1p_alloc = 0;
 	static double *a_ptmp = 0x0, *a = 0x0, *b = 0x0, *c = 0x0, *d = 0x0, *e = 0x0;
+	/* v21: Gerbicz check for p-1 stage 1 (cf. the long comment at the DO_GCHECK setting below): u0[] = the residue the
+	current check-product epoch started from, kept in pure-integer form; g2[] = scratch for the 3^C correction factor;
+	gchk_bits[] = the multiply-by-base bit array the correction powering and the check-product squarings run against
+	in place of the live stage 1 exponent bits. Allocated only for p-1 with the Gerbicz arrays available: */
+	static double *pm1g_ptmp = 0x0, *u0 = 0x0, *g2 = 0x0;	static uint32 pm1g_nalloc = 0;
+	static uint64 *gchk_bits = 0x0, *gchk_bits_ptmp = 0x0;	static uint32 gchk_bits_len = 0;
+	uint64 *bmb_save = 0x0;	// Saved BASE_MULTIPLIER_BITS pointer across the swaps
 	// uint64 scratch array and 4 pointers used to store cast-to-(uint64 *) version of above b,c,d,e-pointers
 	static uint64 *arrtmp = 0x0, *b_uint64_ptr = 0x0, *c_uint64_ptr = 0x0, *d_uint64_ptr = 0x0, *e_uint64_ptr = 0x0;
 	double final_res_offset;
@@ -1474,6 +1483,7 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 	{
 		ASSERT(a_ptmp != 0x0 && a != 0x0 && b != 0x0 && c != 0x0 && d != 0x0,"Require (a_ptmp,a,b,c,d) != 0x0");
 		free((void *)a_ptmp); a_ptmp = a = b = c = d = e = 0x0; b_uint64_ptr = c_uint64_ptr = d_uint64_ptr = e_uint64_ptr = 0x0;
+		if(pm1g_ptmp) { free((void *)pm1g_ptmp); pm1g_ptmp = u0 = g2 = 0x0; pm1g_nalloc = 0; }	// v21: p-1 G-check arrays track a[]
 		free((void *)arrtmp); arrtmp=0x0;
 		free((void *)BIGWORD_BITMAP);	BIGWORD_BITMAP = 0x0;
 		free((void *)BIGWORD_NBITS);	BIGWORD_NBITS = 0x0;
@@ -1508,6 +1518,16 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 			b = a + nalloc;	c = b + nalloc;	d = c + nalloc, e = d + nalloc;
 			b_uint64_ptr = (uint64 *)b; c_uint64_ptr = (uint64 *)c; d_uint64_ptr = (uint64 *)d; e_uint64_ptr = (uint64 *)e;
 		}
+	}
+	/* v21: p-1 stage 1 Gerbicz check needs two more residue-length arrays (see their declaration). Allocated
+	separately from a[]..e[] because those persist across assignments of the same FFT length while the need
+	for these depends on the test type: */
+	if(TEST_TYPE == TEST_TYPE_PM1 && use_lowmem < 2 && (pm1g_ptmp == 0x0 || pm1g_nalloc < nalloc)) {
+		if(pm1g_ptmp) { free((void *)pm1g_ptmp); pm1g_ptmp = u0 = g2 = 0x0; }
+		pm1g_ptmp = ALLOC_DOUBLE(pm1g_ptmp, 2*nalloc);	if(!pm1g_ptmp){ sprintf(cbuf, "ERROR: unable to allocate the p-1 Gerbicz-check arrays in main.\n"); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf); }
+		u0 = ALIGN_DOUBLE(pm1g_ptmp);	g2 = u0 + nalloc;	pm1g_nalloc = nalloc;
+	}
+	{
 
 		// This residue/scratch byte-array is allocated once and reused for every exponent in the run. In a
 		// multi-FFT-length self-test the arrays are sized for the largest FFT length used (maxFFT), and the
@@ -1539,7 +1559,52 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 	strcpy(g_cstr, RESTARTFILE);
 	// G-check applies to primality/Fermat and PRP/Mersenne (but just to this full-PRP phase, not to any ensuing PRP-CF step):
 	DO_GCHECK = ( (TEST_TYPE == TEST_TYPE_PRIMALITY) && (MODULUS_TYPE == MODULUS_TYPE_FERMAT) && (use_lowmem < 2) )
-				|| ( (TEST_TYPE == TEST_TYPE_PRP) );
+				|| ( (TEST_TYPE == TEST_TYPE_PRP) )
+				|| ( (TEST_TYPE == TEST_TYPE_PM1) && (use_lowmem < 2) );	// v21: p-1 stage 1, see below
+	/* v21: Gerbicz check for p-1 stage 1.
+
+	Stage 1 computes x <- x^2 * 3^b per iteration, b the next bit of the prime-powers product E, so after each block of
+	L = ITERS_BETWEEN_GCHECK_UPDATES iterations x_{(k+1)L} = x_{kL}^(2^L) * 3^(c_k), c_k the value of the L-bit chunk of E
+	consumed in block k (first-consumed bit most significant). With b[] the running product of the x_{kL} (seeded with
+	the epoch's starting residue u0 = x_0) and d[] its copy from the previous check, the PRP identity b == u0 * d^(2^L)
+	acquires one correction factor:
+
+		b == u0 * d^(2^L) * 3^C,    C = sum of c_k over every block of the current epoch up to the check point.
+
+	C is a function of E and the iteration count only, so it is recomputed from PM1_S1_PRODUCT at each check; 3^C is
+	formed by running the stage 1 powering machinery itself with the bits of C in place of the exponent bits, and is
+	applied as one 2-input modmul. Everything else - the block updates, the redundant d[] copy and its checksums, the
+	.G rollback on a failed check - is the PRP code unchanged.
+
+	Two consequences of stage 1 having *live* multiply-by-base bits, which the PRP check never has to think about:
+	(a) the check-product squarings and the correction modmuls read their multiply-by-base bit from the same global
+	    array the carry step uses for the stage 1 powering, so that array is swapped for a private one (zeroed, or
+	    holding the bits of C) around every such call and restored afterwards; (b) the seed u0 is a full residue
+	    when an epoch starts from a loaded residue rather than from 3, so it is kept as an array (u0[]).
+
+	Savefiles: the check-product is appended after the error counts (not inserted in the PRP slot, which older
+	readers parse positionally), preceded by an 8-byte epoch-start field; a p-1 savefile without it starts a new
+	epoch from the residue it holds. Stage 2 has no Gerbicz check; DO_GCHECK is cleared before it starts.
+
+	Why not Jacobi here: squaring maps every value into the quadratic residues, so J(x_{k+1}) = J(3)^b whatever x_k
+	was - a residue corrupted at iteration k carries exactly the expected symbol from k+1 on. The stage 1 Jacobi
+	checks (restart-file read, final residue) therefore only guard the conversion/savefile path; the arithmetic
+	is guarded by this check, and by nothing at all in LowMem=2 mode. */
+	if(TEST_TYPE == TEST_TYPE_PM1) {
+		if(DO_GCHECK) {
+			j = ((ITERS_BETWEEN_CHECKPOINTS+63) >> 6) + 2;
+			if(gchk_bits == 0x0 || gchk_bits_len < (uint32)j) {
+				if(gchk_bits_ptmp) free((void *)gchk_bits_ptmp);
+				gchk_bits_ptmp = ALLOC_UINT64(gchk_bits_ptmp, j);	if(!gchk_bits_ptmp){ sprintf(cbuf, "ERROR: unable to allocate the p-1 Gerbicz-check bit array in main.\n"); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf); }
+				gchk_bits = ALIGN_UINT64(gchk_bits_ptmp);	gchk_bits_len = j;
+			}
+			mi64_clear(gchk_bits, gchk_bits_len);
+			ASSERT(u0 != 0x0 && g2 != 0x0, "p-1 Gerbicz-check arrays not allocated!");
+		} else {
+			snprintf(cbuf,sizeof(cbuf), "WARN: Low-memory run mode: p-1 stage 1 will run with NO arithmetic error check (the Gerbicz check needs the extra residue arrays).\n");
+			mlucas_fprint(cbuf,1);
+		}
+	}
 	// v19: If PRP test, make sure Gerbicz-checkproduct interval divides checkpoint-writing one:
 	if(DO_GCHECK) {
 		i = ITERS_BETWEEN_GCHECKS;
@@ -1631,6 +1696,29 @@ READ_RESTART_FILE:
 					jchk_file = (jchk_file == 0) ? 2 : jchk_file + 1;	goto READ_RESTART_FILE;
 				}
 			}
+			/* v21: p-1 stage 1 restart-file read: Jacobi-check the loaded residue as an integrity check of the savefile and
+			conversion path. The residue is 3^(prefix of E) whose parity is the last consumed exponent bit, so its symbol
+			must be J(3|N) if that bit is 1, else +1 (the stage 1 seed 3 itself at iteration 0, the whole even E at the end):
+			this cannot see an arithmetic error - squaring maps everything into the quadratic residues - but a damaged
+			file or a broken FP->integer conversion shows up here. On a mismatch treat the file as unreadable: */
+			if(TEST_TYPE == TEST_TYPE_PM1 && JACOBI_CHECK && jacobi_check_available()) {
+				uint64 three = 3ull;
+				int jexp = jacobi_check(p, &three, 0, 0, 0x0);	// J(3|N) (nlimb 0 = scalar): -1 for both Mersenne and Fermat moduli
+				if(itmp64 > 0 && !((PM1_S1_PRODUCT[(itmp64-1)>>6] >> ((itmp64-1)&63)) & 1ull)) jexp = 1;
+				jsym = jacobi_check(p, arrtmp, (uint32)((p+63+(MODULUS_TYPE == MODULUS_TYPE_FERMAT))>>6), 0, &jchk_tsec);
+				if(jsym == jexp) {
+					snprintf(cbuf,sizeof(cbuf), "Restart file %s (stage 1 iteration %" PRIu64 ") passed the Jacobi check (%.1f sec).\n",g_cstr,itmp64,jchk_tsec);
+					mlucas_fprint(cbuf,1);
+				} else {
+					snprintf(cbuf,sizeof(cbuf), "Restart file %s (stage 1 iteration %" PRIu64 ") FAILED the Jacobi check (symbol = %d, expected %d, %.1f sec) - its residue is corrupt.\n",g_cstr,itmp64,jsym,jexp,jchk_tsec);
+					mlucas_fprint(cbuf,1);
+					if(g_cstr[0] != 'q' && ierr != ERR_GERBICZ_CHECK && !s2_continuation) {
+						g_cstr[0] = 'q';	goto READ_RESTART_FILE;
+					} else {
+						ASSERT(0,"No usable p-1 savefile: the residue fails its Jacobi check. Delete the p-1 savefiles for this exponent to start over.");
+					}
+				}
+			}
 			// If user attempts to restart run with different PRP base than it was started with, ignore the new value and continue with the initial one:
 			if(TEST_TYPE == TEST_TYPE_PRP && dum != PRP_BASE) {
 				fprintf(stderr,"INFO: User-specified PRP-test base %u differs from value of %u read from savefile %s ... using the latter.\n",dum,PRP_BASE,g_cstr);
@@ -1688,7 +1776,23 @@ READ_RESTART_FILE:
 				}
 			}
 			// v19: G-check residue - we only create savefile for PRP-phase of any PRP-CF run, i.e. always expect a G-check residue:
-		  if(DO_GCHECK) {
+		  if(DO_GCHECK && TEST_TYPE == TEST_TYPE_PM1) {
+			/* v21: p-1 stage 1: continue the check-product epoch if the file carried the product, else start a new epoch
+			from the residue just loaded (which the Jacobi check above has vetted as far as it can): */
+			if(PM1_GCHECK_FILE_HAS_PRODUCT) {
+				if(!convert_res_bytewise_FP((uint8 *)e_uint64_ptr, b, n, p)) {
+					snprintf(cbuf,sizeof(cbuf), "ERROR: convert_res_bytewise_FP Failed on Gerbicz-check residue read from savefile %s!\n",g_cstr);
+					mlucas_fprint(cbuf,0); ASSERT(0,cbuf);
+				}
+				memset(u0, 0, npad*sizeof(double));	u0[0] = PRP_BASE;	PM1_GCHECK_EPOCH_START = 0;
+			} else {
+				memcpy(b, a, nbytes);	memcpy(u0, a, nbytes);	PM1_GCHECK_EPOCH_START = (uint32)ilo;
+				snprintf(cbuf,sizeof(cbuf), "Savefile %s carries no Gerbicz check-product; starting a new check epoch at stage 1 iteration %u.\n",g_cstr,PM1_GCHECK_EPOCH_START);
+				mlucas_fprint(cbuf,1);
+			}
+			memcpy(d, b, nbytes);	s1 = sum64(b_uint64_ptr, n); s2 = s3 = s1;
+			ierr = 0;
+		  } else if(DO_GCHECK) {
 			if(!convert_res_bytewise_FP((uint8 *)e_uint64_ptr, b, n, p)) {
 				snprintf(cbuf,sizeof(cbuf), "ERROR: convert_res_bytewise_FP Failed on Gerbicz-check residue read from savefile %s!\n",g_cstr);
 				mlucas_fprint(cbuf,0); ASSERT(0,cbuf);
@@ -1766,6 +1870,10 @@ READ_RESTART_FILE:
 		/* Always use 3 as the p-1 and Pepin-test seed, and 4 for the LL-test seed. For PRP-test, use seed set in worktodo assignment line: */
 		if(TEST_TYPE == TEST_TYPE_PM1) {
 			iseed = PRP_BASE;
+			if(DO_GCHECK) {	// v21: Gerbicz check-product and epoch seed both start from the stage 1 seed:
+				b[0] = d[0] = PRP_BASE;	s1 = s2 = s3 = PRP_BASE;
+				memset(u0, 0, npad*sizeof(double));	u0[0] = PRP_BASE;	PM1_GCHECK_EPOCH_START = 0;
+			}
 		} else if(TEST_TYPE == TEST_TYPE_PRP) {	// v21: Enable G-check also for Fermat Pepin test, but use separate clause below due to the PRP_BASE-used-for-something-else issue
 			iseed = b[0] = d[0] = PRP_BASE;	// Init the Gerbicz residue-product accumulator b[] and its redundant copy d[].
 											// On restart b[] inited via full-bytewise-array read from savefile.
@@ -2090,7 +2198,13 @@ READ_RESTART_FILE:
 			// to pure-int form here - the skipped final-partial-subinterval update would otherwise have done that:
 				mode_flag = 3 - first_sub - ((last_sub || gchk_final)<<1);
 			//	printf("Iter %u: FFT(b)*FFT(c) step.\n",i);
+				/* v21: p-1: this modmul's carry step would read the live stage 1 exponent bit for iteration i and multiply the
+				check-product by 3 wherever it is set - the product must be the plain product of the block-boundary residues,
+				so run it against the zeroed private bit array (found by the oracle test, which compares b[] against a Python
+				product of the same residues): */
+				if(TEST_TYPE == TEST_TYPE_PM1) { bmb_save = BASE_MULTIPLIER_BITS; mi64_clear(gchk_bits, gchk_bits_len); BASE_MULTIPLIER_BITS = gchk_bits; }
 				ierr = func_mod_square  (b, (int*)arrtmp, n, i,i+1, (uint64)c + (uint64)mode_flag, p, scrnFlag, &tdif2, FALSE, 0x0);
+				if(TEST_TYPE == TEST_TYPE_PM1) { BASE_MULTIPLIER_BITS = bmb_save; }
 				if(ierr) {
 					if(ierr == ERR_INTERRUPT) {
 						fprintf(stderr,"Caught interrupt in FFT(b)*FFT(c) step.\n");
@@ -2377,7 +2491,10 @@ READ_RESTART_FILE:
 			step and force the undo-initial-FFT-pass-and-DWT-weighting step, leaving a pure-int G-check residue ready for savefile-writing: */
 			// v21: for the end-of-run check, use the first_sub value in effect when [d] was snapshotted:
 			mode_flag = 1 - (gchk_final ? gchk_first_sub : first_sub);
+			// v21: p-1: the squarings must not pick up the live stage 1 exponent bits - run them against a zeroed bit array:
+			if(TEST_TYPE == TEST_TYPE_PM1) { bmb_save = BASE_MULTIPLIER_BITS; mi64_clear(gchk_bits, gchk_bits_len); BASE_MULTIPLIER_BITS = gchk_bits; }
 			ierr = func_mod_square  (d,0x0, n, gchk_iter,gchk_iter+ITERS_BETWEEN_GCHECK_UPDATES, (uint64)mode_flag, p, scrnFlag, &tdiff, FALSE, 0x0);
+			if(TEST_TYPE == TEST_TYPE_PM1) { BASE_MULTIPLIER_BITS = bmb_save; }
 			if(ierr) {
 				if(ierr == ERR_INTERRUPT) {
 					fprintf(stderr,"Caught interrupt in Gerbicz-checkproduct mod-squaring update ... skipping G-check and savefile-update and performing immediate-exit.\n");
@@ -2393,8 +2510,20 @@ READ_RESTART_FILE:
 			// 1 or more MSBs in high word untouched:
 			j = (p+63)>>6;	/*** Jun 2021: cf. convert_res_FP_bytewise() for why we don't include the extra Fermat-modulus bit here ***/
 			c_uint64_ptr[j-1] = 0ull;
+			/* v21: p-1 stage 1: apply the correction factor u0 * 3^C to d[] (see the DO_GCHECK comment above). g2 = 3^C by the
+			stage 1 powering machinery driven by the bits of C, c = u0 * g2, d *= c; every modmul runs against the private
+			bit array so the live exponent bits stay out of it. On exit d[] is pure-int as the PRP path expects: */
+			if(TEST_TYPE == TEST_TYPE_PM1) {
+				ierr = pm1_gcheck_correction(d, c, g2, u0, gchk_bits, gchk_bits_len, gchk_iter, n, p, func_mod_square, scrnFlag, &tdif2);
+				if(ierr) {
+					snprintf(cbuf,sizeof(cbuf),"Unhandled Error of type[%u] = %s in p-1 Gerbicz-check correction step - please report this with the p*.stat file attached.\n",ierr,returnMlucasErrCode(ierr));
+					mlucas_fprint(cbuf,0); ASSERT(0,cbuf);
+				}
+				c_uint64_ptr[j-1] = 0ull;	// c[] was scratch above; re-zero the top limb the bytewise conversion below leaves untouched
+			}
 			// [1] Convert b[],d[] to bytewise form, former assumed already in e[] doubles-array, latter into currently-unused c[] doubles-array:
 			convert_res_FP_bytewise(d, (uint8 *)c_uint64_ptr, n, p, 0x0,0x0,0x0);
+		  if(TEST_TYPE != TEST_TYPE_PM1) {	// v21: p-1 applied its seed and correction factor in FP form above; no shift, no scalar multiply
 			// Only need to compute this for initial interval - after that the needed adjustment-shift remains constant.
 			// v21: '<=' rather than '==' so that a run too short to ever hit iteration ITERS_BETWEEN_GCHECKS - for which
 			// the end-of-run check below is the *only* check, hence the first - also gets GCHECK_SHIFT computed:
@@ -2473,6 +2602,7 @@ READ_RESTART_FILE:
 				c_uint64_ptr[j] -= cy;	//ASSERT(cy == 0ull, "mi64_sub result has unexpected borrow!");
 			}
 			ASSERT(mi64_cmpult(c_uint64_ptr,d_uint64_ptr,j), "Gerbicz checkproduct reduction (mod 2^p-1) failed!");
+		  }
 			if(mi64_cmp_eq(e_uint64_ptr,c_uint64_ptr,j)) {
 				sprintf(cbuf,"At iteration %u, shift = %" PRIu64 ": Gerbicz check passed.\n",gchk_iter,RES_SHIFT);
 				mlucas_fprint(cbuf,0);
@@ -2889,6 +3019,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 			}
 		}
 	} else if(TEST_TYPE == TEST_TYPE_PM1) {
+		DO_GCHECK = FALSE;	// v21: the Gerbicz check covers stage 1 only; stage 2's savefile I/O must not look for its product
 		// If just completed S1, do a GCD. (ihi == maxiter) is true of both just-completed S1 and completed-S1 residue read from savefile,
 		// but in the latter case set ilo == ihi to differentiate between the two. ***6/22/21: BUT! If run halted mid-GCD, on restart
 		// will have ilo == ihi ... supplement with what amounts to 'grep GCD [STATFILE]', if found, then GCD completed:
@@ -2896,6 +3027,21 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 		{	// j = #limbs; clear high limb before filling arrtmp[0:j-1] with bytewise residue just to be sure:
 			j = (p+63+(MODULUS_TYPE == MODULUS_TYPE_FERMAT))>>6; arrtmp[j-1] = 0ull;
 			convert_res_FP_bytewise(a,(uint8 *)arrtmp,n,p,0x0,0x0,0x0);
+			/* v21: Jacobi-check the exact integer about to go to the GCD (and, renamed, to any later stage 2 run): E is
+			even, so J(3^E | N) must be +1. This guards the FP->integer conversion path, which the Gerbicz check cannot
+			see (both of its operands go through it). A failure here means a corrupt final residue; stop rather than
+			hand it on - the p/q savefiles are intact and a restart re-reads and re-checks them: */
+			if(JACOBI_CHECK && jacobi_check_available()) {
+				jsym = jacobi_check(p, arrtmp, j, 0, &jchk_tsec);
+				if(jsym == 1) {
+					snprintf(cbuf,sizeof(cbuf), "Stage 1 final residue passed the Jacobi check (%.1f sec).\n",jchk_tsec);
+					mlucas_fprint(cbuf,1);
+				} else {
+					NERR_JACOBI++;
+					snprintf(cbuf,sizeof(cbuf), "Stage 1 final residue FAILED the Jacobi check (symbol = %d, expected +1, %.1f sec): the residue handed to the GCD is corrupt. Aborting before the GCD; %s savefiles left in place - restarting re-reads and re-checks them.\n",jsym,jchk_tsec,PSTRING);
+					mlucas_fprint(cbuf,1); ASSERT(0,cbuf);
+				}
+			}
 			arrtmp[0] -= 1;	// S1 GCD needs residue-1
 			i = gcd(1,p,arrtmp,0x0,j,gcd_str);	// 1st arg = stage just completed
 			// If factor found, gcd() will have done needed status-file-writes:
@@ -5702,8 +5848,11 @@ int read_ppm1_savefiles(const char *fname, uint64 p, uint32 *kblocks, FILE *fp, 
 		         + G-check residue and its checksum triplet (nbytes+18) + GCHECK_SHIFT (8):
 	*/
 	len_v17 = (uint64)nbytes + 28;
-	len_v19 = len_v17 + 11 + (DO_GCHECK ? (uint64)nbytes + 30 : 0ull);
+	// v21: p-1 keeps its Gerbicz check-product appended after the error counts, not in the PRP slot (see write_ppm1_savefiles):
+	const int gblock_mid = DO_GCHECK && (TEST_TYPE != TEST_TYPE_PM1);
+	len_v19 = len_v17 + 11 + (gblock_mid ? (uint64)nbytes + 30 : 0ull);
 	len_v20 = len_v19 + 8;	// v21: + the two 4-byte error counts (NERR_ROE, NERR_GCHECK)
+	PM1_GCHECK_FILE_HAS_PRODUCT = 0;
 
 	i = read_ppm1_residue(nbytes, fp, arr1, Res64,Res35m1,Res36m1);
 	if(!i) return 0;
@@ -5802,7 +5951,7 @@ Thus if we use a negative-power algo, to recover 2^p (mod q = 2^k.qodd):
 	}
 	if(i == EOF) {	// v21: EOF here means either a pre-v18 savefile or a truncated current-format one - which?
 		*kblocks = 0;
-		if(!savefile_ends_at(func,fname,fp,j,len_v17,DO_GCHECK)) return 0;
+		if(!savefile_ends_at(func,fname,fp,j,len_v17,gblock_mid)) return 0;
 		sprintf(cbuf,"%s: Hit EOF in read of FFT-kblocks in savefile %s ... assuming a pre-v18 savefile.\n",func,fname); mlucas_fprint(cbuf,1);
 		goto SAVEFILE_READ_DONE;
 	}
@@ -5813,13 +5962,13 @@ Thus if we use a negative-power algo, to recover 2^p (mod q = 2^k.qodd):
 	}
 	if(i == EOF) {
 		res_shift = 0ull;
-		if(!savefile_ends_at(func,fname,fp,j,len_v17+3,DO_GCHECK)) return 0;
+		if(!savefile_ends_at(func,fname,fp,j,len_v17+3,gblock_mid)) return 0;
 		sprintf(cbuf,"%s: Hit EOF in read of residue-shift in savefile %s ... assuming a pre-v18 savefile.\n",func,fname); mlucas_fprint(cbuf,1);
 		goto SAVEFILE_READ_DONE;
 	}
 
   // v19: For PRP-tests, also read a second Gerbicz-check residue array [arr2] and associated S-H checksum triplet [i1,i2,i3]:
-  if(DO_GCHECK) {	// v21: Change to key off DO_GCHECK, to allow Fermat-mod Pepin-tests to use the Gerbicz check, too
+  if(gblock_mid) {	// v21: Change to key off DO_GCHECK, to allow Fermat-mod Pepin-tests to use the Gerbicz check, too
 	ASSERT(arr2 != 0x0, "Null arr2 pointer!");
 	prp_base = 0;
 	for(j = 0; j < 4; j++) {
@@ -5896,6 +6045,33 @@ Thus if we use a negative-power algo, to recover 2^p (mod q = 2^k.qodd):
 		nerr += i << (8*j);
 	}
 	nerr_jacobi = MAX(nerr,nerr_jacobi);
+	/* v21: p-1 stage 1 Gerbicz check-product, appended after everything older readers know about: an 8-byte epoch-start
+	field (0 = the epoch runs from the stage 1 seed, the only form written) and the product residue with its checksum
+	triplet. EOF at the first byte, with the length confirming a complete v21 file, means "no product" and the caller
+	starts a new check epoch from the residue: */
+	if(DO_GCHECK && TEST_TYPE == TEST_TYPE_PM1 && arr2 != 0x0) {
+		uint64 epoch = 0ull;
+		for(j = 0; j < 8; j++) {
+			i = fgetc(fp);
+			if(i == EOF) {
+				if(!j) {
+					if(!savefile_ends_at(func,fname,fp,1,len_v20+4,FALSE)) return 0;
+					goto SAVEFILE_READ_DONE;
+				} else {
+					sprintf(cbuf, "%s: Expected 8 check-product epoch bytes in savefile %s!\n",func,fname);
+					fprintf(stderr,"%s", cbuf);	return 0;
+				}
+			}
+			epoch += (uint64)i << (8*j);
+		}
+		if(epoch != 0ull) {
+			sprintf(cbuf, "%s: savefile %s carries a check-product with epoch start %" PRIu64 " - unsupported, starting a new epoch.\n",func,fname,epoch);
+			mlucas_fprint(cbuf,1);
+			goto SAVEFILE_READ_DONE;
+		}
+		if(!read_ppm1_residue(nbytes, fp, arr2, i1,i2,i3)) return 0;
+		PM1_GCHECK_FILE_HAS_PRODUCT = 1;
+	}
 
 SAVEFILE_READ_DONE:
 	// v21: Read succeeded - only now commit the parsed values to their globals:
@@ -5966,7 +6142,7 @@ void write_ppm1_savefiles(const char *fname, uint64 p, int n, FILE *fp, uint64 i
 	if(!i) goto SAVEFILE_WRITE_ERR;
 
   // v19: For PRP-tests, also write a second Gerbicz-check residue array [arr2] and associated S-H checksum triplet [i1,i2,i3]:
-  if(DO_GCHECK) {	// v21: Change to key off DO_GCHECK, to allow Fermat-mod Pepin-tests to use the Gerbicz check, too
+  if(DO_GCHECK && TEST_TYPE != TEST_TYPE_PM1) {	// v21: Change to key off DO_GCHECK, to allow Fermat-mod Pepin-tests to use the Gerbicz check, too
 	if(!write_savefile_field(fp,PRP_BASE,4)) goto SAVEFILE_WRITE_ERR;
 	write_ppm1_residue(nbytes, fp, arr2, i1,i2,i3);
 	// G-check residues all need to be clshifted by residue-shift count at the ITERS_BETWEEN_GCHECK_UPDATESth PRP-test iteration:
@@ -5977,6 +6153,14 @@ void write_ppm1_savefiles(const char *fname, uint64 p, int n, FILE *fp, uint64 i
 	i &= write_savefile_field(fp,NERR_GCHECK,4);
 	i &= write_savefile_field(fp,NERR_JACOBI,4);	// v21: appended last, so older readers can ignore it
 	if(!i) goto SAVEFILE_WRITE_ERR;
+	/* v21: p-1 stage 1 Gerbicz check-product, appended so that older readers (which stop after the error counts) are
+	unaffected - the PRP layout's mid-file slot would be mis-parsed by them. Written only for an epoch that runs from the
+	stage 1 seed (the 8-byte field says so with a 0); an epoch started from a loaded residue writes no product and the
+	next restart simply begins another: */
+	if(DO_GCHECK && TEST_TYPE == TEST_TYPE_PM1 && PM1_GCHECK_EPOCH_START == 0 && arr2 != 0x0) {
+		if(!write_savefile_field(fp,0ull,8)) goto SAVEFILE_WRITE_ERR;
+		write_ppm1_residue(nbytes, fp, arr2, i1,i2,i3);
+	}
 	return;
 
 SAVEFILE_WRITE_ERR:	// v21: Formerly these writes were unchecked, so a full filesystem silently truncated
@@ -6778,9 +6962,9 @@ void generate_JSON_report(
 		snprintf(ttype,10,"P-1");
 		if(!strlen(factor)) {	// No factor was found:
 		  if(*aid) {
-			snprintf(p_cstr,STR_MAX_LEN,"{\"status\":\"%s\", \"exponent\":%" PRIu64 ", \"worktype\":\"%s\", \"fft-length\":%u, \"B1\":%u, \"B2\":%" PRIu64 ", \"program\":{\"name\":\"Mlucas\", \"version\":\"%s\"}, \"timestamp\":\"%s\", \"aid\":\"%s\"}\n",pm1_status[0],p,ttype,n,B1,B2,VERSION,timebuffer,aid);
+			snprintf(p_cstr,STR_MAX_LEN,"{\"status\":\"%s\", \"exponent\":%" PRIu64 ", \"worktype\":\"%s\", \"fft-length\":%u, \"B1\":%u, \"B2\":%" PRIu64 ", \"error-code\":\"%08X\", \"errors\":{\"Roundoff\":%u, \"gerbicz\":%u, \"jacobi\":%u}, \"program\":{\"name\":\"Mlucas\", \"version\":\"%s\"}, \"timestamp\":\"%s\", \"aid\":\"%s\"}\n",pm1_status[0],p,ttype,n,B1,B2,error_code,NERR_ROE,NERR_GCHECK,NERR_JACOBI,VERSION,timebuffer,aid);
 		  } else {
-			snprintf(p_cstr,STR_MAX_LEN,"{\"status\":\"%s\", \"exponent\":%" PRIu64 ", \"worktype\":\"%s\", \"fft-length\":%u, \"B1\":%u, \"B2\":%" PRIu64 ", \"program\":{\"name\":\"Mlucas\", \"version\":\"%s\"}, \"timestamp\":\"%s\"}\n",pm1_status[0],p,ttype,n,B1,B2,VERSION,timebuffer);
+			snprintf(p_cstr,STR_MAX_LEN,"{\"status\":\"%s\", \"exponent\":%" PRIu64 ", \"worktype\":\"%s\", \"fft-length\":%u, \"B1\":%u, \"B2\":%" PRIu64 ", \"error-code\":\"%08X\", \"errors\":{\"Roundoff\":%u, \"gerbicz\":%u, \"jacobi\":%u}, \"program\":{\"name\":\"Mlucas\", \"version\":\"%s\"}, \"timestamp\":\"%s\"}\n",pm1_status[0],p,ttype,n,B1,B2,error_code,NERR_ROE,NERR_GCHECK,NERR_JACOBI,VERSION,timebuffer);
 		  }
 		} else {	// The factor in the eponymous arglist field was found:
 		  if(B2 <= B1) {	// No stage 2 was run
@@ -7195,6 +7379,7 @@ unshifted value, i.e. the form convert_res_FP_bytewise() leaves in arrtmp[] and 
 
 Computes J(res - sub | N), N = 2^p -+ 1 per MODULUS_TYPE, res[] the shift-removed residue in little-endian
 bytewise form. Only the low ceil(p/8) bytes are read, so stale high bytes in the top limb are harmless.
+nlimb == 0 means res[0] is a small scalar (used for J(3|N) in the p-1 checks).
 Returns +1, -1 or 0 and sets *tsec to the wall time taken. GMP's mpz_jacobi became subquadratic in 5.1.0;
 the older quadratic version would take hours at 100M bits, so a build against an older GMP (or without GMP)
 reports the check unavailable rather than run it. Measured (i9-10885H, GMP 6.3): 0.08 s at 1M bits, 28 s at
@@ -7220,11 +7405,14 @@ int jacobi_check(uint64 p, const uint64 *res, uint32 nlimb, uint32 sub, double *
 	size_t nbytes;
 	ASSERT(res != 0x0, "Null residue pointer input to jacobi_check()!");
 	ASSERT(MODULUS_TYPE == MODULUS_TYPE_MERSENNE || MODULUS_TYPE == MODULUS_TYPE_FERMAT, "jacobi_check(): unsupported modulus type!");
-	ASSERT(nlimb >= (uint32)((p+63+(MODULUS_TYPE == MODULUS_TYPE_FERMAT))>>6), "jacobi_check(): nlimb too small for the exponent!");
+	ASSERT(nlimb == 0 || nlimb >= (uint32)((p+63+(MODULUS_TYPE == MODULUS_TYPE_FERMAT))>>6), "jacobi_check(): nlimb too small for the exponent!");
 	nbytes = (size_t)((p + (MODULUS_TYPE == MODULUS_TYPE_FERMAT) + 7)>>3);	// Fermat-mod residue may need the extra bit
 	clock1 = getRealTime();
 	mpz_init(gmp_a); mpz_init(gmp_n);
-	mpz_import(gmp_a, nbytes, -1, 1, 0, 0, res);	// least-significant byte first, host byte order within each byte
+	if(nlimb == 0)	// nlimb == 0: res[0] is a small scalar, e.g. the p-1 base 3 when computing J(3|N)
+		mpz_set_ui(gmp_a, (unsigned long)res[0]);
+	else
+		mpz_import(gmp_a, nbytes, -1, 1, 0, 0, res);	// least-significant byte first, host byte order within each byte
 	mpz_ui_pow_ui(gmp_n, 2ul, (unsigned long)p);
 	if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE)
 		mpz_sub_ui(gmp_n, gmp_n, 1ul);
@@ -7239,6 +7427,92 @@ int jacobi_check(uint64 p, const uint64 *res, uint32 nlimb, uint32 sub, double *
 	if(tsec) *tsec = clock2 - clock1;
 	return jsym;
 #endif
+}
+
+/*********************/
+
+/* v21: p-1 stage 1 Gerbicz check - apply the correction factor to the L-times-squared check-product copy d[]:
+
+	d <- d * u0 * 3^C  (mod N),   C = sum over the blocks of the current epoch of the L-bit exponent chunk consumed in each,
+
+see the "Gerbicz check for p-1 stage 1" comment in ernstMain(). Inputs: d[] pure-int (as left by its L squarings);
+c[], g2[] scratch; u0[] the epoch seed residue, pure-int; bits[] (nbits limbs) the private multiply-by-base bit array;
+gchk_iter the check iteration. 3^C is computed by left-to-right binary powering with the stage 1 machinery itself -
+seed 3, then one squaring per bit of C below its leading 1 with a multiply-by-3 wherever that bit is 1, the bits fed
+through bits[] exactly as the stage 1 exponent bits are, in windows of ITERS_BETWEEN_CHECKPOINTS. Every modmul here
+runs with BASE_MULTIPLIER_BITS pointed at bits[], so the live exponent bits cannot leak in; the global is restored
+before return. Returns 0 or a func_mod_square() error code. On exit d[] is pure-int.
+*/
+/* y[0..ylen) = bits [bitoff, bitoff + 64*ylen) of the xlen-limb vector x[], zero-filled past its end: */
+static void get_bit_window(const uint64 x[], uint32 xlen, uint64 bitoff, uint64 y[], uint32 ylen)
+{
+	uint32 i, w = (uint32)(bitoff >> 6), r = (uint32)(bitoff & 63);
+	for(i = 0; i < ylen; i++) {
+		uint64 lo = (i+w   < xlen) ? x[i+w  ] : 0ull;
+		uint64 hi = (i+w+1 < xlen) ? x[i+w+1] : 0ull;
+		y[i] = r ? ((lo >> r) | (hi << (64-r))) : lo;
+	}
+}
+
+int pm1_gcheck_correction(double d[], double c[], double g2[], double u0[], uint64 bits[], uint32 nbits, uint32 gchk_iter, int n, uint64 p,
+	int (*func_mod_square)(double [], int [], int, int, int, uint64, uint64, int, double *, int, double *), int scrnFlag, double *tdiff)
+{
+	const uint32 L = ITERS_BETWEEN_GCHECK_UPDATES, CI = ITERS_BETWEEN_CHECKPOINTS;
+	const uint32 clen = ((L + 64 + 63) >> 6) + 2;	// limbs for C: C < (#blocks) * 2^L, #blocks < 2^32
+	uint64 *C = 0x0, *chunk = 0x0, *bmb_save = BASE_MULTIPLIER_BITS;
+	uint32 i,k,k0,k1,nbits_C,nsq,done,todo,plen;
+	int ierr = 0;
+	const int nbytes_dbl = n*sizeof(double);
+	ASSERT(RES_SHIFT == 0ull, "pm1_gcheck_correction(): p-1 stage 1 runs unshifted!");
+	ASSERT(gchk_iter % L == 0 && PM1_GCHECK_EPOCH_START % L == 0 && gchk_iter > PM1_GCHECK_EPOCH_START, "pm1_gcheck_correction(): check iteration and epoch start must be block-aligned!");
+	ASSERT(nbits*64 >= CI + 64, "pm1_gcheck_correction(): bit array too small!");
+	C = (uint64 *)calloc(clen, sizeof(uint64));	chunk = (uint64 *)calloc(clen, sizeof(uint64));
+	ASSERT(C && chunk, "pm1_gcheck_correction(): calloc failed!");
+	// C = sum of the chunks: block k consumed bits [kL, (k+1)L) of the bit-reversed product, first-consumed bit most significant,
+	// so each chunk is the L-bit window read out and bit-reversed:
+	plen = (PM1_S1_PROD_BITS + 63) >> 6;
+	k0 = PM1_GCHECK_EPOCH_START / L;	k1 = gchk_iter / L;
+	for(k = k0; k < k1; k++) {
+		get_bit_window(PM1_S1_PRODUCT, plen, (uint64)k*L, chunk, clen);	// chunk = product >> kL
+		if(L & 63) chunk[L>>6] &= ~(-1ull << (L & 63));	// keep the low L bits
+		for(i = (L+63)>>6; i < clen; i++) chunk[i] = 0ull;
+		mi64_brev(chunk, L);
+		mi64_add(C, chunk, C, clen);	// cannot overflow: clen has 64+ spare bits
+	}
+	// g2 = 3^C by LR binary powering: g2 = 3, then for each bit of C below the leading one, MSB first: g2 = g2^2 * 3^bit.
+	memset(g2, 0, nbytes_dbl);	g2[0] = 1.0;	// C == 0: 3^0 = 1
+	nbits_C = mi64_getlen(C, clen);	nbits_C = (nbits_C) ? nbits_C*64 - mi64_leadz(C, nbits_C) : 0;
+	if(nbits_C) {
+		g2[0] = 3.0;
+		nsq = nbits_C - 1;	// squarings = bits below the leading one
+		// Iteration t (1-based) consumes bit index t-1 of the fed array and must see bit (nbits_C-1-t) of C: bit-reverse
+		// C's nbits_C bits (the leading 1 lands at index 0) and drop that index-0 bit:
+		mi64_brev(C, nbits_C);	mi64_shrl(C, C, 1, clen, clen);
+		BASE_MULTIPLIER_BITS = bits;
+		for(done = 0; done < nsq && !ierr; done += todo) {
+			todo = MIN(CI, nsq - done);
+			get_bit_window(C, clen, done, bits, nbits);	// bits[0..] = the next window of exponent bits
+			if(todo & 63) bits[todo>>6] &= ~(-1ull << (todo & 63));
+			for(i = (todo+63)>>6; i < nbits; i++) bits[i] = 0ull;
+			// Iterations 1..todo read bit indices 0..todo-1 - pure-int in and out (mode_flag 0), as the stage 1 intervals do:
+			ierr = func_mod_square(g2, 0x0, n, 0, (int)todo, 0ull, p, scrnFlag, tdiff, FALSE, 0x0);
+		}
+		BASE_MULTIPLIER_BITS = bmb_save;
+		if(ierr) goto DONE;
+	}
+	// c = u0 * g2, d = d * c, both with a zeroed bit array so the carry step applies no multiply-by-base:
+	BASE_MULTIPLIER_BITS = bits;	mi64_clear(bits, nbits);
+	ierr = func_mod_square(g2, 0x0, n, 0,1, 4ull, p, scrnFlag, tdiff, FALSE, 0x0);	if(ierr) goto RESTORE;	// g2 <- FFT(g2)
+	memcpy(c, u0, nbytes_dbl);
+	ierr = func_mod_square(c,  0x0, n, 0,1, (uint64)g2, p, scrnFlag, tdiff, FALSE, 0x0);	if(ierr) goto RESTORE;	// c = u0 * 3^C, pure-int
+	ierr = func_mod_square(c,  0x0, n, 0,1, 4ull, p, scrnFlag, tdiff, FALSE, 0x0);	if(ierr) goto RESTORE;	// c <- FFT(c)
+	ierr = func_mod_square(d,  0x0, n, 0,1, (uint64)c, p, scrnFlag, tdiff, FALSE, 0x0);	// d = d * c, pure-int
+RESTORE:
+	BASE_MULTIPLIER_BITS = bmb_save;
+DONE:
+	free(C); free(chunk);
+	ASSERT(BASE_MULTIPLIER_BITS == bmb_save, "pm1_gcheck_correction(): BASE_MULTIPLIER_BITS not restored!");
+	return ierr;
 }
 
 /*********************/

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -412,7 +412,7 @@ uint32	ernstMain
 	is the iteration count that update corresponds to, and gchk_first_sub the first_sub value in effect at
 	that point (needed for the [d] mode_flag, since the update may not be in the final iteration interval).
 	gchk_nfail bounds the retry count, so a persistent (non-transient) final-check failure cannot spin: */
-	uint32 gchk_final = FALSE, gchk_iter = 0, gchk_first_sub = 0, gchk_nfail = 0, loop_exit = 0;
+	uint32 gchk_final = FALSE, gchk_iter = 0, gchk_first_sub = 0, gchk_nfail = 0, gchk_fail_iter = 0, loop_exit = 0;
 	/* v21: LL Jacobi-check state (cf. jacobi_check()). do_jcheck: enabled for this assignment. jchk_tlast/jchk_tdur:
 	wall time of, and taken by, the previous check - the next waits JACOBI_CHECK_HOURS and at least 100x jchk_tdur, so the
 	check never exceeds ~1% of the run however slow the host. jchk_nfail: consecutive failures; selects the rollback
@@ -490,7 +490,7 @@ RANGE_BEG:
 	ROE_ITER = 0; ROE_VAL = 0.0;
 	NERR_GCHECK = NERR_ROE = NERR_JACOBI = 0;	// v20: Add counters for Gerbicz-check errors and dangerously high ROEs encountered
 								// during test - if a restart, will re-read actual cumulative values from checkpoint file.
-	gchk_final = FALSE; gchk_nfail = 0;	// v21: End-of-run G-check state. Reset here, i.e. once per assignment - NOT on the
+	gchk_final = FALSE; gchk_nfail = 0; gchk_fail_iter = 0;	// v21: End-of-run G-check state. Reset here, i.e. once per assignment - NOT on the
 										// READ_RESTART_FILE rollback path, else a repeating failure could retry without bound.
 	jchk_nfail = 0; jchk_fail_iter = 0; jchk_file = 0; jchk_passed = FALSE; jchk_tdur = 0.0; jchk_tlast = getRealTime();	// v21: ditto for the Jacobi check
 	ITERS_BETWEEN_GCHECK_UPDATES = 1000; ITERS_BETWEEN_GCHECKS = 1000000;	// v21: a p-1 assignment may have changed these (GerbiczCheckInterval); PRP uses the fixed defaults
@@ -2673,6 +2673,7 @@ READ_RESTART_FILE:
 			if(mi64_cmp_eq(e_uint64_ptr,c_uint64_ptr,j)) {
 				sprintf(cbuf,"At iteration %u, shift = %" PRIu64 ": Gerbicz check passed.\n",gchk_iter,RES_SHIFT);
 				mlucas_fprint(cbuf,0);
+				if(gchk_iter >= gchk_fail_iter) gchk_nfail = 0;	// v21: a pass at or beyond the last failure point clears the retry count
 				// In G-check case we need b[] for that, thus skipped the d = b redundancy-copy ... do that now:
 				memcpy(d, b, nbytes);
 				s1 = sum64(b_uint64_ptr, n); s2 = s3 = s1;	// Init triply-redundant checksum of G-checkproduct
@@ -2690,8 +2691,13 @@ READ_RESTART_FILE:
 					reproducible one, not the transient data corruption this machinery targets) would retry forever
 					and the run would never terminate. So bound the retries and hard-exit with a diagnostic instead of
 					looping - the savefiles and the worktodo entry are left intact, and no result is emitted: */
-					if(gchk_final && ++gchk_nfail > 3) {
-						snprintf(cbuf,sizeof(cbuf),"Final Gerbicz check at iteration %u failed %u times in a row - the error is not being cleared by restarting from the last-good-Gerbicz-check data, so it is not transient. Aborting rather than retrying without bound; %s savefiles left in place. Please check this machine for hardware errors.\n",gchk_iter,gchk_nfail,PSTRING);
+					/* v21: bound the retries for every check, not just the end-of-run one: a reproducible error at one
+					iteration otherwise rolls back to .G and fails there again forever. The count clears only when a check
+					passes at or beyond the failure point (see the pass branch), so the earlier checkpoints passing again on
+					the way back up do not reset it: */
+					gchk_fail_iter = gchk_iter;
+					if(++gchk_nfail > 3) {
+						snprintf(cbuf,sizeof(cbuf),"%sGerbicz check at iteration %u failed %u times in a row - the error is not being cleared by restarting from the last-good-Gerbicz-check data, so it is not transient. Aborting rather than retrying without bound; %s savefiles left in place. Please check this machine for hardware errors.\n",gchk_final ? "Final " : "",gchk_iter,gchk_nfail,PSTRING);
 						mlucas_fprint(cbuf,1); ASSERT(0,cbuf);
 					}
 					if(gchk_iter <= ITERS_BETWEEN_GCHECKS)
@@ -2804,6 +2810,20 @@ READ_RESTART_FILE:
 			}
 		}
 
+	#ifdef MLUCAS_FAULT_INJECT
+		/* Test-only: $MLUCAS_FAULT_STOP_AT=<iter> clears the run flag right here, *between* intervals - after this
+		checkpoint's savefiles are written and before the next interval starts - which is exactly what a signal arriving
+		during the checkpoint write does. Without the between-intervals interrupt handling the run went on with a
+		frozen residue; with it, the next interval reports the interrupt and the run saves and exits: */
+		{
+			static int fs_done = 0; const char *fs_e = getenv("MLUCAS_FAULT_STOP_AT");
+			if(fs_e && !fs_done && ihi == (uint32)strtoul(fs_e,0x0,10) && ierr == 0 && !INTERACT) {
+				fs_done = 1;	MLUCAS_KEEP_RUNNING = 0;	MLUCAS_INTERRUPT_SIGNO = SIGINT;
+				snprintf(cbuf,sizeof(cbuf), "FAULT INJECTION: run flag cleared between intervals at iteration %u.\n",ihi);
+				mlucas_fprint(cbuf,1);
+			}
+		}
+	#endif
 		if(ierr == ERR_INTERRUPT) exit(0);
 
 		// For Fermats and cofactor-PRP tests of either modulus type, exit only after writing final-residue checkpoint file:

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -87,6 +87,8 @@ int ITERS_BETWEEN_CHECKPOINTS;	/* number of iterations between checkpoints */
 int DO_GCHECK = FALSE;	// If Mersenne/PRP or Fermat/Peoin test, Toggle to TRUE at runtime
 uint32 NERR_GCHECK = 0;	// v20: Add counter for Gerbicz-check errors encountered during test
 uint32 NERR_JACOBI = 0;	// v21: Counter for Jacobi-check failures encountered during test
+int PM1_GCHECK_INTERVAL = 0;	// v21: mlucas.ini GerbiczCheckInterval (p-1 stage 1 only; 0 = automatic, see the DO_GCHECK block in ernstMain)
+double CFG_MSEC_PER_ITER = 0.0;	// v21: set by get_preferred_fft_radix() from the mlucas.cfg timing of the radix set it picks
 uint32 PM1_GCHECK_EPOCH_START = 0;	// v21: p-1 stage 1 Gerbicz check - see the "Gerbicz check for p-1 stage 1" comment in ernstMain()
 uint32 PM1_GCHECK_FILE_HAS_PRODUCT = 0;	// v21: read_ppm1_savefiles() output: a p-1 savefile carried an appended check-product
 int JACOBI_CHECK = TRUE;	// v21: mlucas.ini JacobiCheck; forced FALSE when no usable GMP is compiled in
@@ -455,7 +457,8 @@ uint32	ernstMain
 	current check-product epoch started from, kept in pure-integer form; g2[] = scratch for the 3^C correction factor;
 	gchk_bits[] = the multiply-by-base bit array the correction powering and the check-product squarings run against
 	in place of the live stage 1 exponent bits. Allocated only for p-1 with the Gerbicz arrays available: */
-	static double *pm1g_ptmp = 0x0, *u0 = 0x0, *g2 = 0x0;	static uint32 pm1g_nalloc = 0;
+	static double *pm1g_ptmp = 0x0, *u0 = 0x0, *g2 = 0x0, *g3 = 0x0;	static uint32 pm1g_nalloc = 0, g3_L = 0;	// g3 = FFT(3^(2^L)), valid while g3_L == L
+	uint64 gchk_H = 0ull;
 	static uint64 *gchk_bits = 0x0, *gchk_bits_ptmp = 0x0;	static uint32 gchk_bits_len = 0;
 	uint64 *bmb_save = 0x0;	// Saved BASE_MULTIPLIER_BITS pointer across the swaps
 	// uint64 scratch array and 4 pointers used to store cast-to-(uint64 *) version of above b,c,d,e-pointers
@@ -490,6 +493,7 @@ RANGE_BEG:
 	gchk_final = FALSE; gchk_nfail = 0;	// v21: End-of-run G-check state. Reset here, i.e. once per assignment - NOT on the
 										// READ_RESTART_FILE rollback path, else a repeating failure could retry without bound.
 	jchk_nfail = 0; jchk_fail_iter = 0; jchk_file = 0; jchk_passed = FALSE; jchk_tdur = 0.0; jchk_tlast = getRealTime();	// v21: ditto for the Jacobi check
+	ITERS_BETWEEN_GCHECK_UPDATES = 1000; ITERS_BETWEEN_GCHECKS = 1000000;	// v21: a p-1 assignment may have changed these (GerbiczCheckInterval); PRP uses the fixed defaults
 	// Clear out any FFT-radix or known-factor data that might remain from a just-completed run:
 	for(i = 0; i < 10; i++) { RADIX_VEC[i] = 0; }
 	nfac = 0; mi64_clear(KNOWN_FACTORS,40);
@@ -546,6 +550,17 @@ RANGE_BEG:
 		} else {
 			JACOBI_CHECK_HOURS = dtmp;
 			sprintf(cbuf,"User set JacobiCheckHours = %g in %s%s.\n",dtmp,MLUCAS_INI_FILE,(dtmp == 0.0) ? " (Jacobi check at every checkpoint)" : "");
+		}
+		mlucas_fprint(cbuf,1);
+	}
+	PM1_GCHECK_INTERVAL = 0;
+	dtmp = mlucas_getOptVal(MLUCAS_INI_FILE,"GerbiczCheckInterval");
+	if(dtmp == dtmp) {
+		if(dtmp < 10000.0 || dtmp > 1.0e9 || DNINT(dtmp) != dtmp) {
+			sprintf(cbuf,"User set GerbiczCheckInterval = %f in %s ... must be a whole number in [10^4, 10^9], ignoring.\n",dtmp,MLUCAS_INI_FILE);
+		} else {
+			PM1_GCHECK_INTERVAL = (int)dtmp;
+			sprintf(cbuf,"User set GerbiczCheckInterval = %d in %s (applies to p-1 stage 1).\n",PM1_GCHECK_INTERVAL,MLUCAS_INI_FILE);
 		}
 		mlucas_fprint(cbuf,1);
 	}
@@ -1483,7 +1498,7 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 	{
 		ASSERT(a_ptmp != 0x0 && a != 0x0 && b != 0x0 && c != 0x0 && d != 0x0,"Require (a_ptmp,a,b,c,d) != 0x0");
 		free((void *)a_ptmp); a_ptmp = a = b = c = d = e = 0x0; b_uint64_ptr = c_uint64_ptr = d_uint64_ptr = e_uint64_ptr = 0x0;
-		if(pm1g_ptmp) { free((void *)pm1g_ptmp); pm1g_ptmp = u0 = g2 = 0x0; pm1g_nalloc = 0; }	// v21: p-1 G-check arrays track a[]
+		if(pm1g_ptmp) { free((void *)pm1g_ptmp); pm1g_ptmp = u0 = g2 = g3 = 0x0; pm1g_nalloc = 0; g3_L = 0; }	// v21: p-1 G-check arrays track a[]
 		free((void *)arrtmp); arrtmp=0x0;
 		free((void *)BIGWORD_BITMAP);	BIGWORD_BITMAP = 0x0;
 		free((void *)BIGWORD_NBITS);	BIGWORD_NBITS = 0x0;
@@ -1519,13 +1534,13 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 			b_uint64_ptr = (uint64 *)b; c_uint64_ptr = (uint64 *)c; d_uint64_ptr = (uint64 *)d; e_uint64_ptr = (uint64 *)e;
 		}
 	}
-	/* v21: p-1 stage 1 Gerbicz check needs two more residue-length arrays (see their declaration). Allocated
+	/* v21: p-1 stage 1 Gerbicz check needs three more residue-length arrays (see their declaration). Allocated
 	separately from a[]..e[] because those persist across assignments of the same FFT length while the need
 	for these depends on the test type: */
 	if(TEST_TYPE == TEST_TYPE_PM1 && use_lowmem < 2 && (pm1g_ptmp == 0x0 || pm1g_nalloc < nalloc)) {
-		if(pm1g_ptmp) { free((void *)pm1g_ptmp); pm1g_ptmp = u0 = g2 = 0x0; }
-		pm1g_ptmp = ALLOC_DOUBLE(pm1g_ptmp, 2*nalloc);	if(!pm1g_ptmp){ sprintf(cbuf, "ERROR: unable to allocate the p-1 Gerbicz-check arrays in main.\n"); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf); }
-		u0 = ALIGN_DOUBLE(pm1g_ptmp);	g2 = u0 + nalloc;	pm1g_nalloc = nalloc;
+		if(pm1g_ptmp) { free((void *)pm1g_ptmp); pm1g_ptmp = u0 = g2 = g3 = 0x0; }
+		pm1g_ptmp = ALLOC_DOUBLE(pm1g_ptmp, 3*nalloc);	if(!pm1g_ptmp){ sprintf(cbuf, "ERROR: unable to allocate the p-1 Gerbicz-check arrays in main.\n"); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf); }
+		u0 = ALIGN_DOUBLE(pm1g_ptmp);	g2 = u0 + nalloc;	g3 = g2 + nalloc;	pm1g_nalloc = nalloc;	g3_L = 0;
 	}
 	{
 
@@ -1592,6 +1607,49 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 	is guarded by this check, and by nothing at all in LowMem=2 mode. */
 	if(TEST_TYPE == TEST_TYPE_PM1) {
 		if(DO_GCHECK) {
+			/* v21: Gerbicz interval for p-1 stage 1. The PRP value (10^6 iterations, block L = 1000) is 14-55 hours of
+			exposure at 100M-digit exponents; overhead is ~2/L whatever the interval. Constraints from the block
+			bookkeeping: interval = L^2, L | CheckInterval | L^2 - and with the >4-thread CheckInterval default of
+			10^5 the only admissible L is 1000, so p-1 defaults CheckInterval to 10^4 unless the user set it (two
+			savefile writes per checkpoint are no burden). Then: GerbiczCheckInterval from mlucas.ini if set and
+			admissible, else the smallest admissible L >= 100 whose L^2 iterations take at least ~2 hours at the
+			mlucas.cfg per-iteration time, capped at L = 1000 - i.e. the automatic rule only shortens the interval
+			on slow, large runs: */
+			if(!check_interval && ITERS_BETWEEN_CHECKPOINTS > 10000) {
+				ITERS_BETWEEN_CHECKPOINTS = 10000;
+				snprintf(cbuf,sizeof(cbuf), "p-1: using CheckInterval = 10000 (the >4-thread default of 100000 would force the Gerbicz block to L = 1000; set CheckInterval in %s to override).\n",MLUCAS_INI_FILE);
+				mlucas_fprint(cbuf,1);
+			}
+			{
+				const uint32 CI = ITERS_BETWEEN_CHECKPOINTS; uint32 L, Lsel = 0, Lmin = 0, Lmax = 0;
+				#define PM1_L_ADMISSIBLE(L) ((CI % (L)) == 0 && (((uint64)(L)*(L)) % CI) == 0 && (uint64)(L)*(L) <= 0x7FFFFFFFull)
+				for(L = 100; L <= CI; L++) { if(PM1_L_ADMISSIBLE(L)) { if(!Lmin) Lmin = L; Lmax = L; } }
+				ASSERT(Lmin != 0, "No admissible Gerbicz block length for this CheckInterval - it must be a multiple of 100 with a square multiple <= 2^31.");
+				if(PM1_GCHECK_INTERVAL) {
+					for(L = 100; (uint64)L*L < (uint64)PM1_GCHECK_INTERVAL; L++);
+					if((uint64)L*L == (uint64)PM1_GCHECK_INTERVAL && L <= CI && PM1_L_ADMISSIBLE(L)) {
+						Lsel = L;
+					} else {
+						snprintf(cbuf,sizeof(cbuf), "WARN: GerbiczCheckInterval = %d is not usable with CheckInterval = %u: it must be L^2 with L dividing CheckInterval and CheckInterval dividing L^2 (e.g. ",PM1_GCHECK_INTERVAL,CI);
+						for(L = Lmin, i = 0; L <= Lmax && i < 6; L++) { if(PM1_L_ADMISSIBLE(L)) { snprintf(cbuf+strlen(cbuf),sizeof(cbuf)-strlen(cbuf),"%s%" PRIu64,(i ? ", " : ""),(uint64)L*L); i++; } }
+						snprintf(cbuf+strlen(cbuf),sizeof(cbuf)-strlen(cbuf),"). Using the automatic choice instead.\n");
+						mlucas_fprint(cbuf,1);
+					}
+				}
+				if(!Lsel) {
+					double t_iter = CFG_MSEC_PER_ITER*1.0e-3, bound = (t_iter > 0.0) ? sqrt(7200.0/t_iter) : 1000.0;
+					if(bound > 1000.0) bound = 1000.0;
+					for(L = Lmin; L <= Lmax; L++) { if(PM1_L_ADMISSIBLE(L) && (double)L >= bound) { Lsel = L; break; } }
+					if(!Lsel) Lsel = (Lmax < 1000) ? Lmax : 1000;	// no admissible L >= bound: take the largest one up to 1000
+					while(Lsel > Lmin && !PM1_L_ADMISSIBLE(Lsel)) Lsel--;
+				}
+				#undef PM1_L_ADMISSIBLE
+				ITERS_BETWEEN_GCHECK_UPDATES = (int)Lsel;	ITERS_BETWEEN_GCHECKS = (int)(Lsel*Lsel);
+				snprintf(cbuf,sizeof(cbuf), "p-1 stage 1 Gerbicz check every %d iterations (block L = %d%s%s).\n",ITERS_BETWEEN_GCHECKS,ITERS_BETWEEN_GCHECK_UPDATES,
+					(PM1_GCHECK_INTERVAL && ITERS_BETWEEN_GCHECKS == PM1_GCHECK_INTERVAL) ? ", from GerbiczCheckInterval" : ", automatic",
+					(CFG_MSEC_PER_ITER > 0.0) ? "" : "; no mlucas.cfg timing available");
+				mlucas_fprint(cbuf,1);
+			}
 			j = ((ITERS_BETWEEN_CHECKPOINTS+63) >> 6) + 2;
 			if(gchk_bits == 0x0 || gchk_bits_len < (uint32)j) {
 				if(gchk_bits_ptmp) free((void *)gchk_bits_ptmp);
@@ -2491,8 +2549,11 @@ READ_RESTART_FILE:
 			step and force the undo-initial-FFT-pass-and-DWT-weighting step, leaving a pure-int G-check residue ready for savefile-writing: */
 			// v21: for the end-of-run check, use the first_sub value in effect when [d] was snapshotted:
 			mode_flag = 1 - (gchk_final ? gchk_first_sub : first_sub);
-			// v21: p-1: the squarings must not pick up the live stage 1 exponent bits - run them against a zeroed bit array:
-			if(TEST_TYPE == TEST_TYPE_PM1) { bmb_save = BASE_MULTIPLIER_BITS; mi64_clear(gchk_bits, gchk_bits_len); BASE_MULTIPLIER_BITS = gchk_bits; }
+			/* v21: p-1: the squarings must not pick up the live stage 1 exponent bits. They run against the private bit
+			array, which pm1_gcheck_prepare() fills with the low L bits of the correction exponent C (bit-reversed, at
+			the index offset these iterations read from), so d^(2^L) * 3^(C mod 2^L) comes out of them for free; the
+			high part of C is applied afterwards by pm1_gcheck_apply(): */
+			if(TEST_TYPE == TEST_TYPE_PM1) { gchk_H = pm1_gcheck_prepare(gchk_iter, gchk_bits, gchk_bits_len); bmb_save = BASE_MULTIPLIER_BITS; BASE_MULTIPLIER_BITS = gchk_bits; }
 			ierr = func_mod_square  (d,0x0, n, gchk_iter,gchk_iter+ITERS_BETWEEN_GCHECK_UPDATES, (uint64)mode_flag, p, scrnFlag, &tdiff, FALSE, 0x0);
 			if(TEST_TYPE == TEST_TYPE_PM1) { BASE_MULTIPLIER_BITS = bmb_save; }
 			if(ierr) {
@@ -2510,11 +2571,17 @@ READ_RESTART_FILE:
 			// 1 or more MSBs in high word untouched:
 			j = (p+63)>>6;	/*** Jun 2021: cf. convert_res_FP_bytewise() for why we don't include the extra Fermat-modulus bit here ***/
 			c_uint64_ptr[j-1] = 0ull;
-			/* v21: p-1 stage 1: apply the correction factor u0 * 3^C to d[] (see the DO_GCHECK comment above). g2 = 3^C by the
-			stage 1 powering machinery driven by the bits of C, c = u0 * g2, d *= c; every modmul runs against the private
+			/* v21: p-1 stage 1: apply the rest of the correction factor, u0 * 3^(H * 2^L) with H = C >> L, to d[] (see the
+			DO_GCHECK comment above); the low L bits of C already went into the squarings. 3^(2^L) is computed once per
+			run (L squarings) and kept in g3[]; g2 = g3^H is ~2*log2(H) modmuls. Every modmul runs against the private
 			bit array so the live exponent bits stay out of it. On exit d[] is pure-int as the PRP path expects: */
 			if(TEST_TYPE == TEST_TYPE_PM1) {
-				ierr = pm1_gcheck_correction(d, c, g2, u0, gchk_bits, gchk_bits_len, gchk_iter, n, p, func_mod_square, scrnFlag, &tdif2);
+				if(g3_L != (uint32)ITERS_BETWEEN_GCHECK_UPDATES) {
+					ierr = pm1_gcheck_g3(g3, gchk_bits, gchk_bits_len, n, p, func_mod_square, scrnFlag, &tdif2);
+					if(ierr) { snprintf(cbuf,sizeof(cbuf),"Unhandled Error of type[%u] = %s computing 3^(2^L) for the p-1 Gerbicz check.\n",ierr,returnMlucasErrCode(ierr)); mlucas_fprint(cbuf,0); ASSERT(0,cbuf); }
+					g3_L = (uint32)ITERS_BETWEEN_GCHECK_UPDATES;
+				}
+				ierr = pm1_gcheck_apply(d, c, g2, u0, g3, gchk_H, gchk_bits, gchk_bits_len, n, p, func_mod_square, scrnFlag, &tdif2);
 				if(ierr) {
 					snprintf(cbuf,sizeof(cbuf),"Unhandled Error of type[%u] = %s in p-1 Gerbicz-check correction step - please report this with the p*.stat file attached.\n",ierr,returnMlucasErrCode(ierr));
 					mlucas_fprint(cbuf,0); ASSERT(0,cbuf);
@@ -3031,19 +3098,39 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 			even, so J(3^E | N) must be +1. This guards the FP->integer conversion path, which the Gerbicz check cannot
 			see (both of its operands go through it). A failure here means a corrupt final residue; stop rather than
 			hand it on - the p/q savefiles are intact and a restart re-reads and re-checks them: */
-			if(JACOBI_CHECK && jacobi_check_available()) {
-				jsym = jacobi_check(p, arrtmp, j, 0, &jchk_tsec);
-				if(jsym == 1) {
-					snprintf(cbuf,sizeof(cbuf), "Stage 1 final residue passed the Jacobi check (%.1f sec).\n",jchk_tsec);
-					mlucas_fprint(cbuf,1);
-				} else {
-					NERR_JACOBI++;
-					snprintf(cbuf,sizeof(cbuf), "Stage 1 final residue FAILED the Jacobi check (symbol = %d, expected +1, %.1f sec): the residue handed to the GCD is corrupt. Aborting before the GCD; %s savefiles left in place - restarting re-reads and re-checks them.\n",jsym,jchk_tsec,PSTRING);
-					mlucas_fprint(cbuf,1); ASSERT(0,cbuf);
+			{
+				int jthr_started = 0, jchk_on = JACOBI_CHECK && jacobi_check_available();
+				struct jacobi_thread_args jargs = { p, 0x0, (uint32)j, 0, 0.0 };
+			  #if defined(MULTITHREAD) && defined(USE_PTHREAD)
+				pthread_t jthr;
+				/* Overlap the check with the GCD: it needs the residue *before* the -1 below, so give the thread its own
+				copy in c[] (free scratch at this point; absent in LowMem = 2, where the check runs inline instead): */
+				if(jchk_on && c_uint64_ptr != 0x0) {
+					memcpy(c_uint64_ptr, arrtmp, j*sizeof(uint64));	jargs.res = c_uint64_ptr;
+					jthr_started = (pthread_create(&jthr, 0x0, jacobi_thread_main, &jargs) == 0);
+				}
+			  #endif
+				if(jchk_on && !jthr_started) { jargs.jsym = jacobi_check(p, arrtmp, j, 0, &jargs.tsec); }
+				arrtmp[0] -= 1;	// S1 GCD needs residue-1
+				i = gcd(1,p,arrtmp,0x0,j,gcd_str);	// 1st arg = stage just completed
+			  #if defined(MULTITHREAD) && defined(USE_PTHREAD)
+				if(jthr_started) pthread_join(jthr, 0x0);
+			  #endif
+				/* A wrong residue cannot produce a false factor - any nontrivial gcd(res-1, N) divides N - so acting on the GCD
+				before the verdict is safe; a failed check still stops the run, since the residue also goes to .s1 and to any
+				later stage 2: */
+				if(jchk_on) {
+					jsym = jargs.jsym; jchk_tsec = jargs.tsec;
+					if(jsym == 1) {
+						snprintf(cbuf,sizeof(cbuf), "Stage 1 final residue passed the Jacobi check (%.1f sec%s).\n",jchk_tsec,jthr_started ? ", overlapped with the GCD" : "");
+						mlucas_fprint(cbuf,1);
+					} else {
+						NERR_JACOBI++;
+						snprintf(cbuf,sizeof(cbuf), "Stage 1 final residue FAILED the Jacobi check (symbol = %d, expected +1, %.1f sec): the residue handed to the GCD is corrupt. Aborting; %s savefiles left in place - restarting re-reads and re-checks them.\n",jsym,jchk_tsec,PSTRING);
+						mlucas_fprint(cbuf,1); ASSERT(0,cbuf);
+					}
 				}
 			}
-			arrtmp[0] -= 1;	// S1 GCD needs residue-1
-			i = gcd(1,p,arrtmp,0x0,j,gcd_str);	// 1st arg = stage just completed
 			// If factor found, gcd() will have done needed status-file-writes:
 			if(i || B2 <= B1) {	// Need to also account for the possibility of no-stage-2, in which case B2 <= B1
 				// Write JSON output and go to next assignment:
@@ -7431,17 +7518,18 @@ int jacobi_check(uint64 p, const uint64 *res, uint32 nlimb, uint32 sub, double *
 
 /*********************/
 
-/* v21: p-1 stage 1 Gerbicz check - apply the correction factor to the L-times-squared check-product copy d[]:
+/* v21: p-1 stage 1 Gerbicz check - the correction factor. See the "Gerbicz check for p-1 stage 1" comment in
+ernstMain(): b == u0 * d^(2^L) * 3^C, C = sum over the blocks of the current epoch of the L-bit exponent chunk
+consumed in each. Split C = H * 2^L + Lo:
 
-	d <- d * u0 * 3^C  (mod N),   C = sum over the blocks of the current epoch of the L-bit exponent chunk consumed in each,
+  pm1_gcheck_prepare(): computes C from PM1_S1_PRODUCT and fills the private bit array so that the L verification
+      squarings of d[] - which read multiply-by-base bit (iter-1) % ITERS_BETWEEN_CHECKPOINTS for iterations
+      gchk_iter+1 .. gchk_iter+L - apply exactly Lo, i.e. yield d^(2^L) * 3^Lo for free. Returns H (< #blocks).
+  pm1_gcheck_g3():      g3 = FFT(3^(2^L)), computed once per run (L squarings against a zeroed bit array).
+  pm1_gcheck_apply():   d <- d * u0 * g3^H, with g3^H by left-to-right powering from 1 (~2 log2 H modmuls), every
+      modmul against the zeroed private array. On exit d[] is pure-int.
 
-see the "Gerbicz check for p-1 stage 1" comment in ernstMain(). Inputs: d[] pure-int (as left by its L squarings);
-c[], g2[] scratch; u0[] the epoch seed residue, pure-int; bits[] (nbits limbs) the private multiply-by-base bit array;
-gchk_iter the check iteration. 3^C is computed by left-to-right binary powering with the stage 1 machinery itself -
-seed 3, then one squaring per bit of C below its leading 1 with a multiply-by-3 wherever that bit is 1, the bits fed
-through bits[] exactly as the stage 1 exponent bits are, in windows of ITERS_BETWEEN_CHECKPOINTS. Every modmul here
-runs with BASE_MULTIPLIER_BITS pointed at bits[], so the live exponent bits cannot leak in; the global is restored
-before return. Returns 0 or a func_mod_square() error code. On exit d[] is pure-int.
+Every one of these runs with BASE_MULTIPLIER_BITS pointed at bits[] and restores it before returning.
 */
 /* y[0..ylen) = bits [bitoff, bitoff + 64*ylen) of the xlen-limb vector x[], zero-filled past its end: */
 static void get_bit_window(const uint64 x[], uint32 xlen, uint64 bitoff, uint64 y[], uint32 ylen)
@@ -7454,22 +7542,19 @@ static void get_bit_window(const uint64 x[], uint32 xlen, uint64 bitoff, uint64 
 	}
 }
 
-int pm1_gcheck_correction(double d[], double c[], double g2[], double u0[], uint64 bits[], uint32 nbits, uint32 gchk_iter, int n, uint64 p,
-	int (*func_mod_square)(double [], int [], int, int, int, uint64, uint64, int, double *, int, double *), int scrnFlag, double *tdiff)
+uint64 pm1_gcheck_prepare(uint32 gchk_iter, uint64 bits[], uint32 nbits)
 {
 	const uint32 L = ITERS_BETWEEN_GCHECK_UPDATES, CI = ITERS_BETWEEN_CHECKPOINTS;
 	const uint32 clen = ((L + 64 + 63) >> 6) + 2;	// limbs for C: C < (#blocks) * 2^L, #blocks < 2^32
-	uint64 *C = 0x0, *chunk = 0x0, *bmb_save = BASE_MULTIPLIER_BITS;
-	uint32 i,k,k0,k1,nbits_C,nsq,done,todo,plen;
-	int ierr = 0;
-	const int nbytes_dbl = n*sizeof(double);
-	ASSERT(RES_SHIFT == 0ull, "pm1_gcheck_correction(): p-1 stage 1 runs unshifted!");
-	ASSERT(gchk_iter % L == 0 && PM1_GCHECK_EPOCH_START % L == 0 && gchk_iter > PM1_GCHECK_EPOCH_START, "pm1_gcheck_correction(): check iteration and epoch start must be block-aligned!");
-	ASSERT(nbits*64 >= CI + 64, "pm1_gcheck_correction(): bit array too small!");
+	uint64 *C, *chunk, H;
+	uint32 i,k,k0,k1,plen,off;
+	ASSERT(RES_SHIFT == 0ull, "pm1_gcheck_prepare(): p-1 stage 1 runs unshifted!");
+	ASSERT(gchk_iter % L == 0 && PM1_GCHECK_EPOCH_START % L == 0 && gchk_iter > PM1_GCHECK_EPOCH_START, "pm1_gcheck_prepare(): check iteration and epoch start must be block-aligned!");
+	ASSERT(nbits*64 >= CI + 64, "pm1_gcheck_prepare(): bit array too small!");
 	C = (uint64 *)calloc(clen, sizeof(uint64));	chunk = (uint64 *)calloc(clen, sizeof(uint64));
-	ASSERT(C && chunk, "pm1_gcheck_correction(): calloc failed!");
-	// C = sum of the chunks: block k consumed bits [kL, (k+1)L) of the bit-reversed product, first-consumed bit most significant,
-	// so each chunk is the L-bit window read out and bit-reversed:
+	ASSERT(C && chunk, "pm1_gcheck_prepare(): calloc failed!");
+	// C = sum of the chunks: block k consumed bits [kL, (k+1)L) of the bit-reversed product, first-consumed bit most
+	// significant, so each chunk is the L-bit window read out and bit-reversed:
 	plen = (PM1_S1_PROD_BITS + 63) >> 6;
 	k0 = PM1_GCHECK_EPOCH_START / L;	k1 = gchk_iter / L;
 	for(k = k0; k < k1; k++) {
@@ -7479,39 +7564,72 @@ int pm1_gcheck_correction(double d[], double c[], double g2[], double u0[], uint
 		mi64_brev(chunk, L);
 		mi64_add(C, chunk, C, clen);	// cannot overflow: clen has 64+ spare bits
 	}
-	// g2 = 3^C by LR binary powering: g2 = 3, then for each bit of C below the leading one, MSB first: g2 = g2^2 * 3^bit.
-	memset(g2, 0, nbytes_dbl);	g2[0] = 1.0;	// C == 0: 3^0 = 1
-	nbits_C = mi64_getlen(C, clen);	nbits_C = (nbits_C) ? nbits_C*64 - mi64_leadz(C, nbits_C) : 0;
-	if(nbits_C) {
-		g2[0] = 3.0;
-		nsq = nbits_C - 1;	// squarings = bits below the leading one
-		// Iteration t (1-based) consumes bit index t-1 of the fed array and must see bit (nbits_C-1-t) of C: bit-reverse
-		// C's nbits_C bits (the leading 1 lands at index 0) and drop that index-0 bit:
-		mi64_brev(C, nbits_C);	mi64_shrl(C, C, 1, clen, clen);
-		BASE_MULTIPLIER_BITS = bits;
-		for(done = 0; done < nsq && !ierr; done += todo) {
-			todo = MIN(CI, nsq - done);
-			get_bit_window(C, clen, done, bits, nbits);	// bits[0..] = the next window of exponent bits
-			if(todo & 63) bits[todo>>6] &= ~(-1ull << (todo & 63));
-			for(i = (todo+63)>>6; i < nbits; i++) bits[i] = 0ull;
-			// Iterations 1..todo read bit indices 0..todo-1 - pure-int in and out (mode_flag 0), as the stage 1 intervals do:
-			ierr = func_mod_square(g2, 0x0, n, 0, (int)todo, 0ull, p, scrnFlag, tdiff, FALSE, 0x0);
-		}
-		BASE_MULTIPLIER_BITS = bmb_save;
-		if(ierr) goto DONE;
+	// Lo = C mod 2^L goes into the bit array: squaring t (1-based) reads index off + t-1 and must apply bit (L-t) of Lo,
+	// i.e. index off+i gets bit L-1-i - the low L bits of C, bit-reversed, at offset off = gchk_iter % CI (nonzero only
+	// for the end-of-run check at a block boundary that is not a checkpoint boundary):
+	off = gchk_iter % CI;	ASSERT(off + L <= CI, "pm1_gcheck_prepare(): Lo window overruns the bit array!");
+	mi64_clear(bits, nbits);
+	for(i = 0; i < L; i++) {
+		uint32 sb = L-1-i;
+		if((C[sb>>6] >> (sb&63)) & 1ull) bits[(off+i)>>6] |= 1ull << ((off+i)&63);
 	}
-	// c = u0 * g2, d = d * c, both with a zeroed bit array so the carry step applies no multiply-by-base:
-	BASE_MULTIPLIER_BITS = bits;	mi64_clear(bits, nbits);
-	ierr = func_mod_square(g2, 0x0, n, 0,1, 4ull, p, scrnFlag, tdiff, FALSE, 0x0);	if(ierr) goto RESTORE;	// g2 <- FFT(g2)
-	memcpy(c, u0, nbytes_dbl);
-	ierr = func_mod_square(c,  0x0, n, 0,1, (uint64)g2, p, scrnFlag, tdiff, FALSE, 0x0);	if(ierr) goto RESTORE;	// c = u0 * 3^C, pure-int
+	// H = C >> L, as a uint64 (C < #blocks * 2^L with #blocks < 2^32):
+	get_bit_window(C, clen, L, chunk, 2);	H = chunk[0];
+	ASSERT(chunk[1] == 0ull, "pm1_gcheck_prepare(): C >> L does not fit in 64 bits!");
+	free(C); free(chunk);
+	return H;
+}
+
+/* v21: the end-of-stage-1 Jacobi check runs on its own thread while the main thread does the GCD - both are GMP
+work on independent objects, and at 332M bits the check (~150 s) hides behind the GCD (~130 s) plus the ensuing
+modular inverse. The verdict is joined before the GCD result is acted on: */
+void *jacobi_thread_main(void *arg) {
+	struct jacobi_thread_args *a = (struct jacobi_thread_args *)arg;
+	a->jsym = jacobi_check(a->p, a->res, a->nlimb, 0, &a->tsec);
+	return 0x0;
+}
+
+int pm1_gcheck_g3(double g3[], uint64 bits[], uint32 nbits, int n, uint64 p,
+	int (*func_mod_square)(double [], int [], int, int, int, uint64, uint64, int, double *, int, double *), int scrnFlag, double *tdiff)
+{
+	const uint32 L = ITERS_BETWEEN_GCHECK_UPDATES;
+	uint64 *bmb_save = BASE_MULTIPLIER_BITS;
+	int ierr;
+	ASSERT(L <= (uint32)ITERS_BETWEEN_CHECKPOINTS, "pm1_gcheck_g3(): L exceeds CheckInterval!");
+	memset(g3, 0, n*sizeof(double));	g3[0] = 3.0;
+	mi64_clear(bits, nbits);	BASE_MULTIPLIER_BITS = bits;
+	ierr = func_mod_square(g3, 0x0, n, 0, (int)L, 0ull, p, scrnFlag, tdiff, FALSE, 0x0);	// g3 = 3^(2^L), pure-int (iterations 1..L read zeroed bits 0..L-1)
+	if(!ierr) ierr = func_mod_square(g3, 0x0, n, 0,1, 4ull, p, scrnFlag, tdiff, FALSE, 0x0);	// g3 <- FFT(g3)
+	BASE_MULTIPLIER_BITS = bmb_save;
+	return ierr;
+}
+
+int pm1_gcheck_apply(double d[], double c[], double g2[], double u0[], double g3[], uint64 H, uint64 bits[], uint32 nbits, int n, uint64 p,
+	int (*func_mod_square)(double [], int [], int, int, int, uint64, uint64, int, double *, int, double *), int scrnFlag, double *tdiff)
+{
+	uint64 *bmb_save = BASE_MULTIPLIER_BITS;
+	const int nbytes_dbl = n*sizeof(double);
+	int ierr = 0, b;
+	mi64_clear(bits, nbits);	BASE_MULTIPLIER_BITS = bits;	// no multiply-by-base in any of the modmuls below
+	if(H) {
+		// g2 = g3^H by LR powering from 1 over all bits of H: g2 = g2^2, then g2 *= g3 where the bit is set:
+		memset(g2, 0, nbytes_dbl);	g2[0] = 1.0;
+		for(b = 63 - (int)leadz64(H); b >= 0 && !ierr; b--) {
+			ierr = func_mod_square(g2, 0x0, n, 0,1, 0ull, p, scrnFlag, tdiff, FALSE, 0x0);
+			if(!ierr && ((H >> b) & 1ull)) ierr = func_mod_square(g2, 0x0, n, 0,1, (uint64)g3, p, scrnFlag, tdiff, FALSE, 0x0);
+		}
+		if(ierr) goto RESTORE;
+		ierr = func_mod_square(g2, 0x0, n, 0,1, 4ull, p, scrnFlag, tdiff, FALSE, 0x0);	if(ierr) goto RESTORE;	// g2 <- FFT(g2)
+		memcpy(c, u0, nbytes_dbl);
+		ierr = func_mod_square(c,  0x0, n, 0,1, (uint64)g2, p, scrnFlag, tdiff, FALSE, 0x0);	if(ierr) goto RESTORE;	// c = u0 * g3^H, pure-int
+	} else {
+		memcpy(c, u0, nbytes_dbl);	// H == 0: the correction is just u0
+	}
 	ierr = func_mod_square(c,  0x0, n, 0,1, 4ull, p, scrnFlag, tdiff, FALSE, 0x0);	if(ierr) goto RESTORE;	// c <- FFT(c)
 	ierr = func_mod_square(d,  0x0, n, 0,1, (uint64)c, p, scrnFlag, tdiff, FALSE, 0x0);	// d = d * c, pure-int
 RESTORE:
 	BASE_MULTIPLIER_BITS = bmb_save;
-DONE:
-	free(C); free(chunk);
-	ASSERT(BASE_MULTIPLIER_BITS == bmb_save, "pm1_gcheck_correction(): BASE_MULTIPLIER_BITS not restored!");
+	ASSERT(BASE_MULTIPLIER_BITS == bmb_save, "pm1_gcheck_apply(): BASE_MULTIPLIER_BITS not restored!");
 	return ierr;
 }
 

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -2319,7 +2319,7 @@ READ_RESTART_FILE:
 		fp = mlucas_fopen(RESTARTFILE, "wb");
 		if(fp) {		// In the non-PRP-test case, write_ppm1_savefiles() treats the latter 4 args as null:
 			write_ppm1_savefiles(RESTARTFILE,p,n,fp, itmp64, (uint8 *)arrtmp,Res64,Res35m1,Res36m1, (uint8 *)e_uint64_ptr,i1,i2,i3);
-			fclose(fp); fp = 0x0;
+			close_savefile(RESTARTFILE,fp); fp = 0x0;
 			/* If we're on the primary restart file, set up for secondary: */
 			if(RESTARTFILE[0] != 'q') {
 				RESTARTFILE[0] = 'q';	goto WRITE_RESTART_FILE;
@@ -2345,7 +2345,7 @@ READ_RESTART_FILE:
 				fp = mlucas_fopen(g_cstr, "wb");
 				if(fp) {
 					write_ppm1_savefiles(g_cstr,p,n,fp, itmp64, (uint8 *)arrtmp,Res64,Res35m1,Res36m1, (uint8 *)e_uint64_ptr,i1,i2,i3);
-					fclose(fp); fp = 0x0;
+					close_savefile(g_cstr,fp); fp = 0x0;
 				} else {
 					snprintf(cbuf,sizeof(cbuf), "ERROR: unable to open Gerbicz-check savefile %s for write of checkpoint data.\n",g_cstr);
 					mlucas_fprint(cbuf,1);
@@ -5191,6 +5191,77 @@ int test_types_compatible(uint32 t1, uint32 t2)
 		return t1 == t2;
 }
 
+/* v21: Write the [nbyte] low bytes of [val] to *fp, low byte first, returning 0 if any of the writes
+fails. Prior to v21 every fixed-width savefile field was written using unchecked fputc(), so a write
+error - a filesystem which has just filled up being the realistic case - silently truncated the
+savefile. And since the secondary savefile gets written immediately afterward from the same in-memory
+data, both copies ended up damaged in the same way, with nothing whatsoever printed to screen or
+logfile. Contrast the residue-body fwrite() in write_ppm1_residue(), whose return value has always
+been checked: that one fails loudly and leaves the secondary savefile holding the previous good
+checkpoint, from which the run then restarts cleanly. Same failure, same filesystem - the only
+difference is whether the return value gets looked at, so look at all of them:
+*/
+int write_savefile_field(FILE *fp, const uint64 val, const uint32 nbyte)
+{
+	uint32 i;
+	for(i = 0; i < nbyte; i++) {
+		if(fputc((int)((val >> (8*i)) & 0xff), fp) == EOF)
+			return 0;
+	}
+	return 1;
+}
+
+/* v21: A savefile is only as good as the bytes which actually made it out of the stdio buffer: a
+failed fclose() means buffered data was lost, i.e. exactly the silent-truncation case the checked
+writes above exist to prevent. Treat it the same way - abort while the *other* savefile copy still
+holds the previous good checkpoint, rather than proceed with two damaged copies on disk:
+*/
+void close_savefile(const char *fname, FILE *fp)
+{
+	if(fclose(fp) == EOF) {
+		snprintf(cbuf,sizeof(cbuf),"ERROR: close of savefile %s failed - filesystem full? Aborting rather than leave a silently-truncated savefile.\n",fname);
+		mlucas_fprint(cbuf,0);	ASSERT(0,cbuf);
+	}
+}
+
+/* v21: Several savefile fields were added in later program versions, so a savefile whose data simply
+stops where such a field would begin may be one written by an older version. But it may equally be a
+current-format savefile which a failed write truncated, and prior to v21 the two were conflated: the
+older-format reading was simply assumed, and since that makes read_ppm1_savefiles() return *success*,
+a truncated savefile got accepted and the still-valid backup copy sitting next to it was never even
+consulted. So sanity-check the older-format claim before accepting it - a savefile written by an older
+version ends *exactly* at a format boundary, thus:
+	[1] the EOF must have occurred on the very first byte of the missing field, not partway through it;
+	[2] the file length must exactly equal [expect_len], the length such an older-format savefile has
+	    for this exponent and test type;
+	[3] the run must not need any of the fields which are being skipped: if [need_gcheck] is set the
+	    Gerbicz-check residue is one of them, and no older-format savefile contains it - reading such a
+	    file would leave the G-check accumulator uninitialized.
+Returns 1 if the older-format reading holds up, 0 if the file is simply damaged. [nread] = number of
+bytes the caller's read loop consumed, the one which returned EOF included.
+*/
+int savefile_ends_at(const char *func, const char *fname, FILE *fp, uint32 nread, uint64 expect_len, int need_gcheck)
+{
+	long fsize;
+	if(need_gcheck) {
+		sprintf(cbuf,"%s: savefile %s lacks the Gerbicz-check residue this test type requires.\n",func,fname);
+		fprintf(stderr,"%s", cbuf);	return 0;
+	}
+	if(nread != 1) {	// EOF partway through a field: no version of the program ever wrote such a file
+		sprintf(cbuf,"%s: savefile %s ends in mid-field - truncated, not an older-format savefile.\n",func,fname);
+		fprintf(stderr,"%s", cbuf);	return 0;
+	}
+	if(fseek(fp,0L,SEEK_END) != 0 || (fsize = ftell(fp)) < 0L) {
+		sprintf(cbuf,"%s: Unable to determine length of savefile %s.\n",func,fname);
+		fprintf(stderr,"%s", cbuf);	return 0;
+	}
+	if((uint64)fsize != expect_len) {
+		sprintf(cbuf,"%s: savefile %s is %ld bytes, but an older-format one would be %" PRIu64 " - truncated.\n",func,fname,fsize,expect_len);
+		fprintf(stderr,"%s", cbuf);	return 0;
+	}
+	return 1;
+}
+
 /*** READ: Assumes a valid file pointer has been gotten via a call of the form
 fp = mlucas_fopen(RESTARTFILE,"rb");
 ***/
@@ -5298,6 +5369,16 @@ int read_ppm1_savefiles(const char *fname, uint64 p, uint32 *kblocks, FILE *fp, 
 	const char func[] = "read_ppm1_savefiles";
 	uint32 i,j,k,len,nbytes = 0,nerr;
 	uint64 itmp64, nsquares = 0ull, *avec = (uint64 *)arr1, exp[4],pow[4],rem[4];
+	/* v21: Parse the savefile fields which live in globals into locals, and copy them to the globals
+	only once the read has fully succeeded. Formerly PRP_BASE, NERR_ROE and NERR_GCHECK were written
+	directly, so a *failed* read left them holding fgetc()-EOF garbage (0xFEFEFEFF) which nothing ever
+	restored: if the secondary savefile was unusable too, the ensuing start-from-scratch then ran as a
+	"4278124287-PRP test", and the poisoned error counters got written into every later savefile and
+	reported to the server as a maximal hardware-error code. Init from the globals so that fields which
+	the file does not contain (older formats) are left as-is, exactly as before:
+	*/
+	uint32 prp_base = PRP_BASE, nerr_roe = NERR_ROE, nerr_gcheck = NERR_GCHECK;
+	uint64 res_shift = 0ull, gcheck_shift = GCHECK_SHIFT, len_v17,len_v19;
 	uint128 ui128,vi128; uint192 ui192,vi192; uint256 ui256,vi256;	// Fixed-length 2/3/4-word ints for stashing results of multiword modexp.
 	*Res64 = 0ull;	// 0 value on return indicates failure of some kind
 	mi64_clear(pow,4); mi64_clear(rem,4);
@@ -5356,6 +5437,14 @@ int read_ppm1_savefiles(const char *fname, uint64 p, uint32 *kblocks, FILE *fp, 
 		nbytes = (p>>3) + 1;
 		TRANSFORM_TYPE = RIGHT_ANGLE;
 	}
+	/* v21: Exact lengths of the two historical savefile formats which end short of the current one, used
+	by savefile_ends_at() to tell a legitimately-shorter older-format savefile from a truncated current one:
+		pre-v18: t,m,s header (10 bytes) + residue and its S-H checksum triplet (nbytes+18);
+		    v19: the above + kblocks (3) + RES_SHIFT (8), and if a G-check test, + PRP_BASE (4)
+		         + G-check residue and its checksum triplet (nbytes+18) + GCHECK_SHIFT (8):
+	*/
+	len_v17 = (uint64)nbytes + 28;
+	len_v19 = len_v17 + 11 + (DO_GCHECK ? (uint64)nbytes + 30 : 0ull);
 
 	i = read_ppm1_residue(nbytes, fp, arr1, Res64,Res35m1,Res36m1);
 	if(!i) return 0;
@@ -5452,33 +5541,47 @@ Thus if we use a negative-power algo, to recover 2^p (mod q = 2^k.qodd):
 	for(j = 0; j < 3 && i != EOF; j++) {
 		i = fgetc(fp);	*kblocks += (uint64)i << (8*j);
 	}
-	if(i == EOF) {
+	if(i == EOF) {	// v21: EOF here means either a pre-v18 savefile or a truncated current-format one - which?
 		*kblocks = 0;
-		sprintf(cbuf,"%s: Hit EOF in read of FFT-kblocks ... assuming a pre-v18 savefile.\n",func); fprintf(stderr,"%s", cbuf); return 1;
+		if(!savefile_ends_at(func,fname,fp,j,len_v17,DO_GCHECK)) return 0;
+		sprintf(cbuf,"%s: Hit EOF in read of FFT-kblocks in savefile %s ... assuming a pre-v18 savefile.\n",func,fname); mlucas_fprint(cbuf,1);
+		goto SAVEFILE_READ_DONE;
 	}
 	/* May 2018: 8 bytes for circular-shift to apply to the (unshifted) residue read from the file: */
-	i = 0; RES_SHIFT = 0ull;
+	i = 0;
 	for(j = 0; j < 8 && i != EOF; j++) {
-		i = fgetc(fp);	RES_SHIFT += (uint64)i << (8*j);
+		i = fgetc(fp);	res_shift += (uint64)i << (8*j);
 	}
 	if(i == EOF) {
-		RES_SHIFT = 0ull;
-		sprintf(cbuf,"%s: Hit EOF in read of FFT-kblocks ... assuming a pre-v18 savefile.\n",func); fprintf(stderr,"%s", cbuf); return 1;
+		res_shift = 0ull;
+		if(!savefile_ends_at(func,fname,fp,j,len_v17+3,DO_GCHECK)) return 0;
+		sprintf(cbuf,"%s: Hit EOF in read of residue-shift in savefile %s ... assuming a pre-v18 savefile.\n",func,fname); mlucas_fprint(cbuf,1);
+		goto SAVEFILE_READ_DONE;
 	}
 
   // v19: For PRP-tests, also read a second Gerbicz-check residue array [arr2] and associated S-H checksum triplet [i1,i2,i3]:
   if(DO_GCHECK) {	// v21: Change to key off DO_GCHECK, to allow Fermat-mod Pepin-tests to use the Gerbicz check, too
 	ASSERT(arr2 != 0x0, "Null arr2 pointer!");
-	PRP_BASE = 0ull;
+	prp_base = 0;
 	for(j = 0; j < 4; j++) {
-		i = fgetc(fp);	PRP_BASE += i << (8*j);
+		i = fgetc(fp);
+		if(i == EOF) {	// v21: Formerly unchecked, leaving PRP_BASE = 0xFEFEFEFF on a failed read
+			sprintf(cbuf, "%s: Hit EOF in read of PRP-base in savefile %s!\n",func,fname);
+			fprintf(stderr,"%s", cbuf);	return 0;
+		}
+		prp_base += i << (8*j);
 	}
 	i = read_ppm1_residue(nbytes, fp, arr2, i1,i2,i3);
 	if(!i) return 0;
 	// G-check residues all need to be clshifted by residue-shift count at the ITERS_BETWEEN_GCHECK_UPDATESth PRP-test iteration:
-	GCHECK_SHIFT = 0ull;
+	gcheck_shift = 0ull;
 	for(j = 0; j < 8; j++) {
-		i = fgetc(fp);	GCHECK_SHIFT += (uint64)i << (8*j);
+		i = fgetc(fp);
+		if(i == EOF) {	// v21: ditto for GCHECK_SHIFT
+			sprintf(cbuf, "%s: Hit EOF in read of G-check residue-shift in savefile %s!\n",func,fname);
+			fprintf(stderr,"%s", cbuf);	return 0;
+		}
+		gcheck_shift += (uint64)i << (8*j);
 	}
   }
 
@@ -5488,25 +5591,39 @@ Thus if we use a negative-power algo, to recover 2^p (mod q = 2^k.qodd):
 	for(j = 0; j < 4; j++) {
 		i = fgetc(fp);
 		if(i == EOF) {
-			if(!j) {
-				sprintf(cbuf, "%s: Restart from v19 savefile - will start tracking #errors encountered at this point.\n",func);
-				fprintf(stderr,"%s", cbuf);
-				return 1;
+			if(!j) {	// v21: As above, only believe "older-format savefile" if the file length says so:
+				if(!savefile_ends_at(func,fname,fp,1,len_v19,FALSE)) return 0;
+				sprintf(cbuf, "%s: Restart from v19 savefile %s - will start tracking #errors encountered at this point.\n",func,fname);
+				mlucas_fprint(cbuf,1);
+				goto SAVEFILE_READ_DONE;
 			} else {	// If at least the first of the 3 bytes exists, all 3 had better be there:
-				sprintf(cbuf, "%s: Expected 4 nerr bytes!",func);
+				sprintf(cbuf, "%s: Expected 4 nerr bytes in savefile %s!\n",func,fname);
 				fprintf(stderr,"%s", cbuf);
 				return 0;
 			}
 		}
 		nerr += i << (8*j);
 	}
-	NERR_ROE = MAX(nerr,NERR_ROE);	// If restart-from-savefile as result of hitting an ROE, preserve the runtime-incremented value of NERR_ROE:
+	nerr_roe = MAX(nerr,nerr_roe);	// If restart-from-savefile as result of hitting an ROE, preserve the runtime-incremented value of NERR_ROE:
 	// Similar handling for G-check error count:
 	nerr = 0ull;
 	for(j = 0; j < 4; j++) {
-		i = fgetc(fp);	nerr += i << (8*j);
+		i = fgetc(fp);
+		if(i == EOF) {	// v21: This loop formerly had no EOF check at all, so a savefile truncated in its
+			// last 4 bytes read back as NERR_GCHECK = 0xFEFEFEFF = 4278124287 with the read still reporting
+			// success - which then got submitted to the server as error-code 0x00F00000 ("15 Gerbicz errors")
+			// plus a literal "gerbicz":4278124287, even for test types which have no Gerbicz check at all:
+			sprintf(cbuf, "%s: Expected 4 G-check-error-count bytes in savefile %s!\n",func,fname);
+			fprintf(stderr,"%s", cbuf);	return 0;
+		}
+		nerr += i << (8*j);
 	}
-	NERR_GCHECK = MAX(nerr,NERR_GCHECK);
+	nerr_gcheck = MAX(nerr,nerr_gcheck);
+
+SAVEFILE_READ_DONE:
+	// v21: Read succeeded - only now commit the parsed values to their globals:
+	RES_SHIFT = res_shift;	PRP_BASE = prp_base;	GCHECK_SHIFT = gcheck_shift;
+	NERR_ROE = nerr_roe;	NERR_GCHECK = nerr_gcheck;
 	/* Don't deallocate arr1 here, since we'll need it later for savefile writes. */
 	return 1;
 }
@@ -5527,16 +5644,13 @@ void write_ppm1_residue(const uint32 nbytes, FILE *fp, const uint8 arr_tmp[], co
 		snprintf(cbuf,sizeof(cbuf),"%s: Error writing residue to restart file.\n",func);
 		mlucas_fprint(cbuf,0);	ASSERT(0,cbuf);
 	}
-	/* ...and checksums:	*/
-	/* Res64: */
-	for(i = 0; i < 64; i+=8)
-		fputc((int)(Res64 >> i) & 0xff, fp);
-	/* Res35m1: */
-	for(i = 0; i < 40; i+=8)
-		fputc((int)(Res35m1 >> i) & 0xff, fp);
-	/* Res36m1: */
-	for(i = 0; i < 40; i+=8)
-		fputc((int)(Res36m1 >> i) & 0xff, fp);
+	/* ...and checksums (Res64: 8 bytes, Res35m1 and Res36m1: 5 bytes each) - v21: check these writes
+	as well, since a savefile truncated here reads back as an older-format, i.e. valid, one: */
+	if(!write_savefile_field(fp,Res64,8) || !write_savefile_field(fp,Res35m1,5) || !write_savefile_field(fp,Res36m1,5)) {
+		fclose(fp); fp = 0x0;
+		snprintf(cbuf,sizeof(cbuf),"%s: Error writing residue checksums to restart file.\n",func);
+		mlucas_fprint(cbuf,0);	ASSERT(0,cbuf);
+	}
 }
 
 // v20: E.g. distributed deep p-1 S2 may use B2 >= 2^32, so make ihi a uint64; add filename arg since S2 appends '.s2' to RESTARTFILE:
@@ -5550,14 +5664,12 @@ void write_ppm1_savefiles(const char *fname, uint64 p, int n, FILE *fp, uint64 i
 	kblocks = (n >> 10);
 	ASSERT(n == (kblocks << 10),"Not a proper unpadded FFT length");
 
-	/* See the function read_ppm1_savefiles() for the file format here: */
-	/* t: */
-	fputc(TEST_TYPE, fp);
-	/* m: */
-	fputc(MODULUS_TYPE, fp);
-	/* s: */
-	for(i = 0; i < 64; i+=8)
-		fputc((ihi >> i) & 0xff, fp);
+	/* See the function read_ppm1_savefiles() for the file format here. v21: All the fixed-width fields
+	go out through write_savefile_field(), which checks its writes - see the comment on that function: */
+	/* t: */	i  = write_savefile_field(fp,TEST_TYPE   ,1);
+	/* m: */	i &= write_savefile_field(fp,MODULUS_TYPE,1);
+	/* s: */	i &= write_savefile_field(fp,ihi         ,8);
+	if(!i) goto SAVEFILE_WRITE_ERR;
 
 	/* Set the expected number of residue bytes, depending on the modulus: */
 	if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE) {
@@ -5571,27 +5683,31 @@ void write_ppm1_savefiles(const char *fname, uint64 p, int n, FILE *fp, uint64 i
 
 	write_ppm1_residue(nbytes, fp, arr1, Res64,Res35m1,Res36m1);
 
-	// v18: FFT length in K (3 bytes):
-	for(i = 0; i < 24; i+=8)
-		fputc((kblocks >> i) & 0xff, fp);
-	// v18: circular-shift to apply to the (unshifted) residue read from the file (8 bytes):
-	for(i = 0; i < 64; i+=8)
-		fputc((RES_SHIFT >> i) & 0xff, fp);
+	// v18: FFT length in K (3 bytes), then circular-shift to apply to the residue read from the file (8 bytes):
+	i  = write_savefile_field(fp,kblocks  ,3);
+	i &= write_savefile_field(fp,RES_SHIFT,8);
+	if(!i) goto SAVEFILE_WRITE_ERR;
 
   // v19: For PRP-tests, also write a second Gerbicz-check residue array [arr2] and associated S-H checksum triplet [i1,i2,i3]:
   if(DO_GCHECK) {	// v21: Change to key off DO_GCHECK, to allow Fermat-mod Pepin-tests to use the Gerbicz check, too
-	for(i = 0; i < 32; i+=8)
-		fputc((PRP_BASE >> i) & 0xff, fp);
+	if(!write_savefile_field(fp,PRP_BASE,4)) goto SAVEFILE_WRITE_ERR;
 	write_ppm1_residue(nbytes, fp, arr2, i1,i2,i3);
 	// G-check residues all need to be clshifted by residue-shift count at the ITERS_BETWEEN_GCHECK_UPDATESth PRP-test iteration:
-	for(i = 0; i < 64; i+=8)
-		fputc((GCHECK_SHIFT >> i) & 0xff, fp);
+	if(!write_savefile_field(fp,GCHECK_SHIFT,8)) goto SAVEFILE_WRITE_ERR;
   }
 	// v20: Write cumulative #errs for ROE >= 0.4375 (>= for LL, > for PRP) and Gerbicz-check for the test in question:
-	for(i = 0; i < 32; i+=8)
-		fputc((NERR_ROE >> i) & 0xff, fp);
-	for(i = 0; i < 32; i+=8)
-		fputc((NERR_GCHECK >> i) & 0xff, fp);
+	i  = write_savefile_field(fp,NERR_ROE   ,4);
+	i &= write_savefile_field(fp,NERR_GCHECK,4);
+	if(!i) goto SAVEFILE_WRITE_ERR;
+	return;
+
+SAVEFILE_WRITE_ERR:	// v21: Formerly these writes were unchecked, so a full filesystem silently truncated
+	// the savefile - and, the secondary copy being written straight afterward from the same data, both
+	// copies alike. Abort here instead, at which point the *other* copy still holds the previous good
+	// checkpoint, exactly as already happens when the residue-body write above fails:
+	fclose(fp);
+	snprintf(cbuf,sizeof(cbuf),"write_ppm1_savefiles: Error writing savefile %s - filesystem full? Aborting rather than leave a silently-truncated savefile.\n",fname);
+	mlucas_fprint(cbuf,0);	ASSERT(0,cbuf);
 }
 
 /*********************/
@@ -6792,7 +6908,9 @@ int restart_file_valid(const char *fname, const uint64 p, uint8 *arr1, uint8 *ar
 	int retval = 0;
 	uint32 j;
 	uint64 Res64,Res35m1,Res36m1, i1,i2,i3, itmp64;
-	FILE *fptr = mlucas_fopen(fname,"r");
+	// v21: "rb", not "r": read_ppm1_savefiles()'s contract requires binary mode, and on Windows text mode
+	// mangles \r\n pairs and treats an embedded 0x1A as EOF, both of which occur in a bytewise residue:
+	FILE *fptr = mlucas_fopen(fname,"rb");
 	if(fptr) {
 		retval = read_ppm1_savefiles(fname, p, &j, fptr, &itmp64,
 										arr1, &Res64,&Res35m1,&Res36m1,	// Primality-test residue

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -415,7 +415,7 @@ uint32	ernstMain
 	target (p/q, then .J, then .J1, then scratch) and bounds the retries. jchk_file: position in that chain during a
 	restart-file read. jchk_passed: this checkpoint passed, so the .J/.J1 files get updated after the p/q write: */
 	int do_jcheck = FALSE, jchk_passed = FALSE, jchk_file = 0, jsym = 0;
-	uint32 jchk_nfail = 0;
+	uint32 jchk_nfail = 0, jchk_fail_iter = 0;	// jchk_fail_iter: iteration of the last failed check; a pass at or beyond it clears the count
 	double jchk_tlast = 0.0, jchk_tdur = 0.0, jchk_tsec = 0.0;
 	char jchk_fname[STR_MAX_LEN];
 	/* Exponent of number to be tested - note that for trial-factoring, we represent p
@@ -480,7 +480,7 @@ RANGE_BEG:
 								// during test - if a restart, will re-read actual cumulative values from checkpoint file.
 	gchk_final = FALSE; gchk_nfail = 0;	// v21: End-of-run G-check state. Reset here, i.e. once per assignment - NOT on the
 										// READ_RESTART_FILE rollback path, else a repeating failure could retry without bound.
-	jchk_nfail = 0; jchk_file = 0; jchk_passed = FALSE; jchk_tdur = 0.0; jchk_tlast = getRealTime();	// v21: ditto for the Jacobi check
+	jchk_nfail = 0; jchk_fail_iter = 0; jchk_file = 0; jchk_passed = FALSE; jchk_tdur = 0.0; jchk_tlast = getRealTime();	// v21: ditto for the Jacobi check
 	// Clear out any FFT-radix or known-factor data that might remain from a just-completed run:
 	for(i = 0; i < 10; i++) { RADIX_VEC[i] = 0; }
 	nfac = 0; mi64_clear(KNOWN_FACTORS,40);
@@ -2235,7 +2235,7 @@ READ_RESTART_FILE:
 			}
 			if(fi_iter && !fi_done && ihi == fi_iter && ierr == 0 && !INTERACT) {
 				uint32 fi_j1 = fi_word + ((fi_word >> DAT_BITS) << PAD_BITS);	// padded-array index of digit fi_word
-				a[fi_j1] += 1.0;	fi_done = 1;
+				a[fi_j1] += 1.0;	fi_done = (getenv("MLUCAS_FAULT_REPEAT") == 0x0);	// MLUCAS_FAULT_REPEAT: re-fire on every visit, i.e. a reproducible fault
 				snprintf(cbuf,sizeof(cbuf), "FAULT INJECTION: added 1.0 to residue digit %u at iteration %u.\n",fi_word,ihi);
 				mlucas_fprint(cbuf,1);
 			}
@@ -2308,7 +2308,11 @@ READ_RESTART_FILE:
 				if(jsym == -1) {
 					snprintf(cbuf,sizeof(cbuf), "At iteration %u, shift = %" PRIu64 ": Jacobi check passed (%.1f sec).\n",ihi,RES_SHIFT,jchk_tsec);
 					mlucas_fprint(cbuf,scrnFlag);
-					jchk_nfail = 0; jchk_passed = TRUE;
+					/* Only a pass at or beyond the last failure point clears the failure count: after a rollback the earlier
+					checkpoints pass again on the way back up, and letting them reset the count made a *reproducible* fault at
+					one iteration walk the chain forever (scratch -> passes -> fail -> ... , observed) instead of aborting: */
+					if(ihi >= jchk_fail_iter) jchk_nfail = 0;
+					jchk_passed = TRUE;
 				} else if(jsym == 0) {
 					/* Symbol 0 means gcd(s - 2, M(p)) > 1. Exponents are checked prime when the worktodo entry is parsed (the
 					composite case, where M(q) | M(p) for q | p and the LL sequence collapses mod M(q), never gets here), so for
@@ -2318,7 +2322,7 @@ READ_RESTART_FILE:
 					snprintf(cbuf,sizeof(cbuf), "Jacobi check at iteration %u failed with symbol 0: the residue shares a factor with the modulus, which cannot happen for a correct LL residue of a prime exponent. Aborting rather than retrying; %s savefiles left in place - please check this machine for hardware errors.\n",ihi,PSTRING);
 					mlucas_fprint(cbuf,1); ASSERT(0,cbuf);
 				} else {
-					NERR_JACOBI++; jchk_nfail++;
+					NERR_JACOBI++; jchk_nfail++; jchk_fail_iter = ihi;
 					if(jchk_nfail >= 5) {
 						snprintf(cbuf,sizeof(cbuf), "Jacobi check at iteration %u failed %u times in a row, the last after restarting from scratch - the error is not being cleared by rolling back, so it is not transient. Aborting rather than retrying without bound; %s savefiles left in place. Please check this machine for hardware errors.\n",ihi,jchk_nfail,PSTRING);
 						mlucas_fprint(cbuf,1); ASSERT(0,cbuf);

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -2842,7 +2842,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 		re-using it would kibosh subsequent stage 2 continuation runs. Safer to start with s1 residue for those:
 		*/
 		strcpy(g_cstr, RESTARTFILE); strcat(g_cstr, ".s2");
-		if(remove(g_cstr)) {
+		if(mlucas_remove(g_cstr)) {
 			snprintf(cbuf,sizeof(cbuf),"INFO: Unable to remove stage 2 savefile %s.\n",g_cstr);
 			mlucas_fprint(cbuf,1);
 		}
@@ -2869,7 +2869,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 						snprintf(cbuf,sizeof(cbuf),"ERROR: Primary savefile missing/corrupt, but unable to rename the secondary %s ==> %s ... any ensuing LL/PRP test will overwrite.\n",RESTARTFILE,g_cstr);
 						mlucas_fprint(cbuf,1);
 					}
-				} else if(remove(g_cstr))	// ...otherwise delete the secondary
+				} else if(mlucas_remove(g_cstr))	// ...otherwise delete the secondary
 					fprintf(stderr, "Unable to delete secondary restart file %s.\n",g_cstr);
 			}
 		} else
@@ -2880,7 +2880,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 	}
 	// If completion of LL/PRP run, or secondary was not used as a backup for p-1 stage 1 savefile rename, delete it now:
 	RESTARTFILE[0] = 'q';
-	if(remove(RESTARTFILE))
+	if(mlucas_remove(RESTARTFILE))
 		fprintf(stderr, "Unable to delete secondary restart file %s\n",RESTARTFILE);
 
 	RESTARTFILE[0] = ((MODULUS_TYPE == MODULUS_TYPE_MERSENNE) ? 'p' : 'f');
@@ -2910,7 +2910,7 @@ GET_NEXT_ASSIGNMENT:
 			ASSERT(0,cbuf);
 		}
 		/* Remove any WINI.TMP file that may be present: */
-		remove("WINI.TMP");
+		mlucas_remove("WINI.TMP");
 		fq = mlucas_fopen("WINI.TMP", "w");
 		if(!fq) {
 			sprintf(cbuf, "Unable to open WINI.TMP file for writing.\n");
@@ -3027,7 +3027,7 @@ GET_NEXT_ASSIGNMENT:
 
 			/*...Then remove the WINI.TMP file:	*/
 
-			remove("WINI.TMP");
+			mlucas_remove("WINI.TMP");
 		}
 		/* if one or more exponents left in rangefile, go back for more; otherwise exit. */
 		if (i > 0) {

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -2305,7 +2305,10 @@ READ_RESTART_FILE:
 			sprintf(cbuf, ".%dM", ilo/1000000);
 			strcpy(g_cstr, RESTARTFILE);
 			strcat(g_cstr, cbuf);
-			if(rename(RESTARTFILE, g_cstr)) {
+			// v21: mlucas_rename(), not rename(): the latter ignored MLUCAS_PATH (so under a nonempty prefix it
+			// renamed a nonexistent cwd-relative name and always failed) and cannot replace an existing
+			// destination on Windows. Same for the other rename() calls below:
+			if(mlucas_rename(RESTARTFILE, g_cstr)) {
 				snprintf(cbuf,sizeof(cbuf),"ERROR: unable to rename %s restart file ==> %s ... skipping every-10M-iteration restart file archiving\n",WORKFILE,g_cstr);
 				fprintf(stderr,"%s",cbuf);
 			}
@@ -2316,7 +2319,9 @@ READ_RESTART_FILE:
 		itmp64 = ihi;
 		// If Pepin test is at final iteration, change PRP base to 3 for final write to file (cf. earlier assignment at line 1214). More info: https://github.com/primesearch/Mlucas/pull/11
 		if (ihi == maxiter && TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT) PRP_BASE = 3;
-		fp = mlucas_fopen(RESTARTFILE, "wb");
+		// v21: _atomic: stage the new checkpoint in a scratch file and rename it over the savefile, so that
+		// a crash/kill/power-loss partway through the write cannot leave a truncated savefile behind:
+		fp = mlucas_fopen_atomic(RESTARTFILE, "wb");
 		if(fp) {		// In the non-PRP-test case, write_ppm1_savefiles() treats the latter 4 args as null:
 			write_ppm1_savefiles(RESTARTFILE,p,n,fp, itmp64, (uint8 *)arrtmp,Res64,Res35m1,Res36m1, (uint8 *)e_uint64_ptr,i1,i2,i3);
 			close_savefile(RESTARTFILE,fp); fp = 0x0;
@@ -2342,7 +2347,7 @@ READ_RESTART_FILE:
 			if(ihi%ITERS_BETWEEN_GCHECKS == 0) {
 				strcpy(g_cstr, RESTARTFILE);
 				strcat(g_cstr, ".G");
-				fp = mlucas_fopen(g_cstr, "wb");
+				fp = mlucas_fopen_atomic(g_cstr, "wb");	// v21: atomic-replace, as for the p/q savefiles above
 				if(fp) {
 					write_ppm1_savefiles(g_cstr,p,n,fp, itmp64, (uint8 *)arrtmp,Res64,Res35m1,Res36m1, (uint8 *)e_uint64_ptr,i1,i2,i3);
 					close_savefile(g_cstr,fp); fp = 0x0;
@@ -2852,7 +2857,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 			// If end of a regular (non-s2-continuation) p-1 run and primary good, rename it from [p|f][expo] ==> [p|f][expo].s1;
 			// if primary missing/corrupt, rename secondary q[expo] ==> [p|f][expo].s1:
 			if(TEST_TYPE == TEST_TYPE_PM1 && !s2_continuation) {
-				if(rename(RESTARTFILE, g_cstr)) {
+				if(mlucas_rename(RESTARTFILE, g_cstr)) {
 					snprintf(cbuf,sizeof(cbuf),"ERROR: unable to rename the p-1 stage 1 savefile %s ==> %s ... any ensuing LL/PRP test will overwrite.\n",RESTARTFILE,g_cstr);
 					mlucas_fprint(cbuf,1);
 				}
@@ -2860,7 +2865,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 				// If primary was missing/corrupt, i.e. we're on the secondary, rename secondary to primary-name
 				if(RESTARTFILE[0] == 'q') {
 					RESTARTFILE[0] = ((MODULUS_TYPE == MODULUS_TYPE_MERSENNE) ? 'p' : 'f');
-					if(rename(g_cstr, RESTARTFILE)) {
+					if(mlucas_rename(g_cstr, RESTARTFILE)) {
 						snprintf(cbuf,sizeof(cbuf),"ERROR: Primary savefile missing/corrupt, but unable to rename the secondary %s ==> %s ... any ensuing LL/PRP test will overwrite.\n",RESTARTFILE,g_cstr);
 						mlucas_fprint(cbuf,1);
 					}
@@ -2992,8 +2997,12 @@ GET_NEXT_ASSIGNMENT:
 		fclose(fq); fq = 0x0;
 
 		/* Now blow away the old worktodo file and rename WINI.TMP ==> worktodo.txt...	*/
-		remove(WORKFILE);
-		if(rename("WINI.TMP", WORKFILE))
+		// v21: A single atomic rename replaces the former remove()-then-rename() pair, which on POSIX left a
+		// window in which the worktodo file did not exist at all - a crash there lost the entire assignment
+		// list. mlucas_rename() also supplies the MLUCAS_PATH prefix which the bare rename() omitted (both files
+		// having been *created* through mlucas_fopen(), which prefixes) and the replace-existing semantics which
+		// the Windows CRT rename() lacks - the very reason the remove() was there in the first place:
+		if(mlucas_rename("WINI.TMP", WORKFILE))
 		{
 			sprintf(cbuf,"ERROR: unable to rename WINI.TMP file ==> %s ... attempting line-by-line copy instead.\n",WORKFILE);
 			fprintf(stderr,"%s",cbuf);
@@ -5218,7 +5227,7 @@ holds the previous good checkpoint, rather than proceed with two damaged copies 
 */
 void close_savefile(const char *fname, FILE *fp)
 {
-	if(fclose(fp) == EOF) {
+	if(mlucas_fclose_atomic(fname,fp)) {
 		snprintf(cbuf,sizeof(cbuf),"ERROR: close of savefile %s failed - filesystem full? Aborting rather than leave a silently-truncated savefile.\n",fname);
 		mlucas_fprint(cbuf,0);	ASSERT(0,cbuf);
 	}

--- a/src/Mlucas.h
+++ b/src/Mlucas.h
@@ -94,6 +94,9 @@ uint32	Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[
 	int	(*func_mod_square)(double [], int [], int, int, int, uint64, uint64, int, double *, int, double *),
 	int n, int scrnFlag, double *tdiff, char *const gcd_str);
 int		test_types_compatible(uint32 t1, uint32 t2);
+int		write_savefile_field(FILE *fp, const uint64 val, const uint32 nbyte);
+void	close_savefile(const char *fname, FILE *fp);
+int		savefile_ends_at(const char *func, const char *fname, FILE *fp, uint32 nread, uint64 expect_len, int need_gcheck);
 int		 read_ppm1_residue(const uint32 nbytes, FILE *fp,       uint8 arr_tmp[],       uint64 *Res64,       uint64 *Res35m1,       uint64 *Res36m1);
 void	write_ppm1_residue(const uint32 nbytes, FILE *fp, const uint8 arr_tmp[], const uint64 Res64, const uint64 Res35m1, const uint64 Res36m1);
 int		 read_ppm1_savefiles(const char *fname, uint64 p, uint32 *kblocks, FILE *fp, uint64 *ilo, uint8 arr1[], uint64 *Res64, uint64 *Res35m1, uint64 *Res36m1, uint8 arr2[], uint64 *i1, uint64 *i2, uint64 *i3);

--- a/src/Mlucas.h
+++ b/src/Mlucas.h
@@ -114,6 +114,9 @@ void dif1_dit1_func_name(
 uint32	extract_known_factors(uint64 p, char *fac_start);
 uint32	gcd(uint32 stage, uint64 p, uint64 *vec1, uint64 *vec2, uint32 nlimb, char *const gcd_str);
 void	modinv(uint64 p, uint64 *vec1, uint64 *vec2, uint32 nlimb);
+#define JACOBI_UNAVAILABLE	2	// v21: jacobi_check() return value when built without a usable GMP
+int		jacobi_check_available(void);
+int		jacobi_check(uint64 p, const uint64 *res, uint32 nlimb, uint32 sub, double *tsec);
 int		restart_file_valid(const char *fname, const uint64 p, uint8 *arr1, uint8 *arr2);
 uint32	filegrep(const char *fname, const char *find_str, char *p_cstr, uint32 find_before_line_number);
 void	write_fft_debug_data(double a[], int jlo, int jhi);

--- a/src/Mlucas.h
+++ b/src/Mlucas.h
@@ -117,7 +117,12 @@ void	modinv(uint64 p, uint64 *vec1, uint64 *vec2, uint32 nlimb);
 #define JACOBI_UNAVAILABLE	2	// v21: jacobi_check() return value when built without a usable GMP
 int		jacobi_check_available(void);
 int		jacobi_check(uint64 p, const uint64 *res, uint32 nlimb, uint32 sub, double *tsec);
-int		pm1_gcheck_correction(double d[], double c[], double g2[], double u0[], uint64 bits[], uint32 nbits, uint32 gchk_iter, int n, uint64 p,
+uint64	pm1_gcheck_prepare(uint32 gchk_iter, uint64 bits[], uint32 nbits);
+struct jacobi_thread_args { uint64 p; const uint64 *res; uint32 nlimb; int jsym; double tsec; };	// v21: end-of-stage-1 Jacobi check on its own thread
+void	*jacobi_thread_main(void *arg);
+int		pm1_gcheck_g3(double g3[], uint64 bits[], uint32 nbits, int n, uint64 p,
+			int (*func_mod_square)(double [], int [], int, int, int, uint64, uint64, int, double *, int, double *), int scrnFlag, double *tdiff);
+int		pm1_gcheck_apply(double d[], double c[], double g2[], double u0[], double g3[], uint64 H, uint64 bits[], uint32 nbits, int n, uint64 p,
 			int (*func_mod_square)(double [], int [], int, int, int, uint64, uint64, int, double *, int, double *), int scrnFlag, double *tdiff);
 int		restart_file_valid(const char *fname, const uint64 p, uint8 *arr1, uint8 *arr2);
 uint32	filegrep(const char *fname, const char *find_str, char *p_cstr, uint32 find_before_line_number);

--- a/src/Mlucas.h
+++ b/src/Mlucas.h
@@ -117,6 +117,8 @@ void	modinv(uint64 p, uint64 *vec1, uint64 *vec2, uint32 nlimb);
 #define JACOBI_UNAVAILABLE	2	// v21: jacobi_check() return value when built without a usable GMP
 int		jacobi_check_available(void);
 int		jacobi_check(uint64 p, const uint64 *res, uint32 nlimb, uint32 sub, double *tsec);
+int		pm1_gcheck_correction(double d[], double c[], double g2[], double u0[], uint64 bits[], uint32 nbits, uint32 gchk_iter, int n, uint64 p,
+			int (*func_mod_square)(double [], int [], int, int, int, uint64, uint64, int, double *, int, double *), int scrnFlag, double *tdiff);
 int		restart_file_valid(const char *fname, const uint64 p, uint8 *arr1, uint8 *arr2);
 uint32	filegrep(const char *fname, const char *find_str, char *p_cstr, uint32 find_before_line_number);
 void	write_fft_debug_data(double a[], int jlo, int jhi);

--- a/src/factor.c
+++ b/src/factor.c
@@ -4101,7 +4101,9 @@ MFACTOR_HELP:
 			}
 			if(fp) { fclose(fp); fp = 0x0; }
 			fclose(fq); fq = 0x0;
-			if(rename(TMPFILE,RESTARTFILE)) {
+			// v21: mlucas_rename(), not rename(): supplies the MLUCAS_PATH prefix both files were created with,
+			// and replaces an existing destination on Windows, whose CRT rename() fails with EEXIST instead:
+			if(mlucas_rename(TMPFILE,RESTARTFILE)) {
 				sprintf(g_cstr,"ERROR: unable to rename %s file ==> %s.\n",TMPFILE,RESTARTFILE);
 				ASSERT(0,g_cstr);
 			}
@@ -4724,8 +4726,10 @@ uint64 kmin, uint64 know, uint64 kmax, uint32 passmin, uint32 passnow, uint32 pa
 {
 	int itmp;
 	uint32 curr_line = 0, nerr = 0;
-	/* TF restart files are in HRF, not binary: */
-	fp = mlucas_fopen(fname,"w");	// Open in write mode
+	/* TF restart files are in HRF, not binary. v21: _atomic - stage the new contents in a scratch file and
+	rename it over the target, so that a crash partway through this write cannot leave a truncated savefile
+	where a complete one used to be: */
+	fp = mlucas_fopen_atomic(fname,"w");	// Open in write mode
 	if(!fp) {
 	#ifndef FACTOR_STANDALONE
 		fp = mlucas_fopen(STATFILE,"a");
@@ -4790,7 +4794,14 @@ uint64 kmin, uint64 know, uint64 kmax, uint32 passmin, uint32 passnow, uint32 pa
 		if(itmp <= 0) {
 			++nerr; fprintf(stderr,"ERROR: unable to write Line %d (#Q tried) of factoring restart file %s!\n",curr_line,fname);
 		}
-		fclose(fp); fp = 0x0;
+		// v21: If any of the above writes failed we have nothing worth publishing, so drop the scratch file and
+		// leave any pre-existing savefile alone; otherwise commit it, counting a failure to do so as one more error:
+		if(nerr) {
+			mlucas_discard_atomic(fname,fp);
+		} else if(mlucas_fclose_atomic(fname,fp)) {
+			++nerr; fprintf(stderr,"ERROR: unable to commit factoring restart file %s ... any previous savefile left in place.\n",fname);
+		}
+		fp = 0x0;
 		return (int)nerr;
 	}
 }

--- a/src/get_preferred_fft_radix.c
+++ b/src/get_preferred_fft_radix.c
@@ -192,7 +192,7 @@ uint32	get_preferred_fft_radix(uint32 kblocks)
 								ASSERT(0, cbuf);
 							}
 							kprod >>= 10;
-							tbest = tcurr;
+							tbest = tcurr;	CFG_MSEC_PER_ITER = tcurr;	// v21: exported for the p-1 Gerbicz-interval default
 							if(i == kblocks) {
 								/* Product of radices must equal complex vector length (n/2): */
 								if(kprod != kblocks) {

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -1502,7 +1502,7 @@ fprintf(stderr,"#1: vec1 = A^+1 checksums = %" PRIu64 ",%" PRIu64 ",%" PRIu64 ";
 		fp = mlucas_fopen(inv_file, "wb");
 		if(fp) {
 			write_ppm1_savefiles(inv_file,p,n,fp, 0ull, (uint8*)vec2,Res64,Res35m1,Res36m1, 0x0,0x0,0x0,0x0);
-			fclose(fp);	fp = 0x0;
+			close_savefile(inv_file,fp);	fp = 0x0;
 		} else {
 			snprintf(cbuf, sizeof(cbuf), "ERROR: unable to open restart file %s for write of checkpoint data.\n",inv_file);
 			mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0,cbuf);
@@ -1757,7 +1757,7 @@ MME = 0;
 	savefile[0] = ((MODULUS_TYPE == MODULUS_TYPE_MERSENNE) ? 'p' : 'f');
 	strcat(savefile, ".s2");
 	// [From the above p-1 savefile schema] 3. On entry, S2 checks for existence of ".s2" savefile:
-	fp = mlucas_fopen(savefile,"r");
+	fp = mlucas_fopen(savefile,"rb");	// v21: the .s2 savefile is binary (written "wb"); text mode mangles it on Windows
 	// o If exists, read nsquares field into uint64 qlo, mask off high byte (which stores the value of any relocation-prime
 	// psmall used for stage 2), compare vs original-assignment B2_start read (or inferred, as B2_start = B1) from worktodo entry:
 	if(fp) {												// G-check residue fields all set NULL in this call:
@@ -2514,7 +2514,7 @@ MME = 0;
 				// q won't get += bigstep until we loop, so here, (q + bigstep) is the q-value corr. to just-incremented k.
 				// Also write any relocation-prime psmall into high bit of the resulting nsquares field:
 				write_ppm1_savefiles(savefile,p,n,fp, ((uint64)psmall<<56) + q + bigstep, (uint8*)arrtmp,Res64,Res35m1,Res36m1, 0x0,0x0,0x0,0x0);
-				fclose(fp);	fp = 0x0;
+				close_savefile(savefile,fp);	fp = 0x0;
 			} else {
 				snprintf(cbuf, sizeof(cbuf), "ERROR: unable to open restart file %s for write of checkpoint data.\n",savefile);
 				mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0,cbuf);

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -78,6 +78,13 @@ Then to run, e.g.
 #endif
 
 /*************** Bytewise utility routines needed by prime-pairing algorithm ***************/
+// v21: mod-2^64 sum of a uint64 vector, for the stage 2 static-table checksums:
+static uint64 pm1_s2_checksum(const uint64 a[], uint32 len) {
+	uint64 s = 0ull; uint32 i;
+	for(i = 0; i < len; i++) s += a[i];
+	return s;
+}
+
 void bytevec_bitstr(uint8*x, int nbytes, char*ostr)
 {
 	int i;
@@ -1045,6 +1052,12 @@ based on iteration count versus PM1_S1_PROD_BITS as computed from the B1 bound, 
 	static double **buf = 0x0;	// on whether bigstep = [210,330,420 or 840]. a[] is simply a tmp-ptr used to init buf[]
 								// and then as an alias for mult[3]. 	<**** NOTE! ****
 	static double *vone = 0x0;	// Holds fwdFFT(1)
+	/* v21: stage 2 exact checks (help.txt section [9]): checksums of the static buf[] tables, taken after their
+	fwd-FFT and re-verified at checkpoints; a scratch array for recomputing the A^((kD)^2) ladder value from the
+	stage 1 residue; and the previous checkpoint's accumulator checksum triplet for the stuck-accumulator test: */
+	static uint64 *bufsum = 0x0, *s2chk_A = 0x0;	static double *s2chk_ptmp = 0x0, *s2chk = 0x0;
+	static uint32 s2chk_round = 0, s2chk_have = 0;	static uint64 s2chk_r64 = 0ull, s2chk_r35 = 0ull, s2chk_r36 = 0ull;
+	static double s2chk_tlast = 0.0, s2chk_tdur = 0.0;
   #ifdef macintosh
 	argc = ccommand(&argv);			/* Macintosh CW */
   #endif
@@ -1431,6 +1444,10 @@ based on iteration count versus PM1_S1_PROD_BITS as computed from the B1 bound, 
 	sprintf(cbuf,"Using Bigstep %u, pairing-window multiplicity M = %u: Init M*%u = %u [base^(A^(b^2)) %% n] buffers for Stage 2...\n",bigstep,m,num_b,m*num_b);
 	mlucas_fprint(cbuf,pm1_standlone+1);
 	// [a] Generate set of precomputed buffers A^(b^2) (A = s1 residue stored in pow[]) for b-values corr. to our choice of D:
+	// v21: keep a packed copy of the stage 1 residue A for the checkpoint ladder check (pow[] holds A, pure-int, here):
+	if(s2chk_A) free((void *)s2chk_A);
+	s2chk_A = (uint64 *)calloc(nlimb+1, sizeof(uint64));	ASSERT(s2chk_A != 0x0, "calloc of stage 2 check residue copy failed!");
+	convert_res_FP_bytewise(pow, (uint8*)s2chk_A, n, p, 0x0,0x0,0x0);
 	memcpy(buf[0] ,pow,nbytes);	// b[0] = 1 --> Copy of A^1 into buf[0]
 	memcpy(mult[0],pow,nbytes);	// Another copy of A^1 into mult[0][] - this will hold ascending odd-square powers A^1,9,25,...
 	memcpy(mult[1],pow,nbytes);	// A third copy of A^1 into mult[1][] - this will end up holding A^8 in fwd-FFTed form:
@@ -1751,6 +1768,16 @@ MME = 0;
 		//                                                                    vvvvvvvv
 		ierr = func_mod_square(buf[i], 0x0, n, 0,1, 4ull + (uint64)(mode_flag - (i==0)), p, scrnFlag,&tdif2, FALSE, 0x0); if(ierr) nerr |= 1<<ierr;
 	}	ASSERT(nerr == 0, "fwdFFT of buf[] entries returns error!");
+	/* v21: The buf[] tables never change from here on, so checksum each now; checkpoints re-verify a rotating 1/16
+	of them (a full pass streams the whole table set - tens of GB at 100M-digit exponents), or all of them when the
+	periodic-check clock is set to "every checkpoint". Also allocate the scratch array the ladder check needs: */
+	if(bufsum) free((void *)bufsum);
+	bufsum = (uint64 *)calloc(m*num_b, sizeof(uint64));	ASSERT(bufsum != 0x0, "calloc of stage 2 buffer checksums failed!");
+	for(i = 0; i < m*num_b; i++) bufsum[i] = pm1_s2_checksum((uint64 *)buf[i], nbytes>>3);
+	if(s2chk_ptmp) { free((void *)s2chk_ptmp); s2chk_ptmp = s2chk = 0x0; }
+	s2chk_ptmp = ALLOC_DOUBLE(s2chk_ptmp, npad);	ASSERT(s2chk_ptmp != 0x0, "alloc of stage 2 check scratch array failed!");
+	s2chk = ALIGN_DOUBLE(s2chk_ptmp);
+	s2chk_round = 0; s2chk_have = 0; s2chk_tlast = getRealTime(); s2chk_tdur = 0.0;
 
 	// Accumulate the cycle count in a floating double on each pass to avoid problems
 	// with integer overflow of the clock() result, if clock_t happens to be 32-bit int on the host platform:
@@ -2507,6 +2534,69 @@ MME = 0;
 			ierr = func_mod_square(a, 0x0, n, 0,1, 8ull, p, scrnFlag,&tdif2, FALSE, 0x0);
 			arrtmp[nlimb-1] = 0ull;
 			convert_res_FP_bytewise(a, (uint8*)arrtmp, n, p, &Res64, &Res35m1, &Res36m1);
+		#ifdef MLUCAS_FAULT_INJECT
+			/* Test-only fault injector for stage 2 (cf. the stage 1 one in Mlucas.c): at the first checkpoint whose q reaches
+			$MLUCAS_FAULT_S2_Q, add 1.0 to element 0 of the ladder value mult[0] ("ladder"), of table entry buf[1] ("table")
+			or of the accumulator pow[] ("accum", which nothing can catch - the documented gap). Fires once per process: */
+			{
+				static int fi_done = 0; const char *fi_what = getenv("MLUCAS_FAULT_S2"), *fi_q = getenv("MLUCAS_FAULT_S2_Q");
+				if(fi_what && fi_q && !fi_done && (q+bigstep) >= strtoull(fi_q,0x0,10)) {
+					fi_done = 1;
+					if(!strcmp(fi_what,"ladder")) mult[0][0] += 1.0;
+					else if(!strcmp(fi_what,"table")) buf[1][0] += 1.0;
+					else if(!strcmp(fi_what,"accum")) { pow[0] += 1.0; memcpy(a,pow,nbytes); ierr = func_mod_square(a, 0x0, n, 0,1, 8ull, p, scrnFlag,&tdif2, FALSE, 0x0); arrtmp[nlimb-1] = 0ull; convert_res_FP_bytewise(a, (uint8*)arrtmp, n, p, &Res64, &Res35m1, &Res36m1); }
+					snprintf(cbuf,sizeof(cbuf), "FAULT INJECTION: stage 2 %s perturbed at q = %" PRIu64 ".\n",fi_what,q+bigstep);
+					mlucas_fprint(cbuf,pm1_standlone+1);
+				}
+			}
+		#endif
+			/* v21: Stage 2 exact checks. There is no algebraic invariant for the accumulator itself (a product of
+			differences of powers), so it gets sanity tests only; the two *inputs* every later term is built from -
+			the A^((kD)^2) ladder and the static buf[] tables - have closed forms and are checked exactly. All three
+			abort on failure: the .s2 checkpoint on disk is intact, and a restart rebuilds ladder and tables from
+			the stage 1 residue and resumes the accumulator from the file.
+			[1] Accumulator: never zero (every term is a nonzero difference mod N... a zero would mean a term was
+			    exactly 0 mod N, i.e. a factor was found by the ladder hitting a table entry, probability ~1/N),
+			    and never identical to the previous checkpoint's value: */
+			if(mi64_iszero(arrtmp, nlimb)) {
+				snprintf(cbuf,sizeof(cbuf), "ERROR: %s stage 2 accumulator is identically zero at q = %" PRIu64 " - not a possible value; memory corruption or a broken build. Aborting; the .s2 checkpoint is intact and a restart resumes from it.\n",PSTRING,q+bigstep);
+				mlucas_fprint(cbuf,pm1_standlone+1); ASSERT(0,cbuf);
+			}
+			if(s2chk_have && Res64 == s2chk_r64 && Res35m1 == s2chk_r35 && Res36m1 == s2chk_r36) {
+				snprintf(cbuf,sizeof(cbuf), "ERROR: %s stage 2 accumulator did not change over the checkpoint interval ending at q = %" PRIu64 " - the run is not advancing (stuck data or a broken build). Aborting; the .s2 checkpoint is intact.\n",PSTRING,q+bigstep);
+				mlucas_fprint(cbuf,pm1_standlone+1); ASSERT(0,cbuf);
+			}
+			s2chk_have = 1; s2chk_r64 = Res64; s2chk_r35 = Res35m1; s2chk_r36 = Res36m1;
+			/* [2] Static tables: a rotating 1/16 of buf[] per checkpoint, all of them when JacobiCheckHours = 0: */
+			{
+				uint32 nb = m*num_b, per = (JACOBI_CHECK_HOURS == 0.0) ? nb : (nb + 15)/16, lo = s2chk_round*per, hi = MIN(nb, lo+per);
+				for(i = lo; i < hi; i++) {
+					if(pm1_s2_checksum((uint64 *)buf[i], nbytes>>3) != bufsum[i]) {
+						snprintf(cbuf,sizeof(cbuf), "ERROR: %s stage 2 table entry %u of %u fails its checksum at q = %" PRIu64 " - the precomputed A^(b^2) buffers have been corrupted in memory. Aborting; the .s2 checkpoint is intact and a restart rebuilds the tables.\n",PSTRING,i,nb,q+bigstep);
+						mlucas_fprint(cbuf,pm1_standlone+1); ASSERT(0,cbuf);
+					}
+				}
+				s2chk_round = (hi >= nb) ? 0 : s2chk_round+1;
+			}
+			/* [3] Ladder: recompute A^((kD)^2) from the stage 1 residue (packed form kept in vec1[]) by the same
+			two-step modpow the stage 2 setup uses - D^2 first, then k^2 - forward-FFT it as the loop does, and require
+			the result to be bit-identical to mult[0]. Same integer, same carry normalisation, same FFT, so it is.
+			~130 modmuls, so it rides the periodic-check clock (JacobiCheckHours, 0 = every checkpoint) with the
+			100x-previous-duration guard: */
+			if(JACOBI_CHECK && (JACOBI_CHECK_HOURS == 0.0 || (getRealTime() - s2chk_tlast) >= MAX(JACOBI_CHECK_HOURS*3600.0, 100.0*s2chk_tdur))) {
+				double t0 = getRealTime();
+				convert_res_bytewise_FP((uint8*)s2chk_A, s2chk, n, p);	// s2chk = A, pure-int
+				modpow(s2chk, a, TRUE , (uint64)bigstep*bigstep, func_mod_square, p, n, scrnFlag,&tdif2);	// s2chk = A^(D^2)
+				modpow(s2chk, a, FALSE, (uint64)k*k, func_mod_square, p, n, scrnFlag,&tdif2);			// s2chk = A^((kD)^2)
+				ierr = func_mod_square(s2chk, 0x0, n, 0,1, 4ull + 1ull, p, scrnFlag,&tdif2, FALSE, 0x0);	// fwd-FFT, as [1b] does for mult[0]
+				s2chk_tdur = getRealTime() - t0; s2chk_tlast = getRealTime();
+				if(ierr || memcmp(s2chk, mult[0], nbytes) != 0) {
+					snprintf(cbuf,sizeof(cbuf), "ERROR: %s stage 2 ladder check FAILED at q = %" PRIu64 " (k = %u): A^((kD)^2) recomputed from the stage 1 residue differs from the running value - every term since the last passing check is suspect. Aborting; the .s2 checkpoint is intact and a restart rebuilds the ladder.\n",PSTRING,q+bigstep,k);
+					mlucas_fprint(cbuf,pm1_standlone+1); ASSERT(0,cbuf);
+				}
+				snprintf(cbuf,sizeof(cbuf), "Stage 2 ladder check passed at q = %" PRIu64 " (k = %u, %.1f sec).\n",q+bigstep,k,s2chk_tdur);
+				mlucas_fprint(cbuf,pm1_standlone+scrnFlag);
+			}
 		  #ifdef RTIME
 			clock2 = getRealTime();	*tdiff = clock2 - clock1;	clock1 = clock2;
 		  #endif
@@ -2612,6 +2702,9 @@ ERR_RETURN:
 	free((void *)buf); buf = 0x0;
 	free((void *)b); b = 0x0;
 	free((void *)map); map = 0x0;
+	if(bufsum) { free((void *)bufsum); bufsum = 0x0; }	// v21: stage 2 check data
+	if(s2chk_A) { free((void *)s2chk_A); s2chk_A = 0x0; }
+	if(s2chk_ptmp) { free((void *)s2chk_ptmp); s2chk_ptmp = s2chk = 0x0; }
   #ifdef MULTITHREAD
 	if(tpool) { threadpool_free(tpool); tpool = 0x0; }	// Join+free the Stage-2 worker pool so it does not linger after this call
 	free((void *)thr_ret ); thr_ret  = 0x0;

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -544,7 +544,9 @@ PM1_S1P_READ_RETURN:
 		ASSERT(arr != 0x0, "Null arr pointer!");
 		ASSERT(strlen(fname) != 0, "Empty filename!");
 
-		FILE*fptr = mlucas_fopen(fname, "wb");
+		// v21: atomic-replace: a crash partway through this write formerly left a truncated primes-product
+		// file in place of the previous complete one, and the caller has no backup copy to fall back on:
+		FILE*fptr = mlucas_fopen_atomic(fname, "wb");
 		if(!fptr) {
 			snprintf(cbuf, sizeof(cbuf), "ERROR: Unable to open precomputed p-1 stage 1 primes-product file %s for writing.\n",fname);
 			mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0, cbuf);
@@ -582,7 +584,17 @@ PM1_S1P_READ_RETURN:
 		retval = 1;
 
 	PM1_S1P_WRITE_RETURN:
-		if(fptr) { fclose(fptr); fptr = 0x0; }
+		// v21: On the checksum-mismatch path above retval is still 0, i.e. we are abandoning this write;
+		// commit the scratch file over the target only if the data we staged in it is actually good:
+		if(fptr) {
+			if(!retval)
+				mlucas_discard_atomic(fname,fptr);
+			else if(mlucas_fclose_atomic(fname,fptr)) {
+				sprintf(cbuf,"ERROR: Unable to commit precomputed p-1 stage 1 primes-product file %s.\n",fname);
+				mlucas_fprint(cbuf,pm1_standlone+1);	retval = 0;
+			}
+			fptr = 0x0;
+		}
 		return retval;
 	}
 #endif
@@ -1499,7 +1511,7 @@ fprintf(stderr,"#1: vec1 = A^+1 checksums = %" PRIu64 ",%" PRIu64 ",%" PRIu64 ";
 		Res35m1 = mi64_div_by_scalar64(vec2,two35m1,nlimb,0x0);
 		Res36m1 = mi64_div_by_scalar64(vec2,two36m1,nlimb,0x0);
 		// Write inverse to savefile:
-		fp = mlucas_fopen(inv_file, "wb");
+		fp = mlucas_fopen_atomic(inv_file, "wb");	// v21: atomic-replace, as for the .s2 checkpoint below
 		if(fp) {
 			write_ppm1_savefiles(inv_file,p,n,fp, 0ull, (uint8*)vec2,Res64,Res35m1,Res36m1, 0x0,0x0,0x0,0x0);
 			close_savefile(inv_file,fp);	fp = 0x0;
@@ -2509,7 +2521,13 @@ MME = 0;
 				, 1000*get_time(*tdiff)/(nmodmul - nmodmul_save), Res64, AME, MME);
 			mlucas_fprint(cbuf,pm1_standlone+scrnFlag);
 			*tdiff = MME = 0.0;	// Reset timer and maxerr at end of each iteration interval
-			fp = mlucas_fopen(savefile, "wb");
+			// v21: _atomic: the .s2 checkpoint has no secondary copy standing behind it - unlike the p/q
+			// residue savefiles, where a corrupt primary is detected and the secondary used instead - so
+			// truncating it in place made every checkpoint write a window in which the *only* record of
+			// stage-2 progress on disk was a partially-written file. Killing a run in that window destroyed
+			// the last good checkpoint and cost the whole of stage 2 so far. Stage the write in a scratch
+			// file and rename it over the target, which is then never seen in a partial state:
+			fp = mlucas_fopen_atomic(savefile, "wb");
 			if(fp) {
 				// q won't get += bigstep until we loop, so here, (q + bigstep) is the q-value corr. to just-incremented k.
 				// Also write any relocation-prime psmall into high bit of the resulting nsquares field:

--- a/src/util.c
+++ b/src/util.c
@@ -36,6 +36,10 @@
 #endif
 #if defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
 	#include <windows.h>
+	#include <io.h>		// v21: _commit(), _fileno() - the Windows spellings of fsync(), fileno()
+#else
+	#include <fcntl.h>	// v21: open() of the savefile's containing directory, to fsync() a rename
+	#include <unistd.h>	// v21: fsync(), fileno(), close()
 #endif
 
 #if 0
@@ -9616,6 +9620,172 @@ FILE *mlucas_fopen(const char *path, const char *mode)
 
 	snprintf(mlucas_path, sizeof(mlucas_path), "%s%s", MLUCAS_PATH, path);
 	return fopen(mlucas_path, mode);
+}
+
+/**************************************************************************************************/
+/*** v21: Crash-safe (atomic) savefile replacement - see the mlucas_fopen_atomic() comment below ***/
+/**************************************************************************************************/
+
+/* Suffix appended to a savefile name to form the name of the scratch file its replacement is
+staged in. Deliberately a fixed string rather than a mkstemp()-style random one: it keeps the
+scratch file next to its target in the same directory (a hard requirement, since rename() is only
+atomic *within* a filesystem), it is unique per target because savefile names already are, and a
+leftover from a previous crash is simply reused rather than accumulating as litter: */
+#define SAVEFILE_TMP_SUFFIX	".new"
+
+/* MLUCAS_PATH-prefix [path] (+ optional [suffix]) into caller-supplied buffer [dest], which must
+have room for MLUCAS_PATH_BUFSIZE chars. Same length reasoning as mlucas_fopen(): */
+#define MLUCAS_PATH_BUFSIZE	(2*STR_MAX_LEN + sizeof(SAVEFILE_TMP_SUFFIX) + 1)
+
+static void mlucas_path_cat(char dest[], const char *path, const char *suffix)
+{
+	strcpy(dest, MLUCAS_PATH);
+	strcat(dest, path);
+	if(suffix) strcat(dest, suffix);
+}
+
+/* Rename [oldpath] ==> [newpath], both MLUCAS_PATH-relative, replacing [newpath] if it exists.
+Returns 0 on success, nonzero on failure. Two things this does which a bare rename() call does not:
+
+	[1] It applies the MLUCAS_PATH prefix. Every Mlucas file is *created* through mlucas_fopen(),
+	    which prefixes; the bare rename() calls this replaces did not, so under a nonempty
+	    MLUCAS_PATH (the "$HOME/.mlucas.d/" packaging layout, or the MLUCAS_PATH env var) they
+	    named files which do not exist, and the renames simply failed.
+
+	[2] It replaces an existing destination on Windows as well as POSIX. rename(2) is required to
+	    atomically replace the destination on POSIX, but the Windows CRT rename() fails with EEXIST
+	    if the destination exists - which is exactly the case here, since the whole point is to
+	    overwrite the previous savefile. MoveFileEx(...,MOVEFILE_REPLACE_EXISTING) is the Windows
+	    equivalent; MOVEFILE_WRITE_THROUGH additionally asks that the rename be flushed before the
+	    call returns, which is what makes it durable rather than merely atomic.
+
+Note the preprocessor gate: platform.h routes MinGW builds down its OS_TYPE_LINUX branch on purpose
+(see the "MinGW builds use the Linux codepath" comment there), so a bare #ifdef OS_TYPE_WINDOWS would
+miss MinGW - whose rename() is the same replace-hostile msvcrt one. Test both, as platform.h itself
+does wherever it needs "is this a Windows target?" rather than "is this an MSVC build?".
+*/
+int mlucas_rename(const char *oldpath, const char *newpath)
+{
+	char obuf[MLUCAS_PATH_BUFSIZE], nbuf[MLUCAS_PATH_BUFSIZE];
+	mlucas_path_cat(obuf, oldpath, 0x0);
+	mlucas_path_cat(nbuf, newpath, 0x0);
+#if defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
+	return !MoveFileEx(obuf, nbuf, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH);
+#else
+	return rename(obuf, nbuf);
+#endif
+}
+
+/* Open the scratch file in which a crash-safe replacement of savefile [path] is staged. Use exactly
+as mlucas_fopen(path,"wb"), but close the result with mlucas_fclose_atomic(path,fp) rather than
+fclose(fp); [path] must be the same string in both calls.
+
+Why this exists: a savefile write of the form
+
+	fp = mlucas_fopen(savefile,"wb");  ...write...  fclose(fp);
+
+truncates the target *before* writing a single byte of the replacement, so from the instant the file
+is opened until the instant the last byte lands, there is no complete copy of that checkpoint on
+disk. A crash, kill -9, power loss or full filesystem in that window leaves a short or garbage
+savefile behind and takes the previous good checkpoint with it. Measured, not theoretical: killing a
+p-1 run partway through a .s2 stage-2 checkpoint write leaves a truncated .s2 where the previous
+complete checkpoint used to be, and the next run then discards that stage-2 progress entirely and
+redoes the stage from its start. The p/q residue-savefile pair survives the same treatment only
+because there are two copies of it - the corrupt primary is detected and the secondary used instead.
+The .s2 checkpoint has no second copy, so there is nothing to fall back to.
+
+Staging the new contents in a sibling scratch file and rename()-ing it over the target closes that
+window: the target is only ever replaced by a rename, which is atomic, so at every instant the file
+on disk is either the complete old checkpoint or the complete new one - never a prefix of either.
+The scratch file must live in the same directory as its target for this to work, since rename() is
+only atomic within a filesystem; appending a suffix to the full target path guarantees that.
+*/
+FILE *mlucas_fopen_atomic(const char *path, const char *mode)
+{
+	char tmp_path[MLUCAS_PATH_BUFSIZE];
+	ASSERT(mode != 0x0 && mode[0] == 'w', "mlucas_fopen_atomic: only write ('w'/'wb') modes make sense here!");
+	mlucas_path_cat(tmp_path, path, SAVEFILE_TMP_SUFFIX);
+	return fopen(tmp_path, mode);
+}
+
+/* Abandon a crash-safe savefile write begun with mlucas_fopen_atomic(path,...): close the scratch
+file and delete it, leaving [path] untouched. For callers which discover partway through - or after
+finishing - that the data they staged is not fit to be published: */
+void mlucas_discard_atomic(const char *path, FILE *fp)
+{
+	char tmp_path[MLUCAS_PATH_BUFSIZE];
+	if(fp) fclose(fp);
+	mlucas_path_cat(tmp_path, path, SAVEFILE_TMP_SUFFIX);
+	remove(tmp_path);
+}
+
+/* Finish a crash-safe savefile write begun with mlucas_fopen_atomic(path,...): flush the stdio
+buffer, push the data to stable storage, close, then atomically rename the scratch file over [path].
+Returns 0 on success; on any failure returns nonzero having deleted the scratch file, so that [path]
+still holds the previous good checkpoint. Callers must check the return value - it is the analogue of
+a failed write, not of a failed fclose() nobody looks at.
+
+The fsync() is the difference between "a crash cannot corrupt the savefile" and "a *power loss*
+cannot corrupt the savefile". Without it the rename can reach the disk ahead of the data it is
+supposed to be publishing, leaving the target name pointing at a file whose contents never made it
+out of the page cache. Its failure is treated as a write failure, since a deferred ENOSPC/EIO is
+exactly how a filesystem reports that the data did not make it.
+*/
+int mlucas_fclose_atomic(const char *path, FILE *fp)
+{
+	char tmp_path[MLUCAS_PATH_BUFSIZE], tmp_name[STR_MAX_LEN + sizeof(SAVEFILE_TMP_SUFFIX)];
+	int err = 0;
+	if(!fp) return -1;
+	mlucas_path_cat(tmp_path, path, SAVEFILE_TMP_SUFFIX);
+	strcpy(tmp_name, path);	strcat(tmp_name, SAVEFILE_TMP_SUFFIX);	// MLUCAS_PATH-relative, for mlucas_rename()
+	/* [1] stdio buffer ==> OS: */
+	if(fflush(fp) != 0)
+		err = 1;
+	/* [2] OS page cache ==> stable storage. EINVAL/ENOTSUP mean the fd is of a type which cannot be
+	synced (a pipe, or a filesystem lacking the operation) rather than that the data was lost, so do
+	not treat those as write failures: */
+	if(!err) {
+	#if defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
+		if(_commit(_fileno(fp)) != 0 && errno != EINVAL && errno != EBADF)
+			err = 1;
+	#else
+		if(fsync(fileno(fp)) != 0 && errno != EINVAL && errno != ENOTSUP)
+			err = 1;
+	#endif
+	}
+	/* [3] Close. A failed fclose() means buffered data was dropped, i.e. the file is short: */
+	if(fclose(fp) != 0)
+		err = 1;
+	if(err) {
+		remove(tmp_path);	// Leave [path] holding the previous good checkpoint
+		return 1;
+	}
+	/* [4] Publish, atomically: */
+	if(mlucas_rename(tmp_name, path)) {
+		remove(tmp_path);
+		return 1;
+	}
+	/* [5] Make the rename itself durable by syncing the containing directory. Best-effort: a
+	failure here means the *name change* might not survive a power loss, in which case the target
+	simply still holds the previous good checkpoint - no corruption either way - so unlike the data
+	fsync above this one does not fail the write. No Windows equivalent, and none needed: the
+	MOVEFILE_WRITE_THROUGH flag passed to MoveFileEx() already covers it. */
+#if !defined(OS_TYPE_WINDOWS) && !defined(__MINGW32__)
+	{
+		char *slash;	int dfd;
+		strcpy(tmp_path, MLUCAS_PATH);	strcat(tmp_path, path);
+		slash = strrchr(tmp_path,'/');
+		if(slash == tmp_path)	// Target sits in the root directory
+			tmp_path[1] = '\0';
+		else if(slash)
+			*slash = '\0';
+		else					// No directory component at all ==> current working directory
+			strcpy(tmp_path,".");
+		dfd = open(tmp_path, O_RDONLY);
+		if(dfd >= 0) { fsync(dfd); close(dfd); }
+	}
+#endif
+	return 0;
 }
 
 /*********************/

--- a/src/util.c
+++ b/src/util.c
@@ -9835,12 +9835,19 @@ double mlucas_getOptVal(const char*fname, char*optname)
 	double result = strtod("NaN", 0x0);
 	if(fptr) {
 		while(fgets(cstr, STR_MAX_LEN, fptr)) {
-			if((cptr = strstr(cstr,optname)) != 0x0) {
-				if((cadd = strstr(cptr + strlen(optname),"=")) != 0x0) {
-				 	result = strtod(cadd+1,0x0);	// Could insert a ptr in place of 0x0 to hold ptr to any unconverted suffix, but
-				 									// in the case of an mlucas.ini entry it would typically just contain a newline.
-				 	return result;	// Return first occurrence of option in file
-				}
+			/* v21: Match the option name as a whole word, not as a substring - strstr() alone made "JacobiCheck" match a
+			"JacobiCheckHours = 0" line (returning 0 for an option that was never set). The name must start the line (after
+			any leading whitespace) and be followed by whitespace or '=': */
+			cptr = cstr;
+			while(*cptr == ' ' || *cptr == '\t') cptr++;
+			if(strncmp(cptr, optname, strlen(optname)) != 0) continue;
+			cadd = cptr + strlen(optname);
+			if(*cadd != ' ' && *cadd != '\t' && *cadd != '=') continue;
+			if((cadd = strstr(cadd,"=")) != 0x0) {
+			 	result = strtod(cadd+1,0x0);	// Could insert a ptr in place of 0x0 to hold ptr to any unconverted suffix, but
+			 									// in the case of an mlucas.ini entry it would typically just contain a newline.
+			 	fclose(fptr);
+			 	return result;	// Return first occurrence of option in file
 			}
 		}
 		fclose(fptr);	fptr = 0x0;

--- a/src/util.c
+++ b/src/util.c
@@ -9676,6 +9676,18 @@ int mlucas_rename(const char *oldpath, const char *newpath)
 #endif
 }
 
+/* remove() with the MLUCAS_PATH prefix applied, for the same reason mlucas_rename() exists: every
+savefile in the tree is created through mlucas_fopen(), which prepends MLUCAS_PATH, so a bare
+remove(name) under a nonempty prefix looks in the wrong directory. It does not fail loudly - it
+returns nonzero for "no such file", which the call sites then report as an inability to delete a
+file that was in fact never looked at. */
+int mlucas_remove(const char *path)
+{
+	char buf[MLUCAS_PATH_BUFSIZE];
+	mlucas_path_cat(buf, path, 0x0);
+	return remove(buf);
+}
+
 /* Open the scratch file in which a crash-safe replacement of savefile [path] is staged. Use exactly
 as mlucas_fopen(path,"wb"), but close the result with mlucas_fclose_atomic(path,fp) rather than
 fclose(fp); [path] must be the same string in both calls.

--- a/src/util.h
+++ b/src/util.h
@@ -198,6 +198,7 @@ int		mlucas_fclose_atomic(const char *path, FILE *fp);
 void	mlucas_discard_atomic(const char *path, FILE *fp);
 /* MLUCAS_PATH-aware, replace-existing-destination rename; 0 = success: */
 int		mlucas_rename(const char *oldpath, const char *newpath);
+int		mlucas_remove(const char *path);
 // v20: Add simple utility to print the input string to the current-assignment logfile and/or to stderr:
 void	mlucas_fprint(char*const p_cstr, uint32 echo_to_stderr);
 double	mlucas_getOptVal(const char*fname, char*optname);

--- a/src/util.h
+++ b/src/util.h
@@ -188,6 +188,16 @@ char	*quote_spaces(char *dest, char *src); /* Double-quote spaces in string  */
 int		mkdir_p(char *path); /* Emulate `mkdir -p path'  */
 char	*shell_quote(char *dest, char *src); /* Escape shell meta characters  */
 FILE	*mlucas_fopen(const char *path, const char *mode); /* fopen() wrapper  */
+/* v21: Crash-safe savefile replacement. mlucas_fopen_atomic() stages the new contents in a sibling
+scratch file; mlucas_fclose_atomic() syncs it and renames it over the target, which is thus replaced
+atomically rather than truncated in place. Both take the same MLUCAS_PATH-relative [path]; the close
+returns 0 on success and nonzero (target left holding the previous good checkpoint) on failure: */
+FILE	*mlucas_fopen_atomic(const char *path, const char *mode);
+int		mlucas_fclose_atomic(const char *path, FILE *fp);
+/* Abandon a staged write: close and delete the scratch file, leaving the target untouched: */
+void	mlucas_discard_atomic(const char *path, FILE *fp);
+/* MLUCAS_PATH-aware, replace-existing-destination rename; 0 = success: */
+int		mlucas_rename(const char *oldpath, const char *newpath);
 // v20: Add simple utility to print the input string to the current-assignment logfile and/or to stderr:
 void	mlucas_fprint(char*const p_cstr, uint32 echo_to_stderr);
 double	mlucas_getOptVal(const char*fname, char*optname);

--- a/tests/jacobi-check.sh
+++ b/tests/jacobi-check.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# End-to-end tests for the LL Jacobi residue check (help.txt sections [4], [11], [12], [14b]).
+#
+# Usage: tests/jacobi-check.sh <Mlucas binary> [<Mlucas binary built with -DMLUCAS_FAULT_INJECT>] [<mlucas.cfg>]
+#
+# Runs small LL tests in a scratch directory and asserts on the .stat file, the savefiles and the
+# results.txt JSON line. Exponents: M44497 and M216091 (known primes, whole LL in seconds) and 44501 /
+# 216103 (prime exponents with composite Mersenne numbers, so a results line is emitted). The
+# fault-injection tests need the second binary; they are skipped with a notice if it is not given.
+#
+# What is asserted, and why, is spelled out next to each test. Every expectation is one the check's
+# design makes: a check that passes at every checkpoint of a clean run; a corrupted savefile that is
+# refused on read; an injected fault caught at the next check with a rollback to the previous checkpoint
+# and a correct final result; an injected fault that passes its own checkpoint but is caught at the next
+# and recovered through the .J1 generation; and - deliberately - an injected fault that the check MISSES
+# and a run that then ends wrong. The last one documents the check's known blind spot rather than hiding
+# it: the Jacobi symbol is invariant under the LL recurrence from one iteration after a corruption on,
+# so a corruption that passes the first check after it is never caught by a later one.
+set -u -o pipefail
+
+MLUCAS=${1:?usage: $0 <Mlucas> [<Mlucas-fault-inject>] [<mlucas.cfg>]}
+MLUCAS_FI=${2:-}
+CFG=${3:-}
+MLUCAS=$(readlink -f "$MLUCAS"); [[ -n $MLUCAS_FI ]] && MLUCAS_FI=$(readlink -f "$MLUCAS_FI")
+[[ -n $CFG ]] && CFG=$(readlink -f "$CFG")
+CPU=${JACOBI_TEST_CPU:-0:3}
+WORK=${JACOBI_TEST_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/jacobi-check.XXXXXX")}
+mkdir -p "$WORK"
+PASS=0; FAIL=0; SKIP=0
+
+ok()   { echo "  ok   - $*"; PASS=$((PASS+1)); }
+bad()  { echo "  FAIL - $*"; FAIL=$((FAIL+1)); }
+skip() { echo "  skip - $*"; SKIP=$((SKIP+1)); }
+expect_grep()   { local f=$1 pat=$2 what=$3; if grep -q -- "$pat" "$f"; then ok "$what"; else bad "$what (pattern not found: $pat)"; fi; }
+expect_nogrep() { local f=$1 pat=$2 what=$3; if grep -q -- "$pat" "$f"; then bad "$what (unexpected: $(grep -m1 -- "$pat" "$f"))"; else ok "$what"; fi; }
+expect_count()  { local f=$1 pat=$2 min=$3 what=$4; local n; n=$(grep -c -- "$pat" "$f"); if (( n >= min )); then ok "$what ($n)"; else bad "$what: $n < $min"; fi; }
+
+# Fresh run directory with the binary, cfg (if any) and the mlucas.ini options the tests rely on.
+setup() {	# setup <dir> <exponent> <CheckInterval> [<binary>]
+	local d=$WORK/$1 p=$2 ci=$3 bin=${4:-$MLUCAS}
+	rm -rf "$d"; mkdir -p "$d"
+	ln -s "$bin" "$d/Mlucas"
+	[[ -n $CFG && -f $CFG ]] && cp "$CFG" "$d/mlucas.cfg"
+	printf 'Test=%s\n' "$p" > "$d/worktodo.txt"
+	printf 'CheckInterval = %s\nJacobiCheckHours = 0\n' "$ci" > "$d/mlucas.ini"
+	echo "$d"
+}
+run() {	# run <dir> [env...] : run Mlucas to completion (or until it exits) in <dir>, log to run.log
+	local d=$1; shift
+	( cd "$d" && env "$@" timeout 900 ./Mlucas -cpu "$CPU" > run.log 2>&1 ); echo $? > "$d/exit"
+}
+# Run in the background and stop it with SIGINT once the .stat file shows the given iteration.
+run_until_iter_then_interrupt() {	# <dir> <exponent> <iteration>
+	local d=$1 p=$2 it=$3 pid i
+	( cd "$d" && exec ./Mlucas -cpu "$CPU" > run.log 2>&1 ) & pid=$!
+	for i in $(seq 1 600); do
+		sleep 0.5
+		grep -q "Iter# = $it " "$d/p$p.stat" 2>/dev/null && break
+		kill -0 $pid 2>/dev/null || break
+	done
+	kill -INT $pid 2>/dev/null; wait $pid 2>/dev/null; echo $? > "$d/exit"
+}
+res64_of() { grep -o '"res64":"[0-9A-F]*"' "$1/results.txt" 2>/dev/null | tail -1 | cut -d'"' -f4; }
+
+echo "== Jacobi residue check: end-to-end tests (work dir $WORK)"
+echo "   Mlucas: $MLUCAS"; echo "   fault-inject build: ${MLUCAS_FI:-(none - fault-injection tests skipped)}"
+
+# ---------------------------------------------------------------------------------------------
+echo "-- T1: clean LL of a Mersenne prime (M44497), check at every checkpoint"
+d=$(setup t1 44497 1000); run "$d"
+S=$d/p44497.stat
+expect_grep  "$S" "M44497 is a known MERSENNE PRIME" "correct verdict"
+expect_count "$S" "Jacobi check passed" 45 "a pass logged at every checkpoint plus the final residue"
+expect_nogrep "$S" "FAILED" "no failure on a clean run"
+expect_grep  "$S" "At iteration 44495, shift = [0-9]*: Jacobi check passed" "final residue checked before the verdict"
+[[ -f $d/p44497.J && -f $d/p44497.J1 ]] && ok ".J and .J1 written" || bad ".J/.J1 missing"
+[[ -f $d/q44497 ]] && bad "q44497 left behind after completion" || ok "q44497 removed at completion"
+
+# ---------------------------------------------------------------------------------------------
+echo "-- T2: clean LL of a composite Mersenne number (M44501): results line carries the Jacobi count"
+d=$(setup t2 44501 1000); run "$d"
+S=$d/p44501.stat
+expect_grep "$S" "M44501 is not prime" "correct verdict"
+expect_count "$S" "Jacobi check passed" 45 "a pass logged at every checkpoint plus the final residue"
+[[ -f $d/results.txt ]] && ok "results.txt written" || bad "results.txt missing"
+if grep -qE '"error-code":"[0-9A-F]{6}0[0-9A-F]"' "$d/results.txt"; then ok "clean Jacobi nibble in error-code"; else bad "Jacobi nibble != 0 on a clean run"; fi
+expect_grep "$d/results.txt" '"errors":{"Roundoff":0, "jacobi":0}' "jacobi count 0 in the errors object"
+CLEAN_44501=$(res64_of "$d"); [[ ${#CLEAN_44501} -eq 16 ]] && ok "clean Res64 recorded: $CLEAN_44501" || bad "no Res64 in results.txt"
+
+# ---------------------------------------------------------------------------------------------
+echo "-- T3: interrupt and resume (M216091): the loaded residue is Jacobi-checked before use"
+d=$(setup t3 216091 10000)
+run_until_iter_then_interrupt "$d" 216091 30000
+S=$d/p216091.stat
+expect_grep "$S" "Received SIGINT signal: writing savefile" "interrupt wrote a savefile"
+if grep -q "Received SIGINT signal: writing savefile at Iter = \([0-9]*\)" "$S"; then
+	it=$(grep -o "writing savefile at Iter = [0-9]*" "$S" | grep -o "[0-9]*$")
+	# The interrupt-driven checkpoint must not run the check (shutdown must stay fast)...
+	expect_nogrep "$S" "At iteration $it, shift = [0-9]*: Jacobi check passed" "no Jacobi check on the interrupt checkpoint"
+	run "$d"
+	# ...and the resume must check the residue it loads:
+	expect_grep "$S" "Restart file p216091 (iteration $it) passed the Jacobi check" "restart-read Jacobi check of the saved residue"
+	expect_grep "$S" "Restarting M216091 at iteration = $it" "resumed at the interrupted iteration"
+	expect_grep "$S" "M216091 is a known MERSENNE PRIME" "correct verdict after resume"
+else
+	bad "could not interrupt the run in time"
+fi
+
+# ---------------------------------------------------------------------------------------------
+echo "-- T4: corrupted savefile is refused on read and the chain falls through (M216091)"
+d=$(setup t4 216091 10000)
+run_until_iter_then_interrupt "$d" 216091 30000
+S=$d/p216091.stat
+if [[ -f $d/p216091 && -f $d/q216091 && -f $d/p216091.J ]]; then
+	# Damage p and q identically in the residue body (byte 100 lives inside the residue), which
+	# breaks their checksum triplet; .J is intact and must be the file the run resumes from.
+	for f in p216091 q216091; do printf '\xff' | dd of="$d/$f" bs=1 seek=100 conv=notrunc status=none; done
+	run "$d"
+	expect_grep "$S" "read_ppm1_savefiles Failed on savefile p216091" "damaged primary rejected"
+	expect_grep "$S" "read_ppm1_savefiles Failed on savefile q216091" "damaged secondary rejected"
+	expect_grep "$S" "Restart file p216091.J (iteration [0-9]*) passed the Jacobi check" "resumed from the last Jacobi-passed checkpoint"
+	expect_grep "$S" "M216091 is a known MERSENNE PRIME" "correct verdict after falling through the chain"
+else
+	bad "expected p/q/.J savefiles after the interrupt"
+fi
+
+# ---------------------------------------------------------------------------------------------
+if [[ -z $MLUCAS_FI ]]; then
+	skip "T5: fault-injection tests need a -DMLUCAS_FAULT_INJECT build as the 2nd argument"
+else
+	echo "-- T5: fault injection at iteration 50000 (fixed, deterministic cases)"
+	# Each (exponent, iteration, digit) triple gives a deterministic verdict, so the cases are fixed rather
+	# than searched for. The injection lands exactly at a checked checkpoint, so the check sees two
+	# independent values: the symbol at the corrupted iteration itself (the check at 50000) and the one
+	# shared by every later check (from 60000 on). One case per class:
+	#   caught      - M216103 digit 0: fails at 50000; rollback to the previous checkpoint (40000), correct
+	#                 result, 1 error counted;
+	#   caught_late - M216103 digit 3: passes at 50000 (so the corrupt residue is saved to p, q and .J) but
+	#                 fails at 60000 and on every retry: the chain must walk p -> .J -> .J1 (40000, clean),
+	#                 3 errors counted;
+	#   missed      - M216091 digit 3: passes both, so no check ever fires, and the run ends with a WRONG
+	#                 verdict ("not prime" for a Mersenne prime). Asserted on purpose: it is the check's
+	#                 known limit, and this documents it rather than hiding it.
+	d=$(setup t5clean 216103 10000); run "$d"
+	CLEAN=$(res64_of "$d"); [[ ${#CLEAN} -eq 16 ]] && ok "clean M216103 run Res64 $CLEAN" || bad "clean run produced no results line"
+
+	d=$(setup t5caught 216103 10000 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_ITER=50000 MLUCAS_FAULT_WORD=0
+	S=$d/p216103.stat
+	expect_grep "$S" "FAULT INJECTION: added 1.0 to residue digit 0 at iteration 50000" "caught: injection fired"
+	expect_grep "$S" "Jacobi check at iteration 50000 FAILED" "caught: failure at the corrupted checkpoint"
+	expect_grep "$S" "Restarting from the current savefile" "caught: rollback to the current savefile announced"
+	expect_grep "$S" "Restart file p216103 (iteration 40000) passed the Jacobi check" "caught: rolled back to the previous (clean) checkpoint"
+	[[ $(res64_of "$d") == "$CLEAN" ]] && ok "caught: final Res64 matches the clean run" || bad "caught: final Res64 $(res64_of "$d") != clean $CLEAN"
+	# error-code bits 4-7 = 7th hex digit; other nibbles may legitimately be nonzero (e.g. a startup roundoff warning)
+	if grep -qE '"error-code":"[0-9A-F]{6}1[0-9A-F]"' "$d/results.txt"; then ok "caught: one Jacobi error in the error-code nibble (bits 4-7)"; else bad "caught: Jacobi nibble != 1: $(grep -o '"error-code":"[0-9A-F]*"' "$d/results.txt")"; fi
+	expect_grep "$d/results.txt" '"jacobi":1' "caught: jacobi count 1 in the errors object"
+
+	d=$(setup t5late 216103 10000 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_ITER=50000 MLUCAS_FAULT_WORD=3
+	S=$d/p216103.stat
+	expect_grep "$S" "FAULT INJECTION: added 1.0 to residue digit 3 at iteration 50000" "caught_late: injection fired"
+	expect_nogrep "$S" "Jacobi check at iteration 50000 FAILED" "caught_late: passes the check at its own checkpoint"
+	expect_count "$S" "Jacobi check at iteration 60000 FAILED" 3 "caught_late: the same failure recurs on each retry from a poisoned file"
+	expect_grep "$S" "Restart file p216103 (iteration 50000) passed the Jacobi check" "caught_late: p (poisoned) passes its on-read check, as the symbol invariance predicts"
+	expect_grep "$S" "Restart file p216103.J (iteration 50000) passed the Jacobi check" "caught_late: .J (poisoned) likewise"
+	expect_grep "$S" "Restart file p216103.J1 (iteration 40000) passed the Jacobi check" "caught_late: chain reaches .J1, the clean checkpoint"
+	[[ $(res64_of "$d") == "$CLEAN" ]] && ok "caught_late: final Res64 matches the clean run" || bad "caught_late: final Res64 $(res64_of "$d") != clean $CLEAN"
+	if grep -qE '"error-code":"[0-9A-F]{6}3[0-9A-F]"' "$d/results.txt"; then ok "caught_late: three Jacobi errors in the error-code nibble"; else bad "caught_late: Jacobi nibble != 3: $(grep -o '"error-code":"[0-9A-F]*"' "$d/results.txt")"; fi
+
+	d=$(setup t5missed 216091 10000 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_ITER=50000 MLUCAS_FAULT_WORD=3
+	S=$d/p216091.stat
+	expect_grep "$S" "FAULT INJECTION: added 1.0 to residue digit 3 at iteration 50000" "missed: injection fired"
+	expect_nogrep "$S" "FAILED" "missed: no check ever fires (symbol invariant under the recurrence)"
+	expect_grep "$S" "M216091 is not prime" "missed: run ends with a WRONG verdict for a Mersenne prime - this is the documented limit of the check"
+	expect_nogrep "$S" "known MERSENNE PRIME" "missed: (and not the correct verdict)"
+fi
+
+# ---------------------------------------------------------------------------------------------
+echo "== $PASS passed, $FAIL failed, $SKIP skipped (work dir $WORK)"
+(( FAIL == 0 ))

--- a/tests/jacobi-check.sh
+++ b/tests/jacobi-check.sh
@@ -195,8 +195,22 @@ if [[ -n $MLUCAS_FI ]]; then
 	expect_grep "$S" "failed 5 times in a row, the last after restarting from scratch" "5th failure aborts with the hardware warning"
 	[[ $(cat "$d/exit") != 0 ]] && ok "run stopped (exit $(cat "$d/exit"))" || bad "run did not stop"
 	[[ -f $d/p216103 && -f $d/p216103.J ]] && ok "savefiles left in place" || bad "savefiles missing after the abort"
+
+	echo "-- T7: PRP run whose run flag is cleared between intervals (a signal during the checkpoint write) must stop, not run on frozen"
+	d=$WORK/t7; rm -rf "$d"; mkdir -p "$d"; ln -s "$MLUCAS_FI" "$d/Mlucas"; [[ -n $CFG && -f $CFG ]] && cp "$CFG" "$d/mlucas.cfg"
+	printf 'PRP=1,2,216091,-1,75,0,3,1\n' > "$d/worktodo.txt"; printf 'CheckInterval = 10000\n' > "$d/mlucas.ini"
+	run "$d" MLUCAS_FAULT_STOP_AT=50000; S=$d/p216091.stat
+	expect_grep "$S" "FAULT INJECTION: run flag cleared between intervals at iteration 50000" "flag cleared between intervals"
+	expect_grep "$S" "Received SIGINT signal: writing savefile at Iter = 50000 and exiting" "treated as an interrupt at the last completed iteration"
+	expect_nogrep "$S" "Iter# = 60000" "no further intervals were 'completed' after the stop"
+	expect_nogrep "$S" "MaxErr = 0.000000000" "no frozen-residue checkpoints"
+	[[ $(cat "$d/exit") == 0 ]] && ok "clean exit after the savefile write" || bad "exit $(cat "$d/exit")"
+	run "$d"
+	expect_grep "$S" "Restarting M216091 at iteration = 50000" "resumed at the interrupted iteration"
+	expect_grep "$S" "Gerbicz check passed" "the run's Gerbicz check passed after the resume"
+	expect_grep "$S" "M216091 is a known MERSENNE PRIME" "correct PRP verdict"
 else
-	skip "T6 needs the -DMLUCAS_FAULT_INJECT build"
+	skip "T6/T7 need the -DMLUCAS_FAULT_INJECT build"
 fi
 
 # ---------------------------------------------------------------------------------------------

--- a/tests/jacobi-check.sh
+++ b/tests/jacobi-check.sh
@@ -96,8 +96,10 @@ S=$d/p216091.stat
 expect_grep "$S" "Received SIGINT signal: writing savefile" "interrupt wrote a savefile"
 if grep -q "Received SIGINT signal: writing savefile at Iter = \([0-9]*\)" "$S"; then
 	it=$(grep -o "writing savefile at Iter = [0-9]*" "$S" | grep -o "[0-9]*$")
-	# The interrupt-driven checkpoint must not run the check (shutdown must stay fast)...
-	expect_nogrep "$S" "At iteration $it, shift = [0-9]*: Jacobi check passed" "no Jacobi check on the interrupt checkpoint"
+	# The interrupt-driven checkpoint must not run the check (shutdown must stay fast). Order-aware: when the signal
+	# lands between intervals the interrupt is reported at the iteration of the regular checkpoint just written, whose
+	# own check legitimately ran *before* the signal - so look only at what follows the interrupt message:
+	if sed -n '/Received SIGINT signal/,$p' "$S" | grep -q "Jacobi check passed"; then bad "a Jacobi check ran on the interrupt checkpoint"; else ok "no Jacobi check on the interrupt checkpoint"; fi
 	run "$d"
 	# ...and the resume must check the residue it loads:
 	expect_grep "$S" "Restart file p216091 (iteration $it) passed the Jacobi check" "restart-read Jacobi check of the saved residue"
@@ -175,6 +177,26 @@ else
 	expect_nogrep "$S" "FAILED" "missed: no check ever fires (symbol invariant under the recurrence)"
 	[[ $(res64_of "$d") != "$CLEAN" ]] && ok "missed: run ends with a WRONG residue $(res64_of "$d") - this is the documented limit of the check" || bad "missed: final residue equals the clean one?!"
 	if grep -qE '"error-code":"[0-9A-F]{6}0[0-9A-F]"' "$d/results.txt"; then ok "missed: Jacobi nibble 0, as expected - nothing was detected"; else bad "missed: Jacobi nibble != 0"; fi
+fi
+
+# ---------------------------------------------------------------------------------------------
+if [[ -n $MLUCAS_FI ]]; then
+	echo "-- T6: a reproducible fault: the rollback chain is walked to the end and the run aborts rather than loop"
+	# MLUCAS_FAULT_REPEAT re-fires the injection at every visit of iteration 50000, so every retry fails there
+	# again: current savefile -> .J -> .J1 -> scratch -> fifth failure aborts with a hardware warning.
+	d=$(setup t6 216103 10000 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_ITER=50000 MLUCAS_FAULT_WORD=3 MLUCAS_FAULT_REPEAT=1 -- -shift 0
+	S=$d/p216103.stat
+	expect_count "$S" "FAULT INJECTION: added 1.0 to residue digit 3 at iteration 50000" 5 "injection re-fired on every retry"
+	expect_count "$S" "Jacobi check at iteration 50000 FAILED" 4 "four failures each followed by a rollback"
+	expect_grep "$S" "Restarting from the current savefile" "1st rollback: current savefile"
+	expect_grep "$S" "Restarting from the last Jacobi-passed savefile" "2nd rollback: .J"
+	expect_grep "$S" "Restarting from the previous Jacobi-passed savefile" "3rd rollback: .J1"
+	expect_grep "$S" "Restarting from scratch" "4th rollback: scratch"
+	expect_grep "$S" "failed 5 times in a row, the last after restarting from scratch" "5th failure aborts with the hardware warning"
+	[[ $(cat "$d/exit") != 0 ]] && ok "run stopped (exit $(cat "$d/exit"))" || bad "run did not stop"
+	[[ -f $d/p216103 && -f $d/p216103.J ]] && ok "savefiles left in place" || bad "savefiles missing after the abort"
+else
+	skip "T6 needs the -DMLUCAS_FAULT_INJECT build"
 fi
 
 # ---------------------------------------------------------------------------------------------

--- a/tests/jacobi-check.sh
+++ b/tests/jacobi-check.sh
@@ -45,9 +45,10 @@ setup() {	# setup <dir> <exponent> <CheckInterval> [<binary>]
 	printf 'CheckInterval = %s\nJacobiCheckHours = 0\n' "$ci" > "$d/mlucas.ini"
 	echo "$d"
 }
-run() {	# run <dir> [env...] : run Mlucas to completion (or until it exits) in <dir>, log to run.log
-	local d=$1; shift
-	( cd "$d" && env "$@" timeout 900 ./Mlucas -cpu "$CPU" > run.log 2>&1 ); echo $? > "$d/exit"
+run() {	# run <dir> [env...] [-- <extra Mlucas args>] : run Mlucas to completion (or until it exits) in <dir>, log to run.log
+	local d=$1; shift; local envs=() extra=()
+	while (( $# )); do if [[ $1 == -- ]]; then shift; extra=("$@"); break; fi; envs+=("$1"); shift; done
+	( cd "$d" && env "${envs[@]}" timeout 900 ./Mlucas -cpu "$CPU" "${extra[@]}" > run.log 2>&1 ); echo $? > "$d/exit"
 }
 # Run in the background and stop it with SIGINT once the .stat file shows the given iteration.
 run_until_iter_then_interrupt() {	# <dir> <exponent> <iteration>
@@ -129,24 +130,26 @@ if [[ -z $MLUCAS_FI ]]; then
 	skip "T5: fault-injection tests need a -DMLUCAS_FAULT_INJECT build as the 2nd argument"
 else
 	echo "-- T5: fault injection at iteration 50000 (fixed, deterministic cases)"
-	# Each (exponent, iteration, digit) triple gives a deterministic verdict, so the cases are fixed rather
-	# than searched for. The injection lands exactly at a checked checkpoint, so the check sees two
-	# independent values: the symbol at the corrupted iteration itself (the check at 50000) and the one
-	# shared by every later check (from 60000 on). One case per class:
-	#   caught      - M216103 digit 0: fails at 50000; rollback to the previous checkpoint (40000), correct
-	#                 result, 1 error counted;
-	#   caught_late - M216103 digit 3: passes at 50000 (so the corrupt residue is saved to p, q and .J) but
-	#                 fails at 60000 and on every retry: the chain must walk p -> .J -> .J1 (40000, clean),
+	# Each (exponent, iteration, digit, residue shift) gives a deterministic verdict, so the cases are fixed
+	# rather than searched for. The runs use -shift 0: the injector perturbs one digit of the residue *as
+	# stored*, so with a random shift the perturbed bit position - and hence the verdict - would change from
+	# run to run. The injection lands exactly at a checked checkpoint, so the check sees two independent
+	# values: the symbol at the corrupted iteration itself (the check at 50000) and the one shared by every
+	# later check (from 60000 on). One case per class, all on M216103 (digits classified with -shift 0):
+	#   caught      - digit 3: fails at 50000; rollback to the previous checkpoint (40000), correct result,
+	#                 1 error counted;
+	#   caught_late - digit 13: passes at 50000 (so the corrupt residue is saved to p, q and .J) but fails
+	#                 at 60000 and on every retry: the chain must walk p -> .J -> .J1 (40000, clean),
 	#                 3 errors counted;
-	#   missed      - M216091 digit 3: passes both, so no check ever fires, and the run ends with a WRONG
-	#                 verdict ("not prime" for a Mersenne prime). Asserted on purpose: it is the check's
-	#                 known limit, and this documents it rather than hiding it.
-	d=$(setup t5clean 216103 10000); run "$d"
+	#   missed      - digit 0: passes both, so no check ever fires, and the run ends with a WRONG residue.
+	#                 Asserted on purpose: it is the check's known limit, and this documents it rather than
+	#                 hiding it.
+	d=$(setup t5clean 216103 10000); run "$d" -- -shift 0
 	CLEAN=$(res64_of "$d"); [[ ${#CLEAN} -eq 16 ]] && ok "clean M216103 run Res64 $CLEAN" || bad "clean run produced no results line"
 
-	d=$(setup t5caught 216103 10000 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_ITER=50000 MLUCAS_FAULT_WORD=0
+	d=$(setup t5caught 216103 10000 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_ITER=50000 MLUCAS_FAULT_WORD=3 -- -shift 0
 	S=$d/p216103.stat
-	expect_grep "$S" "FAULT INJECTION: added 1.0 to residue digit 0 at iteration 50000" "caught: injection fired"
+	expect_grep "$S" "FAULT INJECTION: added 1.0 to residue digit 3 at iteration 50000" "caught: injection fired"
 	expect_grep "$S" "Jacobi check at iteration 50000 FAILED" "caught: failure at the corrupted checkpoint"
 	expect_grep "$S" "Restarting from the current savefile" "caught: rollback to the current savefile announced"
 	expect_grep "$S" "Restart file p216103 (iteration 40000) passed the Jacobi check" "caught: rolled back to the previous (clean) checkpoint"
@@ -155,9 +158,9 @@ else
 	if grep -qE '"error-code":"[0-9A-F]{6}1[0-9A-F]"' "$d/results.txt"; then ok "caught: one Jacobi error in the error-code nibble (bits 4-7)"; else bad "caught: Jacobi nibble != 1: $(grep -o '"error-code":"[0-9A-F]*"' "$d/results.txt")"; fi
 	expect_grep "$d/results.txt" '"jacobi":1' "caught: jacobi count 1 in the errors object"
 
-	d=$(setup t5late 216103 10000 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_ITER=50000 MLUCAS_FAULT_WORD=3
+	d=$(setup t5late 216103 10000 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_ITER=50000 MLUCAS_FAULT_WORD=13 -- -shift 0
 	S=$d/p216103.stat
-	expect_grep "$S" "FAULT INJECTION: added 1.0 to residue digit 3 at iteration 50000" "caught_late: injection fired"
+	expect_grep "$S" "FAULT INJECTION: added 1.0 to residue digit 13 at iteration 50000" "caught_late: injection fired"
 	expect_nogrep "$S" "Jacobi check at iteration 50000 FAILED" "caught_late: passes the check at its own checkpoint"
 	expect_count "$S" "Jacobi check at iteration 60000 FAILED" 3 "caught_late: the same failure recurs on each retry from a poisoned file"
 	expect_grep "$S" "Restart file p216103 (iteration 50000) passed the Jacobi check" "caught_late: p (poisoned) passes its on-read check, as the symbol invariance predicts"
@@ -166,12 +169,12 @@ else
 	[[ $(res64_of "$d") == "$CLEAN" ]] && ok "caught_late: final Res64 matches the clean run" || bad "caught_late: final Res64 $(res64_of "$d") != clean $CLEAN"
 	if grep -qE '"error-code":"[0-9A-F]{6}3[0-9A-F]"' "$d/results.txt"; then ok "caught_late: three Jacobi errors in the error-code nibble"; else bad "caught_late: Jacobi nibble != 3: $(grep -o '"error-code":"[0-9A-F]*"' "$d/results.txt")"; fi
 
-	d=$(setup t5missed 216091 10000 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_ITER=50000 MLUCAS_FAULT_WORD=3
-	S=$d/p216091.stat
-	expect_grep "$S" "FAULT INJECTION: added 1.0 to residue digit 3 at iteration 50000" "missed: injection fired"
+	d=$(setup t5missed 216103 10000 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_ITER=50000 MLUCAS_FAULT_WORD=0 -- -shift 0
+	S=$d/p216103.stat
+	expect_grep "$S" "FAULT INJECTION: added 1.0 to residue digit 0 at iteration 50000" "missed: injection fired"
 	expect_nogrep "$S" "FAILED" "missed: no check ever fires (symbol invariant under the recurrence)"
-	expect_grep "$S" "M216091 is not prime" "missed: run ends with a WRONG verdict for a Mersenne prime - this is the documented limit of the check"
-	expect_nogrep "$S" "known MERSENNE PRIME" "missed: (and not the correct verdict)"
+	[[ $(res64_of "$d") != "$CLEAN" ]] && ok "missed: run ends with a WRONG residue $(res64_of "$d") - this is the documented limit of the check" || bad "missed: final residue equals the clean one?!"
+	if grep -qE '"error-code":"[0-9A-F]{6}0[0-9A-F]"' "$d/results.txt"; then ok "missed: Jacobi nibble 0, as expected - nothing was detected"; else bad "missed: Jacobi nibble != 0"; fi
 fi
 
 # ---------------------------------------------------------------------------------------------

--- a/tests/jacobi-pm1.sh
+++ b/tests/jacobi-pm1.sh
@@ -100,7 +100,7 @@ cp "$FCFG" "$d/fermat.cfg"
 printf 'Pminus1=1,2,65536,1,20000,20000\n' > "$d/worktodo.txt"; printf 'CheckInterval = 1000\nGerbiczCheckInterval = 10000\n' > "$d/mlucas.ini"
 # -fft 4: left to itself the p-1 FFT-length choice for F16 is 3K, which the Fermat-mod transform cannot run (no radix 12)
 # and which has no fermat.cfg entry - and a missing Fermat cfg length sends Mlucas into an endless Mersenne self-test loop
-# appending to mlucas.cfg (pre-existing, not this feature's). 4K is what config-fermat.sh and the Pepin test use for F16.
+# appending to mlucas.cfg (pre-existing; PR #174 fixes both). 4K is what config-fermat.sh and the Pepin test use for F16.
 run "$d" -- -fft 4; S=$d/f16.stat
 if [[ -f $S ]]; then
 	expect_grep "$S" "At iteration 10000, shift = 0: Gerbicz check passed" "Fermat: check at 10^4 passed"

--- a/tests/jacobi-pm1.sh
+++ b/tests/jacobi-pm1.sh
@@ -61,6 +61,23 @@ final_res64() { grep "S1 bit = $LAST " "$1/p$P.stat" | grep -o "Res64: [0-9A-F]*
 echo "== p-1 stage 1 Gerbicz / Jacobi checks: end-to-end tests (work dir $WORK)"
 
 # ---------------------------------------------------------------------------------------------
+echo "-- P0: GerbiczCheckInterval = 10000 (block L = 100) on a short stage 1 (B1 = 20000, 29010 iterations)"
+d=$WORK/p0; rm -rf "$d"; mkdir -p "$d"; ln -s "$MLUCAS" "$d/Mlucas"; [[ -n $CFG && -f $CFG ]] && cp "$CFG" "$d/mlucas.cfg"
+printf 'Pminus1=1,2,%s,-1,20000,20000\n' "$P" > "$d/worktodo.txt"; printf 'CheckInterval = 1000\nGerbiczCheckInterval = 10000\n' > "$d/mlucas.ini"
+run "$d"; S=$d/p$P.stat
+expect_grep "$S" "p-1 stage 1 Gerbicz check every 10000 iterations (block L = 100, from GerbiczCheckInterval)" "interval taken from mlucas.ini"
+expect_grep "$S" "At iteration 10000, shift = 0: Gerbicz check passed" "check at 10^4 passed (correction with a large high part H)"
+expect_grep "$S" "At iteration 20000, shift = 0: Gerbicz check passed" "check at 2*10^4 passed"
+expect_grep "$S" "At iteration 29000, shift = 0: Gerbicz check passed" "end-of-run check at the last block boundary passed"
+expect_nogrep "$S" "Gerbicz check iteration" "no failures"
+expect_grep "$S" "Stage 1 final residue passed the Jacobi check (.*overlapped with the GCD)" "final Jacobi check ran on its own thread alongside the GCD"
+d=$WORK/p0b; rm -rf "$d"; mkdir -p "$d"; ln -s "$MLUCAS" "$d/Mlucas"; [[ -n $CFG && -f $CFG ]] && cp "$CFG" "$d/mlucas.cfg"
+printf 'Pminus1=1,2,%s,-1,20000,20000\n' "$P" > "$d/worktodo.txt"; printf 'CheckInterval = 1000\nGerbiczCheckInterval = 12345\n' > "$d/mlucas.ini"
+run "$d"; S=$d/p$P.stat
+expect_grep "$S" "WARN: GerbiczCheckInterval = 12345 is not usable with CheckInterval = 1000: .*(e.g. 10000, 40000, 250000, 1000000)" "unusable value rejected with the admissible list"
+expect_grep "$S" "Gerbicz check every 1000000 iterations (block L = 1000, automatic)" "fell back to the automatic choice"
+
+# ---------------------------------------------------------------------------------------------
 echo "-- P1: clean p-1 stage 1 (M$P, B1 = $B1)"
 d=$(setup p1); run "$d"; S=$d/p$P.stat
 expect_grep  "$S" "At iteration 1000000, shift = 0: Gerbicz check passed" "check at 10^6 passed"

--- a/tests/jacobi-pm1.sh
+++ b/tests/jacobi-pm1.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# End-to-end tests for the p-1 stage 1 Gerbicz check and the p-1 Jacobi integrity checks (help.txt section [9]).
+#
+# Usage: tests/jacobi-pm1.sh <Mlucas binary> [<Mlucas binary built with -DMLUCAS_FAULT_INJECT>] [<mlucas.cfg>]
+#
+# Exponent 44497 with B1 = B2 = 1500000: stage 1 is 2165373 iterations (~30 s at a 2K FFT), so with the default
+# check interval of 10^6 there are Gerbicz checks at 1000000 and 2000000 plus the end-of-run check at 2165000.
+# Stage 2 is not run (B2 = B1).
+#
+# What is asserted, and why: a clean run passes every check and the final residue passes its Jacobi check; a
+# run interrupted mid-epoch resumes with the stored check-product (the epoch continues, and the next check
+# still passes); a savefile whose residue is damaged is refused by the Jacobi read check and the run falls back
+# to the secondary; and an injected fault at a checkpoint is caught by the next Gerbicz check with certainty
+# (unlike the LL Jacobi check, this one is exact), the run rolls back to the last .G checkpoint and finishes
+# with the same stage 1 residue as the clean run.
+set -u -o pipefail
+
+MLUCAS=${1:?usage: $0 <Mlucas> [<Mlucas-fault-inject>] [<mlucas.cfg>]}
+MLUCAS_FI=${2:-}
+CFG=${3:-}
+MLUCAS=$(readlink -f "$MLUCAS"); [[ -n $MLUCAS_FI ]] && MLUCAS_FI=$(readlink -f "$MLUCAS_FI")
+[[ -n $CFG ]] && CFG=$(readlink -f "$CFG")
+CPU=${JACOBI_TEST_CPU:-0:3}
+WORK=${JACOBI_TEST_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/jacobi-pm1.XXXXXX")}
+mkdir -p "$WORK"
+PASS=0; FAIL=0; SKIP=0
+P=44497; B1=1500000; LAST=2165373; LASTCHK=2165000
+
+ok()   { echo "  ok   - $*"; PASS=$((PASS+1)); }
+bad()  { echo "  FAIL - $*"; FAIL=$((FAIL+1)); }
+skip() { echo "  skip - $*"; SKIP=$((SKIP+1)); }
+expect_grep()   { local f=$1 pat=$2 what=$3; if grep -q -- "$pat" "$f"; then ok "$what"; else bad "$what (pattern not found: $pat)"; fi; }
+expect_nogrep() { local f=$1 pat=$2 what=$3; if grep -q -- "$pat" "$f"; then bad "$what (unexpected: $(grep -m1 -- "$pat" "$f"))"; else ok "$what"; fi; }
+expect_count()  { local f=$1 pat=$2 min=$3 what=$4; local n; n=$(grep -c -- "$pat" "$f"); if (( n >= min )); then ok "$what ($n)"; else bad "$what: $n < $min"; fi; }
+
+setup() {	# setup <dir> [<binary>]
+	local d=$WORK/$1 bin=${2:-$MLUCAS}
+	rm -rf "$d"; mkdir -p "$d"
+	ln -s "$bin" "$d/Mlucas"
+	[[ -n $CFG && -f $CFG ]] && cp "$CFG" "$d/mlucas.cfg"
+	printf 'Pminus1=1,2,%s,-1,%s,%s\n' "$P" "$B1" "$B1" > "$d/worktodo.txt"
+	printf 'CheckInterval = 10000\n' > "$d/mlucas.ini"
+	echo "$d"
+}
+run() {	# run <dir> [env...]
+	local d=$1; shift
+	( cd "$d" && env "$@" timeout 1800 ./Mlucas -cpu "$CPU" > run.log 2>&1 ); echo $? > "$d/exit"
+}
+run_until_iter_then_interrupt() {	# <dir> <iteration>
+	local d=$1 it=$2 pid i
+	( cd "$d" && exec ./Mlucas -cpu "$CPU" > run.log 2>&1 ) & pid=$!
+	for i in $(seq 1 1200); do
+		sleep 0.5
+		grep -q "S1 bit = $it " "$d/p$P.stat" 2>/dev/null && break
+		kill -0 $pid 2>/dev/null || break
+	done
+	kill -INT $pid 2>/dev/null; wait $pid 2>/dev/null; echo $? > "$d/exit"
+}
+final_res64() { grep "S1 bit = $LAST " "$1/p$P.stat" | grep -o "Res64: [0-9A-F]*" | tail -1 | cut -d' ' -f2; }
+
+echo "== p-1 stage 1 Gerbicz / Jacobi checks: end-to-end tests (work dir $WORK)"
+
+# ---------------------------------------------------------------------------------------------
+echo "-- P1: clean p-1 stage 1 (M$P, B1 = $B1)"
+d=$(setup p1); run "$d"; S=$d/p$P.stat
+expect_grep  "$S" "At iteration 1000000, shift = 0: Gerbicz check passed" "check at 10^6 passed"
+expect_grep  "$S" "At iteration 2000000, shift = 0: Gerbicz check passed" "check at 2*10^6 passed"
+expect_grep  "$S" "At iteration $LASTCHK, shift = 0: Gerbicz check passed" "end-of-run check at the last block boundary passed"
+expect_nogrep "$S" "Gerbicz check iteration" "no failures"
+expect_grep  "$S" "Stage 1 final residue passed the Jacobi check" "final-residue Jacobi (conversion-path) check passed"
+expect_grep  "$S" "GCD" "stage 1 GCD ran"
+[[ -f $d/p$P.G ]] && ok ".G (last-good-check) savefile written" || bad ".G missing"
+expect_grep "$d/results.txt" '"errors":{"Roundoff":[0-9]*, "gerbicz":0, "jacobi":0}' "results line carries zero Gerbicz and Jacobi counts"
+CLEAN=$(final_res64 "$d"); [[ ${#CLEAN} -eq 16 ]] && ok "clean final stage 1 Res64 $CLEAN" || bad "no final stage 1 Res64 in the .stat file"
+
+# ---------------------------------------------------------------------------------------------
+echo "-- P2: interrupt mid-epoch and resume: the stored check-product carries the epoch across the restart"
+d=$(setup p2); run_until_iter_then_interrupt "$d" 1300000; S=$d/p$P.stat
+if grep -q "Received SIGINT signal: writing savefile at Iter = " "$S"; then
+	run "$d"
+	expect_grep  "$S" "Restart file p$P (stage 1 iteration [0-9]*) passed the Jacobi check" "loaded residue passed the Jacobi read check"
+	expect_nogrep "$S" "carries no Gerbicz check-product" "the epoch continued from the stored product (no new epoch)"
+	expect_grep  "$S" "At iteration 2000000, shift = 0: Gerbicz check passed" "the check spanning the restart passed"
+	[[ $(final_res64 "$d") == "$CLEAN" ]] && ok "final stage 1 Res64 matches the clean run" || bad "final Res64 $(final_res64 "$d") != clean $CLEAN"
+else
+	bad "could not interrupt the run in time"
+fi
+
+# ---------------------------------------------------------------------------------------------
+echo "-- P3: damaged primary savefile is refused by the Jacobi read check; the secondary is used"
+d=$(setup p3); run_until_iter_then_interrupt "$d" 1300000; S=$d/p$P.stat
+if [[ -f $d/p$P && -f $d/q$P ]]; then
+	# Flip a residue byte in p only and re-derive nothing: the S-H triplet catches this first, so also patch the
+	# triplet-consistent case would need the corruptor tool; here the point is the fall-through to q.
+	printf '\xff' | dd of="$d/p$P" bs=1 seek=100 conv=notrunc status=none
+	run "$d"
+	expect_grep "$S" "read_ppm1_savefiles Failed on savefile p$P" "damaged primary rejected"
+	expect_grep "$S" "Restart file q$P (stage 1 iteration [0-9]*) passed the Jacobi check" "secondary passed the Jacobi read check"
+	[[ $(final_res64 "$d") == "$CLEAN" ]] && ok "final stage 1 Res64 matches the clean run" || bad "final Res64 $(final_res64 "$d") != clean $CLEAN"
+else
+	bad "expected p/q savefiles after the interrupt"
+fi
+
+# ---------------------------------------------------------------------------------------------
+if [[ -z $MLUCAS_FI ]]; then
+	skip "P4: fault-injection test needs a -DMLUCAS_FAULT_INJECT build as the 2nd argument"
+else
+	echo "-- P4: fault injected at iteration 1500000: the Gerbicz check at 2000000 must catch it (exact, not a coin flip)"
+	d=$(setup p4 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_ITER=1500000 MLUCAS_FAULT_WORD=0; S=$d/p$P.stat
+	expect_grep "$S" "FAULT INJECTION: added 1.0 to residue digit 0 at iteration 1500000" "injection fired"
+	expect_grep "$S" "Gerbicz check iteration 2000000 failed! Restarting from last-good-Gerbicz-check data" "caught at the next check"
+	expect_grep "$S" "Restart file p$P.G (stage 1 iteration 1000000) passed the Jacobi check" "rolled back to the .G checkpoint at 10^6"
+	expect_grep "$S" "At iteration 2000000, shift = 0: Gerbicz check passed" "the retried block passed"
+	[[ $(final_res64 "$d") == "$CLEAN" ]] && ok "final stage 1 Res64 matches the clean run" || bad "final Res64 $(final_res64 "$d") != clean $CLEAN"
+	expect_grep "$d/results.txt" '"gerbicz":1' "one Gerbicz error counted in the results line"
+	# bits 20-23 = 3rd hex digit of the 8-digit code (digits are bits 31-28, 27-24, 23-20, ...)
+	if grep -qE '"error-code":"[0-9A-F]{2}1[0-9A-F]{5}"' "$d/results.txt"; then ok "Gerbicz nibble (bits 20-23) = 1 in the error-code"; else bad "Gerbicz nibble != 1: $(grep -o '"error-code":"[0-9A-F]*"' "$d/results.txt")"; fi
+fi
+
+# ---------------------------------------------------------------------------------------------
+# Stage 2: B1 = 20000 (fast stage 1), B2 = 2000000. The exact input checks - ladder recomputation, static-table
+# checksums - and the accumulator sanity tests run at every stage 2 checkpoint here (JacobiCheckHours = 0).
+setup2() {	# setup2 <dir> [<binary>]
+	local d=$WORK/$1 bin=${2:-$MLUCAS}
+	rm -rf "$d"; mkdir -p "$d"
+	ln -s "$bin" "$d/Mlucas"
+	[[ -n $CFG && -f $CFG ]] && cp "$CFG" "$d/mlucas.cfg"
+	printf 'Pminus1=1,2,%s,-1,20000,2000000\n' "$P" > "$d/worktodo.txt"
+	printf 'CheckInterval = 10000\nJacobiCheckHours = 0\n' > "$d/mlucas.ini"
+	echo "$d"
+}
+s2_final() { grep -o '"B2":[0-9]*, "error-code":"[0-9A-F]*"' "$1/results.txt" 2>/dev/null | tail -1; grep "S2 at q" "$1/p$P.stat" | tail -1 | grep -o "Res64: [0-9A-F]*"; }
+
+echo "-- P5: clean stage 2 (B1 = 20000, B2 = 2000000): ladder, table and accumulator checks pass at every checkpoint"
+d=$(setup2 p5); run "$d"; S=$d/p$P.stat
+expect_count "$S" "Stage 2 ladder check passed at q = " 5 "ladder recomputation passed at the stage 2 checkpoints"
+expect_nogrep "$S" "ERROR: M$P stage 2" "no stage 2 check failure"
+expect_grep "$d/results.txt" '"B2":2000000' "stage 2 completed and reported"
+CLEAN2=$(s2_final "$d" | tail -1); [[ -n $CLEAN2 ]] && ok "clean stage 2 final accumulator $CLEAN2" || bad "no stage 2 Res64 in the .stat file"
+
+if [[ -n $MLUCAS_FI ]]; then
+	echo "-- P6: stage 2 ladder corrupted at q ~ 1000000: caught exactly by the recomputation; restart finishes clean"
+	d=$(setup2 p6 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_S2=ladder MLUCAS_FAULT_S2_Q=1000000; S=$d/p$P.stat
+	expect_grep "$S" "FAULT INJECTION: stage 2 ladder perturbed" "injection fired"
+	expect_grep "$S" "stage 2 ladder check FAILED" "ladder mismatch detected"
+	[[ $(cat "$d/exit") != 0 ]] && ok "run stopped (exit $(cat "$d/exit")) with the .s2 checkpoint intact" || bad "run did not stop"
+	[[ -f $d/p$P.s2 ]] && ok ".s2 checkpoint present" || bad ".s2 checkpoint missing"
+	run "$d"	# restart: rebuilds ladder and tables from the stage 1 residue, resumes the accumulator from .s2
+	# (A restarted stage 2 rebuilds its prime-pairing window from the checkpoint q, so its final accumulator is a
+	# legitimately different product from an uninterrupted run's - the same is true of a plain interrupt/resume -
+	# hence recovery is asserted through completion and clean checks, not through accumulator equality.)
+	[[ $(grep -c "stage 2 ladder check FAILED" "$S") -eq 1 ]] && ok "no repeat failure on restart" || bad "ladder failure recurred after restart"
+	expect_grep "$d/results.txt" '"B2":2000000' "restarted stage 2 completed"
+	expect_count "$S" "Stage 2 ladder check passed at q = " 3 "ladder checks pass after the restart"
+
+	echo "-- P7: stage 2 table entry corrupted: caught by the checksum; restart finishes clean"
+	d=$(setup2 p7 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_S2=table MLUCAS_FAULT_S2_Q=1000000; S=$d/p$P.stat
+	expect_grep "$S" "FAULT INJECTION: stage 2 table perturbed" "injection fired"
+	expect_grep "$S" "stage 2 table entry 1 of [0-9]* fails its checksum" "checksum mismatch detected on the corrupted entry"
+	run "$d"
+	[[ $(grep -c "fails its checksum" "$S") -eq 1 ]] && ok "no repeat failure on restart" || bad "checksum failure recurred after restart"
+	expect_grep "$d/results.txt" '"B2":2000000' "restarted stage 2 completed"
+
+	echo "-- P8: stage 2 accumulator corrupted: NOT caught (no invariant exists) - the run ends with a different result"
+	d=$(setup2 p8 "$MLUCAS_FI"); run "$d" MLUCAS_FAULT_S2=accum MLUCAS_FAULT_S2_Q=1000000; S=$d/p$P.stat
+	expect_grep "$S" "FAULT INJECTION: stage 2 accum perturbed" "injection fired"
+	expect_nogrep "$S" "ERROR: M$P stage 2" "nothing catches it - this is the documented limit of the stage 2 checks"
+	[[ $(s2_final "$d" | tail -1) != "$CLEAN2" ]] && ok "run ends with a WRONG accumulator $(s2_final "$d" | tail -1) - documented, not hidden" || bad "accumulator equals the clean one?!"
+else
+	skip "P6-P8: stage 2 fault-injection tests need a -DMLUCAS_FAULT_INJECT build"
+fi
+
+echo "== $PASS passed, $FAIL failed, $SKIP skipped (work dir $WORK)"
+(( FAIL == 0 ))

--- a/tests/jacobi-pm1.sh
+++ b/tests/jacobi-pm1.sh
@@ -42,9 +42,10 @@ setup() {	# setup <dir> [<binary>]
 	printf 'CheckInterval = 10000\n' > "$d/mlucas.ini"
 	echo "$d"
 }
-run() {	# run <dir> [env...]
-	local d=$1; shift
-	( cd "$d" && env "$@" timeout 1800 ./Mlucas -cpu "$CPU" > run.log 2>&1 ); echo $? > "$d/exit"
+run() {	# run <dir> [env...] [-- <extra Mlucas args>]
+	local d=$1; shift; local envs=() extra=()
+	while (( $# )); do if [[ $1 == -- ]]; then shift; extra=("$@"); break; fi; envs+=("$1"); shift; done
+	( cd "$d" && env "${envs[@]}" timeout 1800 ./Mlucas -cpu "$CPU" "${extra[@]}" > run.log 2>&1 ); echo $? > "$d/exit"
 }
 run_until_iter_then_interrupt() {	# <dir> <iteration>
 	local d=$1 it=$2 pid i
@@ -76,6 +77,42 @@ printf 'Pminus1=1,2,%s,-1,20000,20000\n' "$P" > "$d/worktodo.txt"; printf 'Check
 run "$d"; S=$d/p$P.stat
 expect_grep "$S" "WARN: GerbiczCheckInterval = 12345 is not usable with CheckInterval = 1000: .*(e.g. 10000, 40000, 250000, 1000000)" "unusable value rejected with the admissible list"
 expect_grep "$S" "Gerbicz check every 1000000 iterations (block L = 1000, automatic)" "fell back to the automatic choice"
+
+# ---------------------------------------------------------------------------------------------
+echo "-- P0c: LowMem = 2: no Gerbicz arrays, so stage 1 runs with no arithmetic check and says so; Jacobi integrity checks still run"
+d=$WORK/p0c; rm -rf "$d"; mkdir -p "$d"; ln -s "$MLUCAS" "$d/Mlucas"; [[ -n $CFG && -f $CFG ]] && cp "$CFG" "$d/mlucas.cfg"
+printf 'Pminus1=1,2,%s,-1,20000,20000\n' "$P" > "$d/worktodo.txt"; printf 'CheckInterval = 1000\nLowMem = 2\n' > "$d/mlucas.ini"
+run "$d"; S=$d/p$P.stat
+expect_grep "$S" "p-1 stage 1 will run with NO arithmetic error check" "the one-time warning"
+expect_nogrep "$S" "Gerbicz check passed\|Gerbicz check iteration\|Gerbicz check at iteration" "no Gerbicz check ran"
+expect_grep "$S" "Stage 1 final residue passed the Jacobi check (.* sec)." "final Jacobi check ran inline (no scratch array for the thread)"
+expect_nogrep "$S" "overlapped with the GCD" "(and not on a thread)"
+expect_grep "$S" "GCD" "stage 1 completed to the GCD"
+[[ ! -f $d/p$P.G ]] && ok "no .G file without the check" || bad ".G written without a check"
+
+echo "-- P0d: Fermat number F16 = 2^65536+1, stage 1 with GerbiczCheckInterval = 10000: the same checks on the Fermat-mod path"
+d=$WORK/p0d; rm -rf "$d"; mkdir -p "$d"; ln -s "$MLUCAS" "$d/Mlucas"; [[ -n $CFG && -f $CFG ]] && cp "$CFG" "$d/mlucas.cfg"
+FCFG=${JACOBI_TEST_FERMAT_CFG:-$(dirname "${CFG:-.}")/fermat.cfg}	# Fermat runs need fermat.cfg (produced by config-fermat.sh)
+if [[ ! -f $FCFG ]]; then
+	skip "P0d: no fermat.cfg at $FCFG (run config-fermat.sh, or point JACOBI_TEST_FERMAT_CFG at one)"
+else
+cp "$FCFG" "$d/fermat.cfg"
+printf 'Pminus1=1,2,65536,1,20000,20000\n' > "$d/worktodo.txt"; printf 'CheckInterval = 1000\nGerbiczCheckInterval = 10000\n' > "$d/mlucas.ini"
+# -fft 4: left to itself the p-1 FFT-length choice for F16 is 3K, which the Fermat-mod transform cannot run (no radix 12)
+# and which has no fermat.cfg entry - and a missing Fermat cfg length sends Mlucas into an endless Mersenne self-test loop
+# appending to mlucas.cfg (pre-existing, not this feature's). 4K is what config-fermat.sh and the Pepin test use for F16.
+run "$d" -- -fft 4; S=$d/f16.stat
+if [[ -f $S ]]; then
+	expect_grep "$S" "At iteration 10000, shift = 0: Gerbicz check passed" "Fermat: check at 10^4 passed"
+	expect_grep "$S" "At iteration 20000, shift = 0: Gerbicz check passed" "Fermat: check at 2*10^4 passed"
+	expect_nogrep "$S" "Gerbicz check iteration" "Fermat: no failures"
+	expect_grep "$S" "Stage 1 final residue passed the Jacobi check" "Fermat: final Jacobi check passed (expected +1)"
+	expect_grep "$S" "Found 10-digit factor in Stage 1: 825753601" "Fermat: the known factor 825753601 of F16 found (stage 1 arithmetic right end to end)"
+	expect_grep "$S" "GCD" "Fermat: stage 1 completed to the GCD"
+else
+	bad "no f16.stat produced (run.log tail: $(tail -2 "$d/run.log" | tr '\n' ' '))"
+fi
+fi
 
 # ---------------------------------------------------------------------------------------------
 echo "-- P1: clean p-1 stage 1 (M$P, B1 = $B1)"
@@ -132,6 +169,19 @@ else
 	expect_grep "$d/results.txt" '"gerbicz":1' "one Gerbicz error counted in the results line"
 	# bits 20-23 = 3rd hex digit of the 8-digit code (digits are bits 31-28, 27-24, 23-20, ...)
 	if grep -qE '"error-code":"[0-9A-F]{2}1[0-9A-F]{5}"' "$d/results.txt"; then ok "Gerbicz nibble (bits 20-23) = 1 in the error-code"; else bad "Gerbicz nibble != 1: $(grep -o '"error-code":"[0-9A-F]*"' "$d/results.txt")"; fi
+fi
+
+# ---------------------------------------------------------------------------------------------
+if [[ -n $MLUCAS_FI ]]; then
+	echo "-- P4b: a reproducible stage 1 fault: the Gerbicz retry is bounded (rollback to .G three times, then abort)"
+	d=$WORK/p4b; rm -rf "$d"; mkdir -p "$d"; ln -s "$MLUCAS_FI" "$d/Mlucas"; [[ -n $CFG && -f $CFG ]] && cp "$CFG" "$d/mlucas.cfg"
+	printf 'Pminus1=1,2,%s,-1,20000,20000\n' "$P" > "$d/worktodo.txt"; printf 'CheckInterval = 1000\nGerbiczCheckInterval = 10000\n' > "$d/mlucas.ini"
+	run "$d" MLUCAS_FAULT_ITER=15000 MLUCAS_FAULT_WORD=0 MLUCAS_FAULT_REPEAT=1; S=$d/p$P.stat
+	expect_count "$S" "FAULT INJECTION: added 1.0 to residue digit 0 at iteration 15000" 4 "injection re-fired on every retry"
+	expect_count "$S" "Gerbicz check iteration 20000 failed! Restarting from last-good-Gerbicz-check data" 3 "three rollbacks to .G"
+	expect_grep "$S" "Gerbicz check at iteration 20000 failed 4 times in a row" "fourth failure aborts with the hardware warning"
+	[[ $(cat "$d/exit") != 0 ]] && ok "run stopped (exit $(cat "$d/exit"))" || bad "run did not stop"
+	[[ -f $d/p$P && -f $d/p$P.G ]] && ok "savefiles left in place" || bad "savefiles missing after the abort"
 fi
 
 # ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
Resolves #97 (the P-1 half; the LL half is #264, which this branch is based on - only the commits after
#264's tip are new here).

**Stage 1: a Gerbicz check, not a Jacobi check.** Stage 1 is x <- x^2 * 3^b per iteration, so the PRP
Gerbicz identity applies with one correction factor: with b[] the running product of the block-boundary
residues and d[] its copy from the previous check, b == u0 * d^(2^L) * 3^C, where C is the sum of the L-bit
exponent chunks consumed since the check epoch started and u0 the residue the epoch started from (3 from
scratch). C is recomputed from the prime-powers product at each check and split C = H * 2^L + Lo: the L
verification squarings run against a private multiply-by-base bit array holding Lo, so they produce
d^(2^L) * 3^Lo for free, and the remainder u0 * 3^(H * 2^L) is g3^H against a once-per-run g3 = 3^(2^L),
~2 log2 H modmuls. The check-product update runs against that private array too, because its carry step
would otherwise pick up the live exponent bit for its iteration (it did, and multiplied a stray 3 into the
product - found by comparing b[] against an independent Python product of the same residues). Detection of
an arithmetic error in the checked interval is essentially certain, at ~2/L of stage 1; a failure rolls back
to the `.G` savefile exactly as PRP does. Why not Jacobi here: squaring maps every value into the quadratic
residues, so a corrupted residue carries the expected symbol from the next iteration on - a Jacobi check
cannot see stage 1 arithmetic at all.

**Check interval.** `GerbiczCheckInterval` in mlucas.ini (p-1 only; PRP keeps 10^6) sets the interval, which
must be L^2 with L dividing CheckInterval and CheckInterval dividing L^2 - an unusable value is reported with
the admissible ones and the automatic choice used. Automatic: the smallest admissible L >= 100 with L^2
iterations >= ~2 h at the mlucas.cfg per-iteration time, capped at L = 1000, so it only shortens the interval
on slow or very large runs (10^6 iterations is 14-55 h of exposure at 100M-digit exponents). Since the
>4-thread CheckInterval default of 10^5 admits only L = 1000, p-1 defaults CheckInterval to 10^4 unless set.

**Savefiles.** The check-product is appended to the p/q (and `.G`) stage 1 savefiles after the error
counts, behind an 8-byte epoch field, so older readers - which stop after the counts - are unaffected. A
file without it starts a new check epoch from the residue it holds. `DO_GCHECK` is cleared before stage 2,
whose own savefile I/O is untouched.

**Gerbicz retry bound (PRP too).** Found by the tests: a Gerbicz failure that reproduces (a fault at one iteration) rolled back to `.G` and failed there again forever, because the retry count was bounded only for the end-of-run check and was cleared by every passing check on the way back up. Every check's failures are now bounded (the fourth in a row aborts with the hardware warning, as the end-of-run one did) and the count is cleared only by a pass at or beyond the failure point. Builds on #178's `gchk_nfail`; applies to PRP as much as to P-1.

**Jacobi in P-1, reduced to what it can actually see:** the savefile and the FP-to-integer conversion path,
which the Gerbicz check cannot (both its operands go through it). It runs on every stage 1 restart-file
read (expected symbol J(3|N) if the last consumed exponent bit is 1, else +1) with fall-through to the
secondary on a mismatch, and on the final stage 1 residue before the GCD (expected +1) - that one runs on
its own thread alongside the GCD, so it costs no wall time. There is no periodic P-1 Jacobi check - there
is nothing for one to find. LowMem = 2, which has no room for the
Gerbicz arrays, runs stage 1 with no arithmetic check and says so once.

**Stage 2: exact checks of the inputs, honesty about the accumulator.** The accumulator is a product of
differences of powers and has no algebraic invariant that could be checked cheaply; the two inputs every
later term is built from do: the A^((kD)^2) ladder value is recomputed from the stage 1 residue by the same
two-step modpow the setup uses and must be bit-identical in the FFT domain to the running value (~130
modmuls, on the `JacobiCheckHours` clock), and the static A^(b^2) tables are checksummed after they are
built and re-verified a rotating 1/16 per checkpoint. The accumulator gets sanity tests only (never zero,
never unchanged across a checkpoint). Every failure stops the run with the `.s2` checkpoint intact; a
restart rebuilds ladder and tables and resumes the accumulator. A corruption of the accumulator itself is
not caught - the consequence is a missed factor, never a false claim - and the tests assert that it is
not caught, so the limit is documented rather than hidden.

**Results line.** P-1 output gains `error-code` (same layout as LL/PRP) and
`errors:{Roundoff, gerbicz, jacobi}`.

**Tests.** `tests/jacobi-pm1.sh`, in the Linux CI job: a short stage 1 with GerbiczCheckInterval = 10^4
(three checks, the folded-in correction with a large high part, the overlapped final Jacobi check) and an
unusable interval value rejected; clean stage 1 at B1 = 1.5M (checks at 10^6,
2*10^6 and the end-of-run boundary); interrupt/resume with the stored product carrying the epoch across
the restart; a damaged primary refused with fall-through to the secondary; a fault injected at 1.5M caught
at the 2M check with rollback to `.G` and the clean final residue; and stage 2 at B2 = 2M with clean checks
at every checkpoint, an injected ladder fault and an injected table fault each caught and recovered after
restart, and an injected accumulator fault demonstrably not caught. Also: a reproducible Gerbicz failure bounded at four attempts (three rollbacks to `.G`, then the abort) instead of looping; LowMem = 2 running stage 1 with no arithmetic check and saying so once; the same stage 1 checks on a Fermat number (F16 at FFT length 4K, the known factor 825753601 found - it needs the fermat.cfg entry config-fermat.sh writes and is skipped without one); and, in `tests/jacobi-check.sh`, the between-intervals interrupt of #267 exercised directly on a PRP run (T7) and the LL rollback chain walked to its end by a reproducible fault (T6).

**Docs.** help.txt sections [9], [11], [12], [14b]; docs/gerbicz.txt and docs/pm1.txt appendices; README
table.

Also included as its first commit: the fix for an interrupt arriving between iteration intervals leaving a
run "completing" with a frozen residue (#267, opened separately so PRP/Pépin users need not wait for this).
Merge order for the whole capability is in #224.

