### PR TITLE
mi64.c, util.c: read the bit-reversal scratch back with memcpy, not a punned cast

### DIFF
--- a/src/mi64.c
+++ b/src/mi64.c
@@ -218,6 +218,7 @@ Bytewise version:
 // For version of this which allows #significant bits to be specified and only those low [nbits] reversed, cf. util.c::reverse64():
 uint64 brev64(uint64 x)
 {
+	uint64 out;
 	uint8 *bin8 = (uint8 *)&x, bout8[8];
 	bout8[0] = brev8[bin8[7]];
 	bout8[1] = brev8[bin8[6]];
@@ -227,7 +228,12 @@ uint64 brev64(uint64 x)
 	bout8[5] = brev8[bin8[2]];
 	bout8[6] = brev8[bin8[1]];
 	bout8[7] = brev8[bin8[0]];
-	return *(uint64 *)bout8;
+	// Not 'return *(uint64 *)bout8': reading a uint8[8] through a uint64 lvalue is a
+	// strict-aliasing violation, and bout8 carries no 8-byte alignment guarantee either.
+	// Reading x through bin8 above is fine - a character type may alias anything - it is
+	// only the read back out that needs this. Every compiler emits the same single load:
+	memcpy(&out, bout8, sizeof(out));
+	return out;
 }
 // Now use the above to construct a multiword bit-reversal:
 void	mi64_brev(uint64 x[], uint32 n)

--- a/src/util.c
+++ b/src/util.c
@@ -3373,6 +3373,7 @@ version which also works with multiword inputs, cf. mi64.c:brev64():
 uint64 reverse64(uint64 i, uint32 nbits)
 {
 	uint32 pad_bits = 64-nbits;
+	uint64 out;
 	uint8 *bin8 = (uint8 *)&i, bout8[8];
 	bout8[0] = brev8[bin8[7]];
 	bout8[1] = brev8[bin8[6]];
@@ -3382,7 +3383,9 @@ uint64 reverse64(uint64 i, uint32 nbits)
 	bout8[5] = brev8[bin8[2]];
 	bout8[6] = brev8[bin8[1]];
 	bout8[7] = brev8[bin8[0]];
-	return (*(uint64 *)bout8) >> pad_bits;
+	// See the identical read-back in mi64.c:brev64() for why this is a memcpy and not a cast:
+	memcpy(&out, bout8, sizeof(out));
+	return out >> pad_bits;
 }
 
 /******* Bit-level utilities: ********/


### PR DESCRIPTION
`brev64()` and `reverse64()` are the same routine — `reverse64()` is a copy that also right-shifts
by the pad width — and both end by reading a `uint8[8]` through a `uint64` lvalue:

```c
	uint8 *bin8 = (uint8 *)&x, bout8[8];
	bout8[0] = brev8[bin8[7]];  ...
	return *(uint64 *)bout8;
```

Reading `x` *in* through `bin8` is fine — a character type may alias anything. The read back out is
not: it accesses an object whose effective type is `uint8[8]` through a `uint64` lvalue, which is a
strict-aliasing violation, and `bout8` carries no 8-byte alignment guarantee either.

#244 lists both sites by line — `mi64.c:230` and `util.c:3377` — with *"dereferencing type-punned
pointer will break strict-aliasing rules"*. Replaced with `memcpy`, which is the standard way to
say "reinterpret these bytes" and which #124 already established as the house treatment for this in
`types.h`'s `u64_to_f64`/`f64_to_u64`.

## Equivalence

These feed the P-1 stage-1 exponent bit-reversal (`pm1.c:389,882`) and the PRP base-multiplier
reversal (`Mlucas.c:3409,3447`), where a wrong answer would be silent — so:

| check | result |
| --- | --- |
| `brev64`, 2,000,007 inputs (7 edge cases + 2e6 xorshift), old vs new vs an independent bit-at-a-time reference | 0 mismatches for all three pairings, gcc and clang at `-O2`/`-O3`/`-Os` |
| `reverse64`, 2,560,000 (input, nbits) pairs — 40k values at each `nbits = 1..64` | 0 mismatches, gcc and clang at `-O2`/`-O3` |
| codegen | instruction-for-instruction identical: 52 insns each under gcc and 49 under clang for `brev64`, 55 each for `reverse64` — this costs nothing |
| self-tests, nosimd, `-cpu 0:3`, against the same build of main | `-s tt` 41 identical `Res64` values, `-prp -s tt` 43 identical, both rc=0 |

Both harnesses are below if you want to re-run them - each is self-contained, `cc -O2 harness.c &&
./a.out`, no Mlucas headers needed.

<details>
<summary><code>brev64</code> equivalence harness (click to expand)</summary>

```c
/* Do the punned and memcpy read-backs agree, and does the compiler emit the same code? */
#include <stdio.h>
#include <stdint.h>
#include <string.h>
static const uint8_t brev8[256] = {
#define R2(n)   n,     n+2*64,  n+1*64,  n+3*64
#define R4(n) R2(n), R2(n+2*16), R2(n+1*16), R2(n+3*16)
#define R6(n) R4(n), R4(n+2*4 ), R4(n+1*4 ), R4(n+3*4 )
  R6(0), R6(2), R6(1), R6(3)
};
__attribute__((noinline)) uint64_t brev_old(uint64_t x) {
	uint8_t *bin8 = (uint8_t *)&x, bout8[8];
	bout8[0]=brev8[bin8[7]]; bout8[1]=brev8[bin8[6]]; bout8[2]=brev8[bin8[5]]; bout8[3]=brev8[bin8[4]];
	bout8[4]=brev8[bin8[3]]; bout8[5]=brev8[bin8[2]]; bout8[6]=brev8[bin8[1]]; bout8[7]=brev8[bin8[0]];
	return *(uint64_t *)bout8;
}
__attribute__((noinline)) uint64_t brev_new(uint64_t x) {
	uint64_t out;
	uint8_t *bin8 = (uint8_t *)&x, bout8[8];
	bout8[0]=brev8[bin8[7]]; bout8[1]=brev8[bin8[6]]; bout8[2]=brev8[bin8[5]]; bout8[3]=brev8[bin8[4]];
	bout8[4]=brev8[bin8[3]]; bout8[5]=brev8[bin8[2]]; bout8[6]=brev8[bin8[1]]; bout8[7]=brev8[bin8[0]];
	memcpy(&out, bout8, sizeof(out));
	return out;
}
/* Independent oracle: reverse the 64 bits one at a time. */
static uint64_t brev_ref(uint64_t x) {
	uint64_t r = 0; for(int i=0;i<64;i++){ r = (r<<1) | (x&1); x >>= 1; } return r;
}
static uint64_t rnd(void){ static uint64_t s=0x9E3779B97F4A7C15ull;
	s^=s<<13; s^=s>>7; s^=s<<17; return s; }
int main(void){
	long n=0, bad_old=0, bad_new=0, disagree=0;
	uint64_t probes[] = {0ull, ~0ull, 1ull, 1ull<<63, 0x0123456789ABCDEFull, 0xFFull, 0xFF00000000000000ull};
	for(unsigned k=0;k<sizeof(probes)/sizeof(*probes);k++){
		uint64_t x=probes[k], a=brev_old(x), b=brev_new(x), r=brev_ref(x);
		n++; if(a!=r) bad_old++; if(b!=r) bad_new++; if(a!=b) disagree++;
	}
	for(long k=0;k<2000000;k++){
		uint64_t x=rnd(), a=brev_old(x), b=brev_new(x), r=brev_ref(x);
		n++; if(a!=r) bad_old++; if(b!=r) bad_new++; if(a!=b) disagree++;
	}
	printf("%ld inputs: old-vs-reference mismatches=%ld, new-vs-reference=%ld, old-vs-new=%ld\n",
	       n, bad_old, bad_new, disagree);
	return (bad_new || disagree) ? 1 : 0;
}
```

</details>

<details>
<summary><code>reverse64</code> equivalence harness (click to expand)</summary>

```c
/* Same check for util.c:reverse64(), across every nbits it accepts. */
#include <stdio.h>
#include <stdint.h>
#include <string.h>
static const uint8_t brev8[256] = {
#define R2(n)   n,     n+2*64,  n+1*64,  n+3*64
#define R4(n) R2(n), R2(n+2*16), R2(n+1*16), R2(n+3*16)
#define R6(n) R4(n), R4(n+2*4 ), R4(n+1*4 ), R4(n+3*4 )
  R6(0), R6(2), R6(1), R6(3)
};
__attribute__((noinline)) uint64_t rev_old(uint64_t i, uint32_t nbits) {
	uint32_t pad_bits = 64-nbits;
	uint8_t *bin8 = (uint8_t *)&i, bout8[8];
	bout8[0]=brev8[bin8[7]]; bout8[1]=brev8[bin8[6]]; bout8[2]=brev8[bin8[5]]; bout8[3]=brev8[bin8[4]];
	bout8[4]=brev8[bin8[3]]; bout8[5]=brev8[bin8[2]]; bout8[6]=brev8[bin8[1]]; bout8[7]=brev8[bin8[0]];
	return (*(uint64_t *)bout8) >> pad_bits;
}
__attribute__((noinline)) uint64_t rev_new(uint64_t i, uint32_t nbits) {
	uint32_t pad_bits = 64-nbits;
	uint64_t out;
	uint8_t *bin8 = (uint8_t *)&i, bout8[8];
	bout8[0]=brev8[bin8[7]]; bout8[1]=brev8[bin8[6]]; bout8[2]=brev8[bin8[5]]; bout8[3]=brev8[bin8[4]];
	bout8[4]=brev8[bin8[3]]; bout8[5]=brev8[bin8[2]]; bout8[6]=brev8[bin8[1]]; bout8[7]=brev8[bin8[0]];
	memcpy(&out, bout8, sizeof(out));
	return out >> pad_bits;
}
static uint64_t rnd(void){ static uint64_t s=0x243F6A8885A308D3ull;
	s^=s<<13; s^=s>>7; s^=s<<17; return s; }
int main(void){
	long n=0, bad=0;
	for(uint32_t nb=1; nb<=64; nb++)
		for(long k=0;k<40000;k++){ uint64_t x=rnd(); n++; if(rev_old(x,nb)!=rev_new(x,nb)) bad++; }
	printf("%ld (input, nbits) pairs over nbits=1..64: old-vs-new mismatches=%ld\n", n, bad);
	return bad?1:0;
}
```

</details>

## One caveat

I could not reproduce the diagnostic itself. gcc 7.5, 11.4, 14.4 and 16.2 and clang 14/16/18/19 all
stay silent here — on the real file with the project's own flags and on a reduced case, at every
`-O` level and every `-Wstrict-aliasing` level. So I am fixing this on the strength of #244's own
log and of the construct being unambiguously undefined, not on a diagnostic I watched appear and
disappear. If you know which CI compiler produced those two lines I'd like to add it to the check.

Part of #244.
