### PR TITLE
mers/fermat_mod_square: the [2a] retry check reads iter on a path that never sets it

### DIFF
--- a/src/fermat_mod_square.c
+++ b/src/fermat_mod_square.c
@@ -201,7 +201,8 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 	static int *index = 0x0;		/* Bit-reversal index array and array storing S*I mod N values for DWT weights.	*/
 //	static int *index_ptmp = 0x0;
 
-	int bimodn,i,ii,ierr = 0,iter,j,j1,j2,k,l,m,mm,k1,k2;
+	// iter = 0 rather than uninitialized - see the same note in mers_mod_square():
+	int bimodn,i,ii,ierr = 0,iter = 0,j,j1,j2,k,l,m,mm,k1,k2;
 	static uint64 psave=0;
 	static uint32 nsave=0, rad0save=0, new_runlength=0;
 	static uint32 nwt,nwt_bits,bw,sw,bits_small;
@@ -1729,7 +1730,12 @@ undo_initial_ffft_pass:
 	// Cf. [2a] above: The interval-retry is successful, i.e. suffers no fatal ROE.
 	// [action] Prior to returning, print a "retry successful" informational and rezero ROE_ITER and ROE_VAL.
 	// *** v20: For PRP-test Must make sure we are at end of checkpoint-file iteration interval, not one of the Gerbicz-update subintervals ***
-	if(!INTERACT && ROE_ITER > 0 && ihi%ITERS_BETWEEN_CHECKPOINTS == 0) {	// In interactive (timing-test) mode, use ROE_ITER to accumulate #iters-with-dangerous-ROEs
+	// The fwd_fft == 2 service call near the top of the function jumps straight to
+	// undo_initial_ffft_pass, so on that path the iteration loop never ran at all: iter is
+	// uninitialized, and there is no iteration interval whose retry could have succeeded. Test for
+	// it here rather than assert on a garbage iter - which is what gcc reports as "'iter' may be
+	// used uninitialized" at the ASSERT below.
+	if(!INTERACT && ROE_ITER > 0 && ihi%ITERS_BETWEEN_CHECKPOINTS == 0 && fwd_fft != 2ull) {	// In interactive (timing-test) mode, use ROE_ITER to accumulate #iters-with-dangerous-ROEs
 		// On normal loop-completion iter = ihi+1; the early-exit-on-interrupt case is filtered out by the
 		// ERR_INTERRUPT return above, *except* for a signal arriving during the final iteration, in which
 		// case the interval did complete but the post-loop iter-- leaves iter = ihi - hence 2nd clause:

--- a/src/mers_mod_square.c
+++ b/src/mers_mod_square.c
@@ -184,7 +184,11 @@ The scratch array (2nd input argument) is only needed for data table initializat
 	/* arrays storing the index values needed for the paired-block wrapper/square scheme: */
 	static int *ws_i,*ws_j1,*ws_j2,*ws_j2_start,*ws_k,*ws_m,*ws_blocklen,*ws_blocklen_sum;
 	int bimodn,simodn;					/* Mnemonic: BIMODN stands for "B times I mod N", nothing to do with bimodal.	*/
-	int i,ii,ierr = 0,iter,j,jhi,k,l,m,mm,k2,m2,l1,l2,l2_start,blocklen,blocklen_sum,outer;
+	// iter = 0 rather than uninitialized: the fwd_fft == 2 path below jumps over the iteration
+	// loop that would otherwise set it, and the guard on the [2a] retry check at the bottom of
+	// the function keeps the only read of it off that path - but gcc cannot correlate the goto
+	// with that guard, so give it a defined value too rather than leave the read UB on paper:
+	int i,ii,ierr = 0,iter = 0,j,jhi,k,l,m,mm,k2,m2,l1,l2,l2_start,blocklen,blocklen_sum,outer;
 	static uint64 psave=0;
 	static uint32 nsave=0, new_runlength=0;
 	static uint32 nwt,nwt_bits,bw,sw,bits_small;
@@ -2131,7 +2135,12 @@ undo_initial_ffft_pass:
 	// Cf. [2a] in fermat_mod_square() function: The interval-retry is successful, i.e. suffers no fatal ROE.
 	// [action] Prior to returning, print a "retry successful" informational and rezero ROE_ITER and ROE_VAL.
 	// *** v19: For PRP-test Must make sure we are at end of checkpoint-file iteration interval, not one of the Gerbicz-update subintervals ***
-	if(!INTERACT && ROE_ITER > 0 && ihi%ITERS_BETWEEN_CHECKPOINTS == 0) {	// In interactive (timing-test) mode, use ROE_ITER to accumulate #iters-with-dangerous-ROEs
+	// The fwd_fft == 2 service call near the top of the function jumps straight to
+	// undo_initial_ffft_pass, so on that path the iteration loop never ran at all: iter is
+	// uninitialized, and there is no iteration interval whose retry could have succeeded. Test for
+	// it here rather than assert on a garbage iter - which is what gcc reports as "'iter' may be
+	// used uninitialized" at the ASSERT below.
+	if(!INTERACT && ROE_ITER > 0 && ihi%ITERS_BETWEEN_CHECKPOINTS == 0 && fwd_fft != 2ull) {	// In interactive (timing-test) mode, use ROE_ITER to accumulate #iters-with-dangerous-ROEs
 		// On normal loop-completion iter = ihi+1; the early-exit-on-interrupt case is filtered out by the
 		// ERR_INTERRUPT return above, *except* for a signal arriving during the final iteration, in which
 		// case the interval did complete but the post-loop iter-- leaves iter = ihi - hence 2nd clause:


### PR DESCRIPTION
Both `mers_mod_square()` and `fermat_mod_square()` have, near the top:

```c
	if(fwd_fft == 2ull)
		goto undo_initial_ffft_pass;
```

and that label sits **after** the `for(iter=ilo+1; ...)` iteration loop but **before** the "retry of
interval with fatal ROE was successful" block at the bottom. On that path the loop never runs, so
`iter` is never assigned — and the only thing that reads `iter` down there is that block's sanity
check:

```c
	if(!INTERACT && ROE_ITER > 0 && ihi%ITERS_BETWEEN_CHECKPOINTS == 0) {
		ASSERT((ierr == 0) && (iter == ihi+1 || !MLUCAS_KEEP_RUNNING), "[2a] sanity check failed!");
```

which is what gcc reports as `'iter' may be used uninitialized` at `mers_mod_square.c:2138` and
`fermat_mod_square.c:1736` — two of the four warnings current main still emits.

## The path is live, not dead code

`fwd_fft` is derived as `fwd_fft_only` with bits 0:1 cleared and then `>>2` when in `(3,0xC)`, so
`fwd_fft == 2` is what `fwd_fft_only == 8` means — *"undo first pass of forward FFT and
DWT-weighting only"* — and P-1 stage 2 asks for exactly that at `pm1.c:1323`, `1343` and `1559`.
(The two literal `2ull` calls at `pm1.c:1564-65` are inside `#if 0`; these three are not.)

## Not overclaiming: the read does not actually happen today

Every caller that takes the bypass passes `ilo,ihi = 0,1`, and the block is gated on
`ihi%ITERS_BETWEEN_CHECKPOINTS == 0` with `ITERS_BETWEEN_CHECKPOINTS` never below 1000, so
`1 % 1000 != 0` keeps it out. What is left is a live path one arithmetic accident away from reading
an uninitialized automatic, in the P-1 code that is itself under repair — and no way for a reader to
tell that from the source.

## The change

- **Gate the block on `fwd_fft != 2ull`**, mirroring the goto's own condition. Beyond the `ASSERT`
  this is the right behaviour anyway: on the bypass path no iterations ran, so there is no interval
  whose retry could have succeeded, and clearing `ROE_ITER`/`ROE_VAL` and printing
  *"retry ... was successful"* would be wrong even if `iter` were defined.
- **Initialize `iter = 0`** at its declaration. gcc cannot correlate the goto with the new guard, so
  it still warns without this; and a defined value is worth having on a path where the guard is the
  only thing keeping the read off.

## Verified

Both files now compile with **zero** diagnostics under gcc and clang × nosimd/sse2/avx2/avx512 at
`-O3`, where main has one each.

Self-tests, nosimd, `-cpu 0:3`, against the same build of main: `-s tt` 41 identical `Res64` values,
`-prp -s tt` 43 identical, both rc=0 — as expected, since the block this guards was already
unreachable on the bypass path.

Part of #244.
