### PR TITLE
Mfactor: the 4word and nword builds are compiled with a TRYQ they cannot dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,12 @@ jobs:
         # built these, so it costs no extra build time.
         if [[ $HOSTTYPE == aarch64 || $HOSTTYPE == arm64 ]]; then MSFX=_NOSIMD; else MSFX=; fi
         for word in '' 1word 2word 3word 4word nword; do
-            ( cd "../obj_mfac${word:+_$word}${MSFX}" && time "./Mfactor${word:+_$word}" -m 127 -bmax 20 )
+            # M(521), not M(127): the 4-word build's 256-bit modpow needs p + 256 >= 512 to have a
+            # lead chunk to work with, and asserts ("twopmodq256 : start_index < 2!") below that.
+            # M(127) only ever passed because a stray -DTRYQ=4 sent that build down the single-word
+            # path instead. 521 is the smallest Mersenne-prime exponent every word variant handles,
+            # and costs slightly less than 127 did (726k trial divides vs 1.66M).
+            ( cd "../obj_mfac${word:+_$word}${MSFX}" && time "./Mfactor${word:+_$word}" -m 521 -bmax 20 )
         done
     - uses: actions/upload-artifact@v7
       if: always()
@@ -159,7 +164,7 @@ jobs:
         # built these, so it costs no extra build time.
         if [[ $HOSTTYPE == aarch64 || $HOSTTYPE == arm64 ]]; then MSFX=_NOSIMD; else MSFX=; fi
         for word in '' 1word 2word 3word 4word nword; do
-            ( cd "../obj_mfac${word:+_$word}${MSFX}" && time "./Mfactor${word:+_$word}" -m 127 -bmax 20 )
+            ( cd "../obj_mfac${word:+_$word}${MSFX}" && time "./Mfactor${word:+_$word}" -m 521 -bmax 20 )
         done
     - uses: actions/upload-artifact@v7
       if: always()
@@ -346,7 +351,7 @@ jobs:
         for s in tt t s; do time ./Mlucas -prp -s $s -cpu "0:$(( $(nproc --all) - 1 ))"; done
         bash -e -o pipefail -- ../config-fermat.sh -cpu "0:$(( $(nproc --all) - 1 ))"
         for word in '' 1word 2word 3word 4word nword; do
-            ( cd "../obj_mfac${word:+_$word}_nosimd" && time "./Mfactor${word:+_$word}" -m 127 -bmax 20 )
+            ( cd "../obj_mfac${word:+_$word}_nosimd" && time "./Mfactor${word:+_$word}" -m 521 -bmax 20 )
         done
 
   TSan-Linux:
@@ -507,7 +512,7 @@ jobs:
         # built these, so it costs no extra build time.
         if [[ $HOSTTYPE == aarch64 || $HOSTTYPE == arm64 ]]; then MSFX=_NOSIMD; else MSFX=; fi
         for word in '' 1word 2word 3word 4word nword; do
-            ( cd "../obj_mfac${word:+_$word}${MSFX}" && time "./Mfactor${word:+_$word}" -m 127 -bmax 20 )
+            ( cd "../obj_mfac${word:+_$word}${MSFX}" && time "./Mfactor${word:+_$word}" -m 521 -bmax 20 )
         done
     - uses: actions/upload-artifact@v7
       if: always()
@@ -568,7 +573,7 @@ jobs:
         # built these, so it costs no extra build time.
         if [[ $HOSTTYPE == aarch64 || $HOSTTYPE == arm64 ]]; then MSFX=_NOSIMD; else MSFX=; fi
         for word in '' 1word 2word 3word 4word nword; do
-            ( cd "../obj_mfac${word:+_$word}${MSFX}" && time "./Mfactor${word:+_$word}" -m 127 -bmax 20 )
+            ( cd "../obj_mfac${word:+_$word}${MSFX}" && time "./Mfactor${word:+_$word}" -m 521 -bmax 20 )
         done
     - uses: actions/upload-artifact@v7
       if: always()
@@ -608,7 +613,7 @@ jobs:
         for s in tt t s; do time ./Mlucas -prp -s $s -cpu "0:$(( $(sysctl -n hw.ncpu) - 1 ))"; done
         bash -e -o pipefail -- ../config-fermat.sh -cpu "0:$(( $(sysctl -n hw.ncpu) - 1 ))"
         for word in '' 1word 2word 3word 4word nword; do
-            ( cd "../obj_mfac${word:+_$word}_nosimd" && time "./Mfactor${word:+_$word}" -m 127 -bmax 20 )
+            ( cd "../obj_mfac${word:+_$word}_nosimd" && time "./Mfactor${word:+_$word}" -m 521 -bmax 20 )
         done
 
   TSan-macOS:
@@ -700,7 +705,7 @@ jobs:
         # coverage: this VM may not be able to execute what they target - running them per-mode is
         # what makes the AVX-512 binary SIGILL on three of the four releases on main today.
         for word in '' 1word 2word 3word 4word nword; do
-            ( cd "../obj_mfac${word:+_$word}" && time "./Mfactor${word:+_$word}" -m 127 -bmax 20 )
+            ( cd "../obj_mfac${word:+_$word}" && time "./Mfactor${word:+_$word}" -m 521 -bmax 20 )
         done
     - uses: actions/upload-artifact@v7
       if: always()
@@ -792,7 +797,7 @@ jobs:
         # built these, so it costs no extra build time.
         if [[ $HOSTTYPE == aarch64 || $HOSTTYPE == arm64 ]]; then MSFX=_NOSIMD; else MSFX=; fi
         for word in '' 1word 2word 3word 4word nword; do
-            ( cd "../obj_mfac${word:+_$word}${MSFX}" && time "./Mfactor${word:+_$word}" -m 127 -bmax 20 )
+            ( cd "../obj_mfac${word:+_$word}${MSFX}" && time "./Mfactor${word:+_$word}" -m 521 -bmax 20 )
         done
     - uses: actions/upload-artifact@v7
       if: always()
@@ -842,5 +847,5 @@ jobs:
         for s in tt t s; do time ./Mlucas -prp -s $s -cpu "0:$(( NUMBER_OF_PROCESSORS - 1 ))"; done
         bash -e -o pipefail -- ../config-fermat.sh -cpu "0:$(( NUMBER_OF_PROCESSORS - 1 ))"
         for word in '' 1word 2word 3word 4word nword; do
-            ( cd "../obj_mfac${word:+_$word}_nosimd" && time "./Mfactor${word:+_$word}" -m 127 -bmax 20 )
+            ( cd "../obj_mfac${word:+_$word}_nosimd" && time "./Mfactor${word:+_$word}" -m 521 -bmax 20 )
         done

--- a/makemake.sh
+++ b/makemake.sh
@@ -38,8 +38,8 @@ TARGET=$Mlucas
 ARGS=(-DUSE_THREADS) # Optional compile args
 WORDS=''
 C_ARGS=()
-# Mfactor's factor.c gets an explicit TRYQ (see the word-size block below); the 1-, 2- and
-# 3-word builds all have 4-way batch modpows, so 4 is the default.
+# Mfactor's factor.c gets an explicit TRYQ. This is the value for a build with no word size
+# named on the command line; a word-size build picks its own in the block below.
 TRYQ_ARG=-DTRYQ=4
 # Optional link args
 LD_ARGS=()
@@ -278,9 +278,12 @@ if [[ -n $WORDS ]]; then
 		# docs/Mfactor_buildnotes.txt use. Leave TRYQ unset for them rather than overriding it here;
 		# factor.c now rejects the unsupported combinations outright instead of quietly compiling its
 		# single-word arm.
-		if [[ ${arg} == 'nword' || ${arg} == '4word' ]]; then
-			TRYQ_ARG=
-		fi
+		# Set this per word size rather than by exception, so a word size that later grows a batch
+		# modpow - or wants some other width - names its own value here instead of inheriting one:
+		case ${arg} in
+			4word | nword) TRYQ_ARG= ;;
+			*) TRYQ_ARG=-DTRYQ=4 ;;
+		esac
 		Mfactor+="_$arg"
 		TARGET=$Mfactor
 		# The word-size macro is a property of the whole build, not just factor.c: factor.h keys

--- a/makemake.sh
+++ b/makemake.sh
@@ -38,6 +38,9 @@ TARGET=$Mlucas
 ARGS=(-DUSE_THREADS) # Optional compile args
 WORDS=''
 C_ARGS=()
+# Mfactor's factor.c gets an explicit TRYQ (see the word-size block below); the 1-, 2- and
+# 3-word builds all have 4-way batch modpows, so 4 is the default.
+TRYQ_ARG=-DTRYQ=4
 # Optional link args
 LD_ARGS=()
 # Optional Make args
@@ -267,6 +270,16 @@ if [[ -n $WORDS ]]; then
 			WORDS=-DNWORD
 		else
 			WORDS=-DP"${arg::1}"WORD
+		fi
+		# TRYQ is how many candidate factors the modpow step handles per call, and factor.c only has
+		# batch-dispatch arms for the word sizes that have batch modpow routines. NWORD and P4WORD
+		# have none: their modpows (mi64_twopmodq, twopmodq256) are scalar-only, so those two builds
+		# want TRYQ = 1, which is both factor.h's own default for them and what the P4WORD recipes in
+		# docs/Mfactor_buildnotes.txt use. Leave TRYQ unset for them rather than overriding it here;
+		# factor.c now rejects the unsupported combinations outright instead of quietly compiling its
+		# single-word arm.
+		if [[ ${arg} == 'nword' || ${arg} == '4word' ]]; then
+			TRYQ_ARG=
 		fi
 		Mfactor+="_$arg"
 		TARGET=$Mfactor
@@ -528,7 +541,7 @@ $Mlucas: \${OBJS}
 $Mfactor: \${OBJS_MFAC}
 	\${CC} \${LDFLAGS} \${CFLAGS} -o $Mfactor \${OBJS_MFAC} \${LDLIBS}
 factor.o: ../src/factor.c
-	\${CC} \${CFLAGS} \${CPPFLAGS} -c ${ARGS[@]} -DFACTOR_STANDALONE $WORDS -DTRYQ=4 -o factor.o ../src/factor.c
+	\${CC} \${CFLAGS} \${CPPFLAGS} -c ${ARGS[@]} -DFACTOR_STANDALONE $WORDS $TRYQ_ARG -o factor.o ../src/factor.c
 .c.o:
 	\${CC} \${CFLAGS} \${CPPFLAGS} -c ${ARGS[@]} ${WORDS:+$WORDS -DFACTOR_STANDALONE} -o \$@ \$<
 clean:

--- a/src/factor.c
+++ b/src/factor.c
@@ -707,15 +707,9 @@ int main(int argc, char *argv[])
   #ifdef P1WORD
 	double twop_float = 0,fqlo,fqhi;
   #endif
-  #ifdef P3WORD
-	uint192 p192,q192,t192;
-  #ifdef USE_FLOAT
-	uint256 x256;	// Needed to hold result of twopmodq200_8WORD_DOUBLE
-  #endif
-  #endif
-  #ifdef P4WORD
-	uint256 p256,q256,t256;
-  #endif
+	// No 192/256-bit scratch operands here: every use of them is in PerPass_tfSieve, which
+	// declares its own. (The USE_FLOAT variant of the P3WORD pair was doubly dead - factor.h
+	// #errors on P3WORD together with USE_FLOAT, so it could never be declared at all.)
 
 	/*...time-related stuff	*/
   #ifdef CTIME
@@ -2725,13 +2719,16 @@ MFACTOR_HELP:
 	#ifdef P1WORD
 		//uint128 p128,q128,t128;	// Despite the naming, these are needed for nominal 1-word runs with moduli exceeding 64 bits
 	#endif
-	#ifdef P3WORD
+	/* Scalar 192/256-bit operands, for the one-candidate-at-a-time dispatch only: at TRYQ > 1
+	the P3WORD arm calls the batch routines twopmodq192_q4/_q8, which take the raw p[] and k
+	values, and P4WORD has no batch arm at all (see the TRYQ == 4 guard further down). */
+	#if defined(P3WORD) && (TRYQ == 1)
 		uint192 p192,q192,t192;
 	  #ifdef USE_FLOAT
 		uint256 x256;	// Needed to hold result of twopmodq200_8WORD_DOUBLE
 	  #endif
 	#endif
-	#ifdef P4WORD
+	#if defined(P4WORD) && (TRYQ == 1)
 		uint256 p256,q256,t256;
 	#endif
 		char cbuf[STR_MAX_LEN*2], cbuf2[STR_MAX_LEN*2];
@@ -3477,7 +3474,7 @@ MFACTOR_HELP:
 									/****** Apr 2105: This all needs to be made thread-safe ******/
 									ASSERT(0, "This all needs to be made thread-safe!");
 										//kdeep[*ndeep] = (uint32)k;
-										*ndeep++;
+										(*ndeep)++;	// Not *ndeep++, which advances the pointer past its one-element object and leaves the count alone
 										ASSERT(*ndeep < 1024, "Increase allocation of kdeep[] array or use deeper sieving bound to reduce #candidate k's!");
 									//	itmp64 = factor_qmmp_sieve64((uint32)findex, k, MAX_SIEVING_PRIME+2, 0x0001000000000000ull);
 									//	if(itmp64) {
@@ -3623,7 +3620,19 @@ MFACTOR_HELP:
 						#elif(TRYQ == 4)	/************** try 4 factor candidates at a time **************/
 					/***************************************************************************************/
 
-						  #ifdef P3WORD
+						  #if(defined(NWORD) || defined(P4WORD))
+
+							/* No 4-way batch modpow exists for these: mi64_twopmodq and twopmodq256 are
+							scalar-only, so the TRYQ = 1 chain above is the only one that dispatches them.
+							Without this guard the chain below silently falls through to its "default
+							single-word-p mode" arm, whose widest routine is 96-bit and which is handed
+							p[0] rather than p - so the run dies on its first candidate batch, in
+							ASSERT(fbits_in_q < 96), for any modulus wide enough to want a NWORD or
+							P4WORD build at all. TRYQ = 2, 16, 32 and 64 already reject the word sizes
+							they cannot batch; 4 and 8 did not. */
+							#error (TRYQ == 4) is not supported for NWORD or P4WORD builds - use TRYQ = 1!
+
+						  #elif(defined(P3WORD))
 
 						//	ASSERT(!p[2], "twopmodq200: p[2] nonzero!");
 							res = twopmodq192_q4(p,k_to_try[0],k_to_try[1],k_to_try[2],k_to_try[3]);
@@ -3689,13 +3698,17 @@ MFACTOR_HELP:
 								#endif
 								}
 							#endif	/* #ifdef USE_FLOAT */
-						  #endif	/* #ifdef NWORD */
+						  #endif	/* word-size dispatch */
 
 					/***************************************************************************************/
 						#elif(TRYQ == 8)	/************** try 8 factor candidates at a time **************/
 					/***************************************************************************************/
 
-						  #ifdef P3WORD
+						  #if(defined(NWORD) || defined(P4WORD))
+
+							#error (TRYQ == 8) is not supported for NWORD or P4WORD builds - use TRYQ = 1!	/* See the TRYQ == 4 arm above */
+
+						  #elif(defined(P3WORD))
 						/*
 							if((q[2] >> 32) == 0)
 								res = twopmodq160_q8(p,k_to_try[0],k_to_try[1],k_to_try[2],k_to_try[3],k_to_try[4],k_to_try[5],k_to_try[6],k_to_try[7]);
@@ -3752,7 +3765,7 @@ MFACTOR_HELP:
 								}
 
 							#endif	/* #ifdef USE_FLOAT */
-						  #endif	/* #ifdef NWORD */
+						  #endif	/* word-size dispatch */
 
 					/***************************************************************************************/
 						#elif(TRYQ == 16)	/************** try 16 factor candidates at a time *************/


### PR DESCRIPTION
`makemake.sh` passes `-DTRYQ=4` to `factor.c` for every Mfactor word variant. `factor.c`'s
candidate-dispatch chain only has 4-way batch arms for the word sizes that have 4-way batch
modpow routines, and **NWORD and P4WORD have none** — `mi64_twopmodq` and `twopmodq256` are
scalar-only, reached only from the `TRYQ == 1` chain. At `TRYQ = 4` or `8` those two word sizes
fall through to the chain's "default single-word-p mode" arm, whose widest routine is 96-bit and
which is handed `p[0]` instead of `p`, so the run dies on its first candidate batch:

```
$ ./Mfactor_nword -f 200 -bmax 215
Assertion 'fbits_in_q < 96' failed: fbits_in_q exceeds allowable limit of 96!
#4  PerPass_tfSieve at ../src/factor.c:3679
```

With `TRYQ = 1` the same run gets past that and reaches the savefile write instead — the same
place the working word variants reach today (#114).

Preprocessing `factor.c` shows the substitution directly. The only surviving 4-way dispatch calls:

| build | surviving `TRYQ == 4` dispatch |
| --- | --- |
| `-DP3WORD -DTRYQ=4` | `twopmodq192_q4(p, k_to_try[0..3])` ✅ |
| `-DP4WORD -DTRYQ=4` | `twopmodq64_q4(p[0], …)`, `twopmodq96_q4(p[0], …)` ❌ |
| `-DNWORD -DTRYQ=4`  | `twopmodq64_q4(p[0], …)`, `twopmodq96_q4(p[0], …)` ❌ |

## Why TRYQ = 1

It is what `factor.h` already defaults to for `NWORD`/`P4WORD`/`P3WORD`, and it is what every
P4WORD recipe in `docs/Mfactor_buildnotes.txt` uses (`-DP4WORD -DTRYQ=1`, three times). The notes
only ever pair `TRYQ = 4` and `8` with `P1WORD`, `P2WORD` and `P3WORD` — all of which do have
batch arms. So `makemake.sh` leaves `TRYQ` unset for the `4word` and `nword` variants and lets
`factor.h` pick.

`factor.c` also grows the two missing `#error` arms. `TRYQ = 2, 16, 32` and `64` already reject
the word sizes they cannot batch; 4 and 8 were the only two that quietly compiled the wrong path.
A hand-rolled build that asks for an unsupported pair now fails at compile time with a message
naming the fix.

## Also here

Routing P4WORD correctly changes what the CI smoke test exercises, so two follow-on changes:

**CI's Mfactor runs move from M(127) to M(521).** `twopmodq256` needs `p + 256 >= 512` to have an
8-bit lead chunk and asserts `twopmodq256 : start_index < 2!` below that, so `-m 127` only ever
passed for the 4word build because `-DTRYQ=4` sent it down the single-word path. M(521) is the
smallest Mersenne-prime exponent every variant handles, and is slightly cheaper (726k trial
divides vs 1.66M). Measured across the four testable variants — all four agree:

```
M(521) has 0 factors in range k = [0, 16336320], passes 0-15
```

the first time the 4word build has produced that answer through `twopmodq256` rather than through
the 1-word routines. (`nword` can't be run end-to-end locally: it asserts
`NTHREADS == 1` under `-nthread`, and single-threaded runs hit #114's savefile corruption —
which is also why CI's Mfactor step is red on main today, on the *default* 1-word build, before
any of this.)

**Three warning sites from #244**, all symptoms of the same thing:

- `factor()`'s P3WORD/P4WORD 192-/256-bit scratch operands are unused at every `TRYQ`, because
  every use of them is in `PerPass_tfSieve`, which declares its own. Removed. (The `USE_FLOAT`
  variant of the P3WORD pair was doubly dead — `factor.h` `#error`s on `P3WORD` together with
  `USE_FLOAT`, so it could never be declared at all.)
- The P3WORD/P4WORD declarations `PerPass_tfSieve` does need are now guarded on `TRYQ == 1`,
  matching the only arm that reads them. Together that clears all six `-Wunused-variable`
  diagnostics in the 3word and 4word builds.
- `*ndeep++` increments the pointer and discards the value it read, where the following `ASSERT`
  and the commented-out `kdeep[]` write both want the count. Parenthesized. The block sits behind
  an `ASSERT(0, "This all needs to be made thread-safe!")` so it is unreachable today, but the
  `-Wunused-value` it raises becomes a *new* warning the moment the nword build stops being
  compiled with `TRYQ = 4`.

## Verified

- All six word variants build with **0** `factor.c` warnings (gcc 16.2, nosimd). Before: six
  `-Wunused-variable` in 3word and 4word.
- The `#error` fires for exactly `NWORD`/`P4WORD` × `TRYQ = {4,8}` and for nothing else —
  `P3WORD`/`P2WORD`/`P1WORD` at `TRYQ = 4` and `P2WORD` at `TRYQ = 8` all still compile.
- 1word/2word/3word are unchanged: byte-for-byte identical `-DTRYQ=4` compile lines and identical
  trial-divide counts.

Part of #244.
