### PR TITLE
util.c: leadz32/leadz64/trailz64's asm writes bpos but declares it a read-only input

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -3646,9 +3646,13 @@ DEV uint32 trailz64(uint64 x)
 	__asm__ volatile (\
 		"bsfq %[__x],%%rax		\n\t"\
 		"movl %%eax,%[__bpos]	\n\t"\
-		:	/* outputs: none */\
+		: [__bpos] "=m" (bpos)	/* outputs: bpos is written by the movl above, so it must be
+								declared here and not as an "m" input. As an input the compiler
+								is entitled to treat it as unmodified - and, since nothing else
+								writes it, as still uninitialized at the read below, which clang
+								duly reports ("variable 'bpos' is uninitialized when used here").
+								The "memory" clobber is what has kept this working. */\
 		: [__x] "m" (x)	/* All inputs from memory addresses here */\
-		 ,[__bpos] "m" (bpos)	\
 		: "cc","memory","rax"	/* Clobbered registers */\
 	);
 	return bpos;
@@ -3713,9 +3717,13 @@ DEV uint32 leadz32(uint32 x)
 	__asm__ volatile (\
 		"bsrl %[__x],%%eax		\n\t"\
 		"movl %%eax,%[__bpos]	\n\t"\
-		:	/* outputs: none */\
+		: [__bpos] "=m" (bpos)	/* outputs: bpos is written by the movl above, so it must be
+								declared here and not as an "m" input. As an input the compiler
+								is entitled to treat it as unmodified - and, since nothing else
+								writes it, as still uninitialized at the read below, which clang
+								duly reports ("variable 'bpos' is uninitialized when used here").
+								The "memory" clobber is what has kept this working. */\
 		: [__x] "m" (x)	/* All inputs from memory addresses here */\
-		 ,[__bpos] "m" (bpos)	\
 		: "cc","memory","eax"	/* Clobbered registers */\
 	);
 	lz = (31 - bpos);	// BSR returns *index* of leftmost set bit, must subtract from (#bits - 1) to get #lz.
@@ -3749,9 +3757,13 @@ DEV uint32 leadz64(uint64 x)
 	__asm__ volatile (\
 		"bsrq %[__x],%%rax		\n\t"\
 		"movl %%eax,%[__bpos]	\n\t"\
-		:	/* outputs: none */\
+		: [__bpos] "=m" (bpos)	/* outputs: bpos is written by the movl above, so it must be
+								declared here and not as an "m" input. As an input the compiler
+								is entitled to treat it as unmodified - and, since nothing else
+								writes it, as still uninitialized at the read below, which clang
+								duly reports ("variable 'bpos' is uninitialized when used here").
+								The "memory" clobber is what has kept this working. */\
 		: [__x] "m" (x)	/* All inputs from memory addresses here */\
-		 ,[__bpos] "m" (bpos)	\
 		: "cc","memory","rax"	/* Clobbered registers */\
 	);
 	lz = (63 - bpos);	// BSR returns *index* of leftmost set bit, must subtract from (#bits - 1) to get #lz.


### PR DESCRIPTION
`leadz32`, `leadz64` and `trailz64` all have the same shape: `BSF`/`BSR` into `%eax`, store `%eax`
to `bpos`, then read `bpos` in C. But `bpos` is declared in the **input** list, as `"m"`, with an
empty output list:

```c
		"bsrq %[__x],%%rax		\n\t"
		"movl %%eax,%[__bpos]	\n\t"
		:	/* outputs: none */
		: [__x] "m" (x)
		 ,[__bpos] "m" (bpos)
		: "cc","memory","rax"
```

An `"m"` input is a promise that the asm does not modify it. Nothing else writes `bpos`, so the
following `return bpos` / `(63 - bpos)` is, as far as the compiler is concerned, a read of an
uninitialized automatic.

## What has been holding it up

The `"memory"` clobber. It forces the compiler to assume the asm wrote memory it was not told
about, so the operand's stack slot gets reloaded rather than assumed dead. That is measurable —
drop **only** the `"memory"` clobber from these three blocks, changing nothing else, and gcc
immediately reports all three:

```
util.c:3654:16: warning: 'bpos' may be used uninitialized [-Wmaybe-uninitialized]
util.c:3721:18: warning: 'bpos' may be used uninitialized [-Wmaybe-uninitialized]
util.c:3757:18: warning: 'bpos' may be used uninitialized [-Wmaybe-uninitialized]
```

at `-O1`, `-O2` and `-O3`. #244's log has the clang form of the same three, *"variable 'bpos' is
uninitialized when used here"*.

That matters because narrowing these clobber lists is exactly the work in #71, #68 and the
asm-clobber lint — an over-broad `"memory"` on every block is what those are removing, and here it
turns out to be load-bearing for reasons nothing in the source states. `leadz64` in particular
feeds the `start_index` computation across the `twopmodq` family and mi64's word-count logic, so a
wrong answer would not announce itself as a crash.

Fixed by moving `bpos` to the output list as `"=m"`, which is what the asm actually does. The
`"memory"` clobber stays — narrowing it is a separate question, and now a safe one.

## Not overclaiming: this is a latent hazard, not a live bug

I checked rather than asserting. All three declaration variants — main as it stands, main minus the
`"memory"` clobber, and this fix — return correct answers for **500,064 inputs** (all 64 single-bit
values plus 5e5 xorshift values) against `__builtin_ctzll`/`__builtin_clzll`, under gcc and clang at
`-O1`/`-O2`/`-O3`: **zero mismatches in all 18 combinations**. The harness is at the bottom of this
description - self-contained, `cc -w -O2 harness.c && ./a.out`, no Mlucas headers needed.

The point of the change is that the declaration should say what the asm does, so correctness stops
resting on a clobber that other work is actively removing.

Self-tests, nosimd, `-cpu 0:3`, against the same build of main: `-s tt` 41 identical `Res64` values,
`-prp -s tt` 43 identical, both rc=0.

## There are 105 more of these

While tracking this down I audited every inline-asm block in `src/` for operands the template stores
into but declares as a read-only `"m"` input. Excluding the ARM blocks — where `%[__add0]` in
`ldr x5,%[__add0]` is the *source*, not the destination — there are **108 in 9 files**:

| file | sites | operands |
| --- | --- | --- |
| `mi64.c` | 42 | `__cy`, `__cy0..3`, `__itmp64` |
| `carry_gcc64.h` | 24 | `__wtA`, `__wtB`, `__wtC`, `__data`, `__cyA`, `__cyB`, `__bjmod_0`, `__i`, `__idx_offset` |
| `carry_gcc32.h` | 14 | `__idx_offset`, `__wtA`, `__wtB`, `__wtC` |
| `twopmodq64_test.c` | 12 | `__x0..7` |
| `twopmodq.c` | 4 | `__x0..3` |
| `mi64.h` | 3 | `__z` |
| `util.c` | 3 | `__bpos` — this PR |
| `twopmodq80.c` | 3 | `__result` |
| `imul_macro0.h` | 2 | `_md32`, `_hi32` |
| `twopmodq100.c` | 1 | `__result` |

**All of them carry a `"memory"` clobber**, which is why none is broken today. I am fixing only the
three `util.c` sites here, because those are the ones #244 names and the ones with a reproducible
diagnostic. **#273 does the other 105**, so between the two PRs none is left. Eight of those needed
the enclosing block's operand budget reduced first — it had 27 operands and a `"+m"` costs two of
gcc's 30 slots, so converting them would have landed on 35.

Part of #244.

<details>
<summary>The three-variant harness (click to expand)</summary>

```c
/* leadz64/trailz64 in three declaration variants, checked against the builtins.
 *   A = main today:          bpos an "m" INPUT, "memory" in the clobber list
 *   B = main minus "memory": what tightening the clobber lists produces
 *   C = the fix:             bpos an "=m" OUTPUT (memory clobber kept)
 */
#include <stdio.h>
#include <stdint.h>

__attribute__((noinline)) uint32_t tz_A(uint64_t x) { int bpos; if(!x) return 64;
	__asm__ volatile ("bsfq %[__x],%%rax\n\t" "movl %%eax,%[__bpos]\n\t"
		: : [__x] "m" (x), [__bpos] "m" (bpos) : "cc","memory","rax"); return bpos; }
__attribute__((noinline)) uint32_t tz_B(uint64_t x) { int bpos; if(!x) return 64;
	__asm__ volatile ("bsfq %[__x],%%rax\n\t" "movl %%eax,%[__bpos]\n\t"
		: : [__x] "m" (x), [__bpos] "m" (bpos) : "cc","rax"); return bpos; }
__attribute__((noinline)) uint32_t tz_C(uint64_t x) { int bpos; if(!x) return 64;
	__asm__ volatile ("bsfq %[__x],%%rax\n\t" "movl %%eax,%[__bpos]\n\t"
		: [__bpos] "=m" (bpos) : [__x] "m" (x) : "cc","memory","rax"); return bpos; }

__attribute__((noinline)) uint32_t lz_A(uint64_t x) { int bpos; if(!x) return 64;
	__asm__ volatile ("bsrq %[__x],%%rax\n\t" "movl %%eax,%[__bpos]\n\t"
		: : [__x] "m" (x), [__bpos] "m" (bpos) : "cc","memory","rax"); return (uint32_t)(63-bpos); }
__attribute__((noinline)) uint32_t lz_B(uint64_t x) { int bpos; if(!x) return 64;
	__asm__ volatile ("bsrq %[__x],%%rax\n\t" "movl %%eax,%[__bpos]\n\t"
		: : [__x] "m" (x), [__bpos] "m" (bpos) : "cc","rax"); return (uint32_t)(63-bpos); }
__attribute__((noinline)) uint32_t lz_C(uint64_t x) { int bpos; if(!x) return 64;
	__asm__ volatile ("bsrq %[__x],%%rax\n\t" "movl %%eax,%[__bpos]\n\t"
		: [__bpos] "=m" (bpos) : [__x] "m" (x) : "cc","memory","rax"); return (uint32_t)(63-bpos); }

static uint64_t rnd(void){ static uint64_t s=0xB5026F5AA96619E9ull;
	s^=s<<13; s^=s>>7; s^=s<<17; return s; }
int main(void){
	long n=0, bad[6]={0,0,0,0,0,0};
	const char *nm[6]={"tz A(main)","tz B(no-mem-clobber)","tz C(fixed)",
	                   "lz A(main)","lz B(no-mem-clobber)","lz C(fixed)"};
	for(int b=0;b<64;b++){ uint64_t x=1ull<<b; n++;
		uint32_t t=(uint32_t)__builtin_ctzll(x), l=(uint32_t)__builtin_clzll(x);
		bad[0]+=tz_A(x)!=t; bad[1]+=tz_B(x)!=t; bad[2]+=tz_C(x)!=t;
		bad[3]+=lz_A(x)!=l; bad[4]+=lz_B(x)!=l; bad[5]+=lz_C(x)!=l; }
	for(long k=0;k<500000;k++){ uint64_t x=rnd(); if(!x) continue; n++;
		uint32_t t=(uint32_t)__builtin_ctzll(x), l=(uint32_t)__builtin_clzll(x);
		bad[0]+=tz_A(x)!=t; bad[1]+=tz_B(x)!=t; bad[2]+=tz_C(x)!=t;
		bad[3]+=lz_A(x)!=l; bad[4]+=lz_B(x)!=l; bad[5]+=lz_C(x)!=l; }
	printf("  %ld inputs -> wrong answers:", n);
	for(int i=0;i<6;i++) printf("  %s=%ld", nm[i], bad[i]);
	printf("\n");
	return bad[2]||bad[5];
}
```

</details>
