### PR TITLE
Declare the inline-asm operands the templates write as outputs, not "m" inputs

### DIFF
--- a/src/carry_gcc32.h
+++ b/src/carry_gcc32.h
@@ -153,12 +153,11 @@
 		"addl	%[__idx_incr],%%ebx		\n\t"\
 		"movl	%%ebx, %[__idx_offset]	\n\t"/* Store incremented idx_offset */\
 	"popl %%ebx	\n\t"\
-	:						/* outputs: none */\
+	: [__idx_offset]	"+m" (Xidx_offset)	/* outputs: the template stores into these */\
 	:	[__data]		"m" (Xdata)	/* All inputs from memory addresses here */\
 	,	[__cy]			"m" (Xcy)\
 	,	[__nrt_bits]	"m" (Xnrt_bits)\
 	,	[__nrtm1]		"m" (Xnrtm1)\
-	,	[__idx_offset]	"m" (Xidx_offset)\
 	,	[__idx_incr]	"m" (Xidx_incr)\
 	,	[__half_arr]	"m" (Xhalf_arr)\
 	,	[__sign_mask]	"m" (Xsign_mask)\
@@ -288,12 +287,11 @@
 		"movl	%[__idx_offset],%%esi	\n\t"\
 		"addl	%[__idx_incr],%%esi		\n\t"\
 		"movl	%%esi, %[__idx_offset]	\n\t"/* Store incremented idx_offset */\
-	:						/* outputs: none */\
+	: [__idx_offset]	"+m" (Xidx_offset)	/* outputs: the template stores into these */\
 	:	[__data]		"m" (Xdata)	/* All inputs from memory addresses here */\
 	,	[__cy]			"m" (Xcy)\
 	,	[__nrt_bits]	"m" (Xnrt_bits)\
 	,	[__nrtm1]		"m" (Xnrtm1)\
-	,	[__idx_offset]	"m" (Xidx_offset)\
 	,	[__idx_incr]	"m" (Xidx_incr)\
 	,	[__half_arr]	"m" (Xhalf_arr)\
 	,	[__sign_mask]	"m" (Xsign_mask)\
@@ -475,12 +473,11 @@
 		"addl	%[__idx_incr],%%ecx		\n\t"\
 		"movl	%%ecx, %[__idx_offset]	\n\t"/* Store incremented idx_offset */\
 	"popl %%ebx	\n\t"\
-	:						/* outputs: none */\
+	: [__idx_offset]	"+m" (Xidx_offset)	/* outputs: the template stores into these */\
 	:	[__data]		"m" (Xdata)	/* All inputs from memory addresses here */\
 	,	[__cy]			"m" (Xcy)\
 	,	[__nrt_bits]	"m" (Xnrt_bits)\
 	,	[__nrtm1]		"m" (Xnrtm1)\
-	,	[__idx_offset]	"m" (Xidx_offset)\
 	,	[__idx_incr]	"m" (Xidx_incr)\
 	,	[__odd_radix]   "m" (Xodd_radix)\
 	,	[__half_arr]	"m" (Xhalf_arr)\
@@ -633,12 +630,11 @@
 		/* Store incremented idx offsetL:  */\
 		"movl	%%esi, %[__idx_offset]	\n\t"\
 	"popl %%ebx	\n\t"\
-	:						/* outputs: none */\
+	: [__idx_offset]	"+m" (Xidx_offset)	/* outputs: the template stores into these */\
 	:	[__data]		"m" (Xdata)	/* All inputs from memory addresses here */\
 	,	[__cy]			"m" (Xcy)\
 	,	[__nrt_bits]	"m" (Xnrt_bits)\
 	,	[__nrtm1]		"m" (Xnrtm1)\
-	,	[__idx_offset]	"m" (Xidx_offset)\
 	,	[__idx_incr]	"m" (Xidx_incr)\
 	,	[__odd_radix]   "m" (Xodd_radix)\
 	,	[__half_arr]	"m" (Xhalf_arr)\
@@ -854,11 +850,10 @@
 		"movl	%[__bjmod_0],%%ecx		\n\t"\
 		"movaps	%%xmm0,(%%ecx)			\n\t"\
 	"popl %%ebx	\n\t"\
-		:					/* outputs: none */\
+		: [__wtA]		"+m" (XwtA)	/* outputs: the template stores into these */\
+		 ,[__wtB]		"+m" (XwtB)\
+		 ,[__wtC]		"+m" (XwtC)\
 		: [__data]		"m" (Xdata)	/* All inputs from memory addresses here */\
-		, [__wtA]		"m" (XwtA)		\
-		, [__wtB]		"m" (XwtB)		\
-		, [__wtC]		"m" (XwtC)		\
 		, [__cyA]		"m" (XcyA)		\
 		, [__cyB]		"m" (XcyB)		\
 		, [__bjmod_0]	"m" (Xbjmod_0)		\
@@ -1076,10 +1071,9 @@
 		"movaps		%%xmm1,0x10(%%eax)	\n\t	movaps		%%xmm5,0x50(%%eax)	\n\t"\
 		"movaps		%%xmm0,    (%%eax)	\n\t	movaps		%%xmm4,0x40(%%eax)	\n\t"\
 	"popl %%ebx	\n\t"\
-		:					/* outputs: none */\
+		: [__wtA]		"+m" (XwtA)	/* outputs: the template stores into these */\
+		 ,[__wtB]		"+m" (XwtB)\
 		: [__data]		"m" (Xdata)	/* All inputs from memory addresses here */\
-		, [__wtA]		"m" (XwtA)		\
-		, [__wtB]		"m" (XwtB)		\
 		, [__cyA]		"m" (XcyA)		\
 		, [__cyB]		"m" (XcyB)		\
 		, [__bjmod_0]	"m" (Xbjmod_0)		\
@@ -1609,11 +1603,10 @@
 		"movl	%[__bjmod_0],%%ecx		\n\t"\
 		"movaps	%%xmm0,(%%ecx)			\n\t"\
 	"popl %%ebx	\n\t"\
-		:					/* outputs: none */\
+		: [__wtA]		"+m" (XwtA)	/* outputs: the template stores into these */\
+		 ,[__wtB]		"+m" (XwtB)\
+		 ,[__wtC]		"+m" (XwtC)\
 		: [__data]		"m" (Xdata)	/* All inputs from memory addresses here */\
-		, [__wtA]		"m" (XwtA)		\
-		, [__wtB]		"m" (XwtB)		\
-		, [__wtC]		"m" (XwtC)		\
 		, [__cyA]		"m" (XcyA)		\
 		, [__cyB]		"m" (XcyB)		\
 		, [__bjmod_0]	"m" (Xbjmod_0)		\
@@ -1838,10 +1831,9 @@
 		"movaps		%%xmm1,0x10(%%eax)	\n\t	movaps		%%xmm5,0x50(%%eax)	\n\t"\
 		"movaps		%%xmm0,    (%%eax)	\n\t	movaps		%%xmm4,0x40(%%eax)	\n\t"\
 	"popl %%ebx	\n\t"\
-		:					/* outputs: none */\
+		: [__wtA]		"+m" (XwtA)	/* outputs: the template stores into these */\
+		 ,[__wtB]		"+m" (XwtB)\
 		: [__data]		"m" (Xdata)	/* All inputs from memory addresses here */\
-		, [__wtA]		"m" (XwtA)		\
-		, [__wtB]		"m" (XwtB)		\
 		, [__cyA]		"m" (XcyA)		\
 		, [__cyB]		"m" (XcyB)		\
 		, [__bjmod_0]	"m" (Xbjmod_0)		\

--- a/src/carry_gcc64.h
+++ b/src/carry_gcc64.h
@@ -4088,12 +4088,11 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		"movslq	%[__idx_incr],%%rdi		\n\t"\
 		"addq	%%rdi,%%rsi				\n\t"/* idx_offset += idx_incr */\
 		"mov	%%esi, %[__idx_offset]	\n\t"/* Store incremented idx_offset */\
-		:						/* outputs: none */\
+		: [__idx_offset]	"+m" (Xidx_offset)	/* outputs: the template stores into these */\
 		:	[__data]		"m" (Xdata)	/* All inputs from memory addresses here */\
 		,	[__cy]			"m" (Xcy)\
 		,	[__nrt_bits]	"m" (Xnrt_bits)\
 		,	[__nrtm1]		"m" (Xnrtm1)\
-		,	[__idx_offset]	"m" (Xidx_offset)\
 		,	[__idx_incr]	"m" (Xidx_incr)\
 		,	[__half_arr]	"m" (Xhalf_arr)\
 		,	[__sign_mask]	"m" (Xsign_mask)\
@@ -4410,12 +4409,11 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		/* Prepare for next pair of complex data: */\
 		"addq	%[__idx_incr],%%rsi		\n\t"/* idx_offset += idx_incr */\
 		"mov	%%esi, %[__idx_offset]	\n\t"/* Store incremented idx_offset */\
-		:						/* outputs: none */\
+		: [__idx_offset]	"+m" (Xidx_offset)	/* outputs: the template stores into these */\
 		:	[__data]		"m" (Xdata)	/* All inputs from memory addresses here */\
 		,	[__cy]			"m" (Xcy)\
 		,	[__nrt_bits]	"m" (Xnrt_bits)\
 		,	[__nrtm1]		"m" (Xnrtm1)\
-		,	[__idx_offset]	"m" (Xidx_offset)\
 		,	[__idx_incr]	"m" (Xidx_incr)\
 		,	[__odd_radix]   "m" (Xodd_radix)\
 		,	[__half_arr]	"m" (Xhalf_arr)\
@@ -4587,12 +4585,11 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		"mulpd		%%xmm0,%%xmm5		\n\t		mulpd		%%xmm8 ,%%xmm13		\n\t"\
 		"movaps		%%xmm4,    (%%rdx)	\n\t		movaps		%%xmm12,0x20(%%rdx)	\n\t"\
 		"movaps		%%xmm5,0x10(%%rdx)	\n\t		movaps		%%xmm13,0x30(%%rdx)	\n\t"\
-		:						/* outputs: none */\
+		: [__idx_offset]	"+m" (Xidx_offset)	/* outputs: the template stores into these */\
 		:	[__data]		"m" (Xdata)	/* All inputs from memory addresses here */\
 		,	[__cy]			"m" (Xcy)\
 		,	[__nrt_bits]	"m" (Xnrt_bits)\
 		,	[__nrtm1]		"m" (Xnrtm1)\
-		,	[__idx_offset]	"m" (Xidx_offset)\
 		,	[__idx_incr]	"m" (Xidx_incr)\
 		,	[__odd_radix]	"m" (Xodd_radix)\
 		,	[__half_arr]	"m" (Xhalf_arr)\
@@ -16260,11 +16257,10 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		"vmovaps	%%ymm2 ,0x040(%%rax)						\n\t		vmovaps	%%ymm3 ,0x060(%%rax)				\n\t"\
 		"vmovaps	%%ymm0 ,0x080(%%rax)						\n\t		vmovaps	%%ymm1 ,0x0a0(%%rax)				\n\t"\
 		"vmovaps	%%ymm10,0x0c0(%%rax)						\n\t		vmovaps	%%ymm11,0x0e0(%%rax)				\n\t"\
-		:					/* outputs: none */\
+		: [__wtA]		"+m" (XwtA)	/* outputs: the template stores into these */\
+		 ,[__wtB]		"+m" (XwtB)\
+		 ,[__wtC]		"+m" (XwtC)\
 		: [__data]		"m" (Xdata)	/* All inputs from memory addresses here */\
-		, [__wtA]		"m" (XwtA)		\
-		, [__wtB]		"m" (XwtB)		\
-		, [__wtC]		"m" (XwtC)		\
 		, [__cy]		"m" (Xcy)		\
 		, [__bjmod_0]	"m" (Xbjmod_0)		\
 		, [__half_arr]	"m" (Xhalf_arr)		\
@@ -23457,11 +23453,10 @@ If so, why does the weights-multiplier stuff work w/o extra shuffling here?
 		"vmovaps	%%ymm2 ,0x040(%%rax)						\n\t		vmovaps	%%ymm3 ,0x060(%%rax)				\n\t"\
 		"vmovaps	%%ymm0 ,0x080(%%rax)						\n\t		vmovaps	%%ymm1 ,0x0a0(%%rax)				\n\t"\
 		"vmovaps	%%ymm10,0x0c0(%%rax)						\n\t		vmovaps	%%ymm11,0x0e0(%%rax)				\n\t"\
-		:					/* outputs: none */\
+		: [__wtA]		"+m" (XwtA)	/* outputs: the template stores into these */\
+		 ,[__wtB]		"+m" (XwtB)\
+		 ,[__wtC]		"+m" (XwtC)\
 		: [__data]		"m" (Xdata)	/* All inputs from memory addresses here */\
-		, [__wtA]		"m" (XwtA)		\
-		, [__wtB]		"m" (XwtB)		\
-		, [__wtC]		"m" (XwtC)		\
 		, [__cy]		"m" (Xcy)		\
 		, [__bjmod_0]	"m" (Xbjmod_0)		\
 		, [__half_arr]	"m" (Xhalf_arr)		\
@@ -23694,11 +23689,10 @@ If so, why does the weights-multiplier stuff work w/o extra shuffling here?
 		"pand	(%%rbx)	,%%xmm0			\n\t"/* bjmodn[0:3] &= nm1 */\
 		"movq	%[__bjmod_0],%%rcx		\n\t"\
 		"movaps	%%xmm0,(%%rcx)			\n\t"/* Write bjmodn[0:3] */\
-		:					/* outputs: none */\
+		: [__wtA]		"+m" (XwtA)	/* outputs: the template stores into these */\
+		 ,[__wtB]		"+m" (XwtB)\
+		 ,[__wtC]		"+m" (XwtC)\
 		: [__data]		"m" (Xdata)	/* All inputs from memory addresses here */\
-		, [__wtA]		"m" (XwtA)		\
-		, [__wtB]		"m" (XwtB)		\
-		, [__wtC]		"m" (XwtC)		\
 		, [__cyA]		"m" (XcyA)		\
 		, [__cyB]		"m" (XcyB)		\
 		, [__bjmod_0]	"m" (Xbjmod_0)		\
@@ -23923,10 +23917,9 @@ If so, why does the weights-multiplier stuff work w/o extra shuffling here?
 		"movaps		%%xmm2,0x20(%%rax)	\n\t	movaps		%%xmm6,0x60(%%rax)	\n\t"/* Store hi real in aj2 */\
 		"movaps		%%xmm1,0x10(%%rax)	\n\t	movaps		%%xmm5,0x50(%%rax)	\n\t"/* a[jp+p0 ] */\
 		"movaps		%%xmm0,    (%%rax)	\n\t	movaps		%%xmm4,0x40(%%rax)	\n\t"/* a[jt+p0 ] */\
-		:					/* outputs: none */\
+		: [__wtA]		"+m" (XwtA)	/* outputs: the template stores into these */\
+		 ,[__wtB]		"+m" (XwtB)\
 		: [__data]		"m" (Xdata)	/* All inputs from memory addresses here */\
-		, [__wtA]		"m" (XwtA)		\
-		, [__wtB]		"m" (XwtB)		\
 		, [__cyA]		"m" (XcyA)		\
 		, [__cyB]		"m" (XcyB)		\
 		, [__bjmod_0]	"m" (Xbjmod_0)		\
@@ -24461,13 +24454,12 @@ If so, why does the weights-multiplier stuff work w/o extra shuffling here?
 		"movq	%[__poff],%%r15			\n\t"/* poff[] = p0,4,8,... */\
 		"leaq	(%%r15,%%rcx,4),%%r15	\n\t"/* Dereference the poff array-element ptr ... our loop index (rcx) doubles as idx into poff[] */\
 	"jnz 1b 	\n\t"/* loop[1] end; continue is via jump-back if rcx != 0 */\
-		:					/* outputs: none */\
-		: [__data]		"m" (Xdata)	/* All inputs from memory addresses here */\
-		, [__cyA]		"m" (XcyA)		\
-		, [__cyB]		"m" (XcyB)		\
-		, [__bjmod_0]	"m" (Xbjmod_0)		\
-		, [__i]			"m" (Xi)			\
-		, [__half_arr]	"m" (Xhalf_arr)		\
+		: [__data]		"+m" (Xdata)	/* outputs: the template stores into these */\
+		 ,[__cyA]		"+m" (XcyA)\
+		 ,[__cyB]		"+m" (XcyB)\
+		 ,[__bjmod_0]	"+m" (Xbjmod_0)\
+		 ,[__i]			"=m" (Xi)\
+		: [__half_arr]	"m" (Xhalf_arr)		\
 		, [__sign_mask]	"m" (Xsign_mask)	\
 		, [__sse_bw]	"m" (Xsse_bw)		\
 		, [__sse_nm1]	"m" (Xsse_nm1)		\
@@ -24702,11 +24694,10 @@ If so, why does the weights-multiplier stuff work w/o extra shuffling here?
 		"psubd		%%xmm1	,%%xmm0		\n\t"\
 		"movq	%[__bjmod_0],%%rcx		\n\t"\
 		"movaps	%%xmm0,(%%rcx)			\n\t"\
-		:					/* outputs: none */\
+		: [__wtA]		"+m" (XwtA)	/* outputs: the template stores into these */\
+		 ,[__wtB]		"+m" (XwtB)\
+		 ,[__wtC]		"+m" (XwtC)\
 		: [__data]		"m" (Xdata)	/* All inputs from memory addresses here */\
-		, [__wtA]		"m" (XwtA)		\
-		, [__wtB]		"m" (XwtB)		\
-		, [__wtC]		"m" (XwtC)		\
 		, [__cyA]		"m" (XcyA)		\
 		, [__cyB]		"m" (XcyB)		\
 		, [__bjmod_0]	"m" (Xbjmod_0)		\
@@ -24941,10 +24932,9 @@ If so, why does the weights-multiplier stuff work w/o extra shuffling here?
 		"movaps		%%xmm2,0x20(%%rax)	\n\t	movaps		%%xmm6,0x60(%%rax)	\n\t"\
 		"movaps		%%xmm1,0x10(%%rax)	\n\t	movaps		%%xmm5,0x50(%%rax)	\n\t"\
 		"movaps		%%xmm0,    (%%rax)	\n\t	movaps		%%xmm4,0x40(%%rax)	\n\t"\
-		:					/* outputs: none */\
+		: [__wtA]		"+m" (XwtA)	/* outputs: the template stores into these */\
+		 ,[__wtB]		"+m" (XwtB)\
 		: [__data]		"m" (Xdata)	/* All inputs from memory addresses here */\
-		, [__wtA]		"m" (XwtA)		\
-		, [__wtB]		"m" (XwtB)		\
 		, [__cyA]		"m" (XcyA)		\
 		, [__cyB]		"m" (XcyB)		\
 		, [__bjmod_0]	"m" (Xbjmod_0)		\

--- a/src/imul_macro0.h
+++ b/src/imul_macro0.h
@@ -471,10 +471,9 @@ or the with functions using them (if we declare no _-prepended variables local t
 			"movl	%[_hi32], %%eax		\n\t"\
 			"adcl	$0	 	, %%eax		\n\t"/* (1)    0 + (b*c)_hi + (carryin from (0)), result ( upper 32 bits) in hi32, carryout in CF bit - should be zero! */\
 			"movl	%%eax	,%[_hi32]	\n\t"/* Move high result to hi32 */	\
-			: /* outputs: none */\
+			: [_md32] "+m" (_md32)	/* outputs: both are read and then written by the addl/adcl above */\
+			 ,[_hi32] "+m" (_hi32)	\
 			: [_bclo] "m" (_bclo)	/* All inputs from memory/register here */\
-			 ,[_md32] "m" (_md32)	\
-			 ,[_hi32] "m" (_hi32)	\
 			: "cc","memory","eax"	/* Clobbered registers */\
 			);\
 		}\

--- a/src/mi64.c
+++ b/src/mi64.c
@@ -6178,11 +6178,10 @@ uint64 radix_power64(const uint64 q, const uint64 qinv, uint32 n)
 			"cmovcq %%rbx,%%rax	\n\t"/* if CF = 1 (CMPSD = true), overwrite dest (rax = itmp64-q) with source (rbx = itmp64+q), else leave dest = itmp64-q. */\
 		"rad_pow64_end: 	\n\t"\
 			"movq	%%rax,%[__itmp64]	\n\t"\
-		:	/* outputs: none */\
+		: [__itmp64] "=m" (itmp64)	/* outputs: the template stores into these */\
 		: [__fquo] "m" (fquo)	/* All inputs from memory addresses here */\
 		 ,[__rnd] "m" (rnd)	\
 		 ,[__q] "m" (q)	\
-		 ,[__itmp64] "m" (itmp64)	\
 		: "cc","memory","rax","rbx","rcx","rdx","xmm0","xmm1"	/* Clobbered registers */\
 		);
 
@@ -6343,11 +6342,10 @@ int mi64_is_div_by_scalar64(const uint64 x[], uint64 q, uint32 len)
 	"jnz loop_start 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 
 		"movq	%%rdx,%[__cy]	\n\t"\
-		:	/* outputs: none */\
+		: [__cy] "=m" (cy)	/* outputs: the template stores into these */\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy] "m" (cy)	\
 		 ,[__len] "m" (len)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r10"	/* Clobbered registers */\
 		);
@@ -6373,11 +6371,10 @@ int mi64_is_div_by_scalar64(const uint64 x[], uint64 q, uint32 len)
 	"jnz loop_start 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 
 		"movq	%%rdx,%[__cy]	\n\t"\
-		:	/* outputs: none */\
+		: [__cy] "=m" (cy)	/* outputs: the template stores into these */\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy] "m" (cy)	\
 		 ,[__len] "m" (len)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r10"	/* Clobbered registers */\
 		);
@@ -6480,7 +6477,10 @@ int mi64_is_div_by_scalar64_x4(const uint64 x[], uint64 q0, uint64 q1, uint64 q2
 	"jnz loop4x 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%r8 ,%[__cy1]	\n\t	movq	%%r9 ,%[__cy2]	\n\t	movq	%%rdx,%[__cy3]	\n\t"\
-	:	/* outputs: none */\
+	: [__cy0] "=m" (cy0)	/* outputs: the template stores into these */\
+	 ,[__cy1] "=m" (cy1)\
+	 ,[__cy2] "=m" (cy2)\
+	 ,[__cy3] "=m" (cy3)\
 	: [__q0] "m" (q0)	/* All inputs from memory addresses here */\
 	 ,[__q1] "m" (q1)	\
 	 ,[__q2] "m" (q2)	\
@@ -6490,10 +6490,6 @@ int mi64_is_div_by_scalar64_x4(const uint64 x[], uint64 q0, uint64 q1, uint64 q2
 	 ,[__qinv2] "m" (qinv2)	\
 	 ,[__qinv3] "m" (qinv3)	\
 	 ,[__x] "m" (x)	\
-	 ,[__cy0] "m" (cy0)	\
-	 ,[__cy1] "m" (cy1)	\
-	 ,[__cy2] "m" (cy2)	\
-	 ,[__cy3] "m" (cy3)	\
 	 ,[__len] "m" (len)	\
 	: "cc","memory","rax","rcx","rdx","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
 	);
@@ -6583,12 +6579,11 @@ ASSERT(!nshift, "2-way folded ISDIV requires odd q!");
 	"jnz loop2a 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%rdx,%[__cy1]	"\
-		:	/* outputs: none */\
+		: [__cy0] "=m" (cy0)	/* outputs: the template stores into these */\
+		 ,[__cy1] "=m" (cy1)\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
 		 ,[__len] "m" (len)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r10","r11","r12"		/* Clobbered registers */\
 		);
@@ -6715,14 +6710,13 @@ ASSERT(!nshift, "4-way folded ISDIV requires odd q!");
 	"subq	$1,%%rcx \n\t"\
 	"jnz loop4u 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%r8 ,%[__cy1]	\n\t	movq	%%r9 ,%[__cy2]	\n\t	movq	%%rax,%[__cy3]	\n\t"\
-	:	/* outputs: none */\
+	: [__cy0] "=m" (cy0)	/* outputs: the template stores into these */\
+	 ,[__cy1] "=m" (cy1)\
+	 ,[__cy2] "=m" (cy2)\
+	 ,[__cy3] "=m" (cy3)\
 	: [__q] "m" (q)	/* All inputs from memory addresses here */\
 	 ,[__qinv] "m" (qinv)	\
 	 ,[__x] "m" (x)	\
-	 ,[__cy0] "m" (cy0)	\
-	 ,[__cy1] "m" (cy1)	\
-	 ,[__cy2] "m" (cy2)	\
-	 ,[__cy3] "m" (cy3)	\
 	 ,[__len] "m" (len)	\
 	: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
 	);
@@ -6763,14 +6757,13 @@ ASSERT(!nshift, "4-way folded ISDIV requires odd q!");
 	"subq	$1,%%rcx \n\t"\
 	"jnz loop4u 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%r8 ,%[__cy1]	\n\t	movq	%%r9 ,%[__cy2]	\n\t	movq	%%rdx,%[__cy3]	\n\t"\
-	:	/* outputs: none */\
+	: [__cy0] "=m" (cy0)	/* outputs: the template stores into these */\
+	 ,[__cy1] "=m" (cy1)\
+	 ,[__cy2] "=m" (cy2)\
+	 ,[__cy3] "=m" (cy3)\
 	: [__q] "m" (q)	/* All inputs from memory addresses here */\
 	 ,[__qinv] "m" (qinv)	\
 	 ,[__x] "m" (x)	\
-	 ,[__cy0] "m" (cy0)	\
-	 ,[__cy1] "m" (cy1)	\
-	 ,[__cy2] "m" (cy2)	\
-	 ,[__cy3] "m" (cy3)	\
 	 ,[__len] "m" (len)	\
 	: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
 	);
@@ -7181,12 +7174,11 @@ See similar behavior for 4-way-split version of the algorithm.
 	"subq	$1,%%rcx \n\t"\
 	"jnz loop2b 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%rdx,%[__cy1]	\n\t"\
-		:	/* outputs: none */\
+		: [__cy0] "=m" (cy0)	/* outputs: the template stores into these */\
+		 ,[__cy1] "=m" (cy1)\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
 		 ,[__len2] "m" (len2)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r10","r11","r12"		/* Clobbered registers */\
 		);
@@ -7243,12 +7235,11 @@ See similar behavior for 4-way-split version of the algorithm.
 		"andq	%%rsi,%%rdi			\n\t	andq	%%rsi,%%rdx		\n\t"/* q & (-cy0|1) */\
 		"addq	%%rdi,%%rax			\n\t	addq	%%rdx,%%r12		\n\t"/* cy0|1 = tmp0|1 + ((-cy0|1)&q) */\
 		"movq	%%rax,%[__cy0]		\n\t	movq	%%r12,%[__cy1]	\n\t"\
-		:	/* outputs: none */\
+		: [__cy0] "=m" (cy0)	/* outputs: the template stores into these */\
+		 ,[__cy1] "=m" (cy1)\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
 		 ,[__len2] "m" (len2)	\
 		 ,[__n] "m" (nshift)	\
 		 ,[__iptr0] "m" (iptr0)	/* Output pointers (will both point to itmp64 if no quotient desired.) */\
@@ -7344,14 +7335,13 @@ See similar behavior for 4-way-split version of the algorithm.
 	"subq	$1,%%rcx	\n\t"\
 	"jnz loop2d			\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%rdx,%[__cy1]	"\
-		:	/* outputs: none */\
+		: [__cy0] "+m" (cy0)	/* outputs: the template stores into these */\
+		 ,[__cy1] "+m" (cy1)\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__iptr0] "m" (iptr0)	/* Input pointers (point to x,x+len2 if q odd, y,y+len2 if q even) */\
 		 ,[__iptr1] "m" (iptr1)	\
 		 ,[__y] "m" (y)	\
-		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
 		 ,[__len2] "m" (len2)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14"		/* Clobbered registers */\
 		);
@@ -7382,14 +7372,13 @@ See similar behavior for 4-way-split version of the algorithm.
 	"subq	$1,%%rcx	\n\t"\
 	"jnz loop2d			\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"							\n\t	movq	%%rdx,%[__cy1]	"/* Only useful carryout is cy1, check-equal-to-zero */\
-		:	/* outputs: none */\
+		: [__cy1] "+m" (cy1)	/* outputs: the template stores into these */\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__iptr0] "m" (iptr0)	/* Input pointers (point to x,x+len2 if q odd, y,y+len2 if q even) */\
 		 ,[__iptr1] "m" (iptr1)	\
 		 ,[__y] "m" (y)	\
 		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
 		 ,[__len2] "m" (len2)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","r8","r9","r10","r11","r12","r13","r14"		/* Clobbered registers */\
 		);
@@ -7622,14 +7611,13 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 	"subq	$1,%%rcx \n\t"\
 	"jnz 0b \n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%r8 ,%[__cy1]	\n\t	movq	%%r9 ,%[__cy2]	\n\t	movq	%%rax,%[__cy3]	\n\t"\
-	:	/* outputs: none */\
+	: [__cy0] "=m" (cy0)	/* outputs: the template stores into these */\
+	 ,[__cy1] "=m" (cy1)\
+	 ,[__cy2] "=m" (cy2)\
+	 ,[__cy3] "=m" (cy3)\
 	: [__q] "m" (q)	/* All inputs from memory addresses here */\
 	 ,[__qinv] "m" (qinv)	\
 	 ,[__x] "m" (iptr0)	\
-	 ,[__cy0] "m" (cy0)	\
-	 ,[__cy1] "m" (cy1)	\
-	 ,[__cy2] "m" (cy2)	\
-	 ,[__cy3] "m" (cy3)	\
 	 ,[__len] "m" (len)	\
 	: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
 	);
@@ -7684,14 +7672,13 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 	"subq	$1,%%rcx \n\t"\
 	"jnz 0b	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rdi,%[__cy0]	\n\t	movq	%%r8 ,%[__cy1]	\n\t	movq	%%r9 ,%[__cy2]	\n\t	movq	%%rdx,%[__cy3]	\n\t"\
-		:	/* outputs: none */\
+		: [__cy0] "=m" (cy0)	/* outputs: the template stores into these */\
+		 ,[__cy1] "=m" (cy1)\
+		 ,[__cy2] "=m" (cy2)\
+		 ,[__cy3] "=m" (cy3)\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
-		 ,[__cy2] "m" (cy2)	\
-		 ,[__cy3] "m" (cy3)	\
 		 ,[__len] "m" (len)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
 		);
@@ -7761,14 +7748,13 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 		"addq	%%r9 ,%%r12			\n\t	addq	%%rdx,%%r13		\n\t"/* cy2|3 = tmp2|3 + ((-cy2|3)&q) */\
 		"movq	%%rax,%[__cy0]		\n\t	movq	%%r11,%[__cy1]	\n\t"\
 		"movq	%%r12,%[__cy2]		\n\t	movq	%%r13,%[__cy3]	\n\t"\
-		:	/* outputs: none */\
+		: [__cy0] "+m" (cy0)	/* outputs: the template stores into these */\
+		 ,[__cy1] "+m" (cy1)\
+		 ,[__cy2] "+m" (cy2)\
+		 ,[__cy3] "+m" (cy3)\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
-		 ,[__cy2] "m" (cy2)	\
-		 ,[__cy3] "m" (cy3)	\
 		 ,[__len4] "m" (len4)	\
 		 ,[__n] "m" (nshift)	\
 		: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
@@ -7848,14 +7834,13 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 		"addq	%%r9 ,%%r12			\n\t	addq	%%rdx,%%r13		\n\t"/* cy2|3 = tmp2|3 + ((-cy2|3)&q) */\
 		"movq	%%rax,%[__cy0]		\n\t	movq	%%r11,%[__cy1]	\n\t"\
 		"movq	%%r12,%[__cy2]		\n\t	movq	%%r13,%[__cy3]	\n\t"\
-		:	/* outputs: none */\
+		: [__cy0] "+m" (cy0)	/* outputs: the template stores into these */\
+		 ,[__cy1] "+m" (cy1)\
+		 ,[__cy2] "+m" (cy2)\
+		 ,[__cy3] "+m" (cy3)\
 		: [__q] "m" (q)	/* All inputs from memory addresses here */\
 		 ,[__qinv] "m" (qinv)	\
 		 ,[__x] "m" (x)	\
-		 ,[__cy0] "m" (cy0)	\
-		 ,[__cy1] "m" (cy1)	\
-		 ,[__cy2] "m" (cy2)	\
-		 ,[__cy3] "m" (cy3)	\
 		 ,[__len4] "m" (len4)	\
 		 ,[__n] "m" (nshift)	\
 		 ,[__iptr0] "m" (iptr0)	/* Output base-pointer */\
@@ -7991,7 +7976,7 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 	"subq	$1,%%rcx \n\t"\
 	"jnz loop4c 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rax,%[__cy3]	\n\t"\
-	:	/* outputs: none */\
+	: [__cy3] "+m" (cy3)	/* outputs: the template stores into these */\
 	: [__q] "m" (q)	/* All inputs from memory addresses here */\
 	 ,[__qinv] "m" (qinv)	\
 	 ,[__x] "m" (iptr0)	\
@@ -7999,7 +7984,6 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 	 ,[__cy0] "m" (cy0)	\
 	 ,[__cy1] "m" (cy1)	\
 	 ,[__cy2] "m" (cy2)	\
-	 ,[__cy3] "m" (cy3)	\
 	 ,[__len] "m" (len)	\
 	: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
 	);
@@ -8048,7 +8032,7 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 	"subq	$1,%%rcx \n\t"\
 	"jnz loop4c 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
 		"movq	%%rdx,%[__cy3]	\n\t"\
-	:	/* outputs: none */\
+	: [__cy3] "+m" (cy3)	/* outputs: the template stores into these */\
 	: [__q] "m" (q)	/* All inputs from memory addresses here */\
 	 ,[__qinv] "m" (qinv)	\
 	 ,[__iptr0] "m" (iptr0)	/* Input pointers (point to x,x+len2 if q odd, y,y+len2 if q even) */\
@@ -8057,7 +8041,6 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 	 ,[__cy0] "m" (cy0)	\
 	 ,[__cy1] "m" (cy1)	\
 	 ,[__cy2] "m" (cy2)	\
-	 ,[__cy3] "m" (cy3)	\
 	 ,[__len4] "m" (len4)	\
 	: "cc","memory","rax","rbx","rcx","rdx","rsi","rdi","r8","r9","r10","r11","r12","r13","r14","r15"	/* Clobbered registers */\
 	);

--- a/src/mi64.h
+++ b/src/mi64.h
@@ -433,12 +433,11 @@ __device__ uint32 mi64_twopmodq_gpu(
 		"andq	%[__q],%%rdx	\n\t"/* ((-(int64)(hi < lo)) & __q) */\
 		"addq	%%rdx,%%rdi		\n\t"/* __z in rdi */\
 		"movq	%%rdi,%[__z]	\n\t"\
-		:	/* outputs: none */\
+		: [__z] "=m" (__Xz)	/* outputs: the template stores into these */\
 		: [__x] "m" (__Xx)	/* All inputs from memory addresses here */\
 		 ,[__y] "m" (__Xy)	\
 		 ,[__q] "m" (__Xq)	\
 		 ,[__qinv] "m" (__Xqinv)	\
-		 ,[__z] "m" (__Xz)	\
 		: "cc","memory","rax","rdx","rdi"	/* Clobbered registers */\
 		);\
 	}
@@ -529,12 +528,11 @@ __device__ uint32 mi64_twopmodq_gpu(
 		"andq	%[__q],%%rdx	\n\t"/* ((-(int64)(hi < lo)) & __q) */\
 		"addq	%%rdx,%%rdi		\n\t"/* __z in rdi */\
 		"movq	%%rdi,%[__z]	\n\t"\
-		:	/* outputs: none */\
+		: [__z] "=m" (__Xz)	/* outputs: the template stores into these */\
 		: [__x] "m" (__Xx)	/* All inputs from memory addresses here */\
 		 ,[__y] "m" (__Xy)	\
 		 ,[__q] "m" (__Xq)	\
 		 ,[__qinv] "m" (__Xqinv)	\
-		 ,[__z] "m" (__Xz)	\
 		: "cc","memory","rax","rdx","rdi"	/* Clobbered registers */\
 		);\
 	}
@@ -561,11 +559,10 @@ __device__ uint32 mi64_twopmodq_gpu(
 		"andq	%[__q],%%rdi	\n\t"/* ((-(int64)(hi < lo)) & __q) */\
 		"addq	%%rdx,%%rdi		\n\t"/* __z in rdi */\
 		"movq	%%rdi,%[__z]	\n\t"\
-		:	/* outputs: none */\
+		: [__z] "=m" (__Xz)	/* outputs: the template stores into these */\
 		: [__x] "m" (__Xx)	/* All inputs from memory addresses here */\
 		 ,[__q] "m" (__Xq)	\
 		 ,[__qinv] "m" (__Xqinv)	\
-		 ,[__z] "m" (__Xz)	\
 		: "cc","memory","rax","rdx","rdi"	/* Clobbered registers */\
 		);\
 	}

--- a/src/twopmodq.c
+++ b/src/twopmodq.c
@@ -1526,7 +1526,10 @@ void twopmmodq64_q4(uint64 p, uint64 *i0, uint64 *i1, uint64 *i2, uint64 *i3, ui
 		"movq	%%r13,%[__x1]	\n\t"\
 		"movq	%%r14,%[__x2]	\n\t"\
 		"movq	%%r15,%[__x3]	\n\t"\
-		:	/* outputs: none */\
+		: [__x0] "+m" (x0)	/* outputs: the template stores into these */\
+		 ,[__x1] "+m" (x1)\
+		 ,[__x2] "+m" (x2)\
+		 ,[__x3] "+m" (x3)\
 		: [__q0] "m" (q0)	/* All inputs from memory addresses here */\
 		 ,[__q1] "m" (q1)	\
 		 ,[__q2] "m" (q2)	\
@@ -1535,10 +1538,6 @@ void twopmmodq64_q4(uint64 p, uint64 *i0, uint64 *i1, uint64 *i2, uint64 *i3, ui
 		 ,[__qinv1] "m" (qinv1)	\
 		 ,[__qinv2] "m" (qinv2)	\
 		 ,[__qinv3] "m" (qinv3)	\
-		 ,[__x0] "m" (x0)	\
-		 ,[__x1] "m" (x1)	\
-		 ,[__x2] "m" (x2)	\
-		 ,[__x3] "m" (x3)	\
 		 ,[__p] "m" (p)	\
 		 ,[__j] "m" (j)	/* Only need this if debug and explicit loop enabled, but try with/sans for each version of the asm, pivk faster one. */\
 		 ,[__start_index] "m" (start_index)	\

--- a/src/twopmodq100.c
+++ b/src/twopmodq100.c
@@ -566,9 +566,8 @@ opcount - umulh adds 5 mul, 3 fma, 5 add, 1 round:
 			"addq	%%rdx,%%rcx		\n\t"\
 			"addq	%%rcx,%%rax		\n\t"\
 			"movq	%%rax,%[__result]	\n\t"\
-			:					/* outputs: none */\
+			: [__result] "=m" (r)	/* outputs: the template stores into these */\
 			: [__fq0] "m" (dptr)	/* All inputs from memory addresses here */\
-			 ,[__result] "m" (r)	\
 			: "cc","memory","k0","k1","k2","k3","k4","k5","k6","k7","cl","rax","rbx","rcx","rdx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm30","xmm31"	/* Clobbered registers */\
 		);
 

--- a/src/twopmodq64_test.c
+++ b/src/twopmodq64_test.c
@@ -692,7 +692,19 @@ uint64 twopmodq64_q8(uint64 p, uint64 k0, uint64 k1, uint64 k2, uint64 k3, uint6
 		x7 = y7;
 	}
 
+	/* The eight qinv values reach the asm below as one array-pointer operand rather than eight
+	separate "m" inputs. Not a style choice: x0-x7 must be declared "+m" - the asm loads, updates
+	and stores them back - and a "+m" costs two of gcc's 30 asm operand slots, being implemented
+	as an output plus a matching input. Spelled out, this block needs 35 slots and does not
+	compile ("more than 30 operands in 'asm'"). Folding the qinv's into one operand, and dropping
+	__j which the template never referenced, brings it to 27. */
+	const uint64 qinv_arr[8] = {qinv0,qinv1,qinv2,qinv3,qinv4,qinv5,qinv6,qinv7};
+	const uint64*qinv_ptr = qinv_arr;
+
 	__asm__ volatile (\
+	/* Base address of the qinv[8] array. Nothing else in this block touches rdi, so this
+	survives the loop below: */\
+		"movq	%[__qinv],%%rdi	\n\t"\
 	/* Load the x's into r8-15: */\
 		"movq	%[__x0],%%r8 	\n\t"\
 		"movq	%[__x1],%%r9 	\n\t"\
@@ -744,14 +756,14 @@ uint64 twopmodq64_q8(uint64 p, uint64 k0, uint64 k1, uint64 k2, uint64 k3, uint6
 		"\n\t"\
 	/* MULL_q4((qinv*, lo*, lo*): */\
 		"\n\t"\
-		"imulq	%[__qinv0],%%r8 	\n\t"\
-		"imulq	%[__qinv1],%%r9 	\n\t"\
-		"imulq	%[__qinv2],%%r10	\n\t"\
-		"imulq	%[__qinv3],%%r11	\n\t"\
-		"imulq	%[__qinv4],%%r12	\n\t"\
-		"imulq	%[__qinv5],%%r13	\n\t"\
-		"imulq	%[__qinv6],%%r14	\n\t"\
-		"imulq	%[__qinv7],%%r15	\n\t"\
+		"imulq	0x00(%%rdi),%%r8 	\n\t"\
+		"imulq	0x08(%%rdi),%%r9 	\n\t"\
+		"imulq	0x10(%%rdi),%%r10	\n\t"\
+		"imulq	0x18(%%rdi),%%r11	\n\t"\
+		"imulq	0x20(%%rdi),%%r12	\n\t"\
+		"imulq	0x28(%%rdi),%%r13	\n\t"\
+		"imulq	0x30(%%rdi),%%r14	\n\t"\
+		"imulq	0x38(%%rdi),%%r15	\n\t"\
 		"\n\t"\
 	/* UMULH_q4((q*, lo*, lo*): lo0-3 in r8-11: */\
 		"\n\t"\
@@ -905,7 +917,14 @@ uint64 twopmodq64_q8(uint64 p, uint64 k0, uint64 k1, uint64 k2, uint64 k3, uint6
 		"movq	%%r13,%[__x5]	\n\t"\
 		"movq	%%r14,%[__x6]	\n\t"\
 		"movq	%%r15,%[__x7]	\n\t"\
-		:	/* outputs: none */\
+		: [__x0] "+m" (x0)	/* outputs: the template stores into these */\
+		 ,[__x1] "+m" (x1)\
+		 ,[__x2] "+m" (x2)\
+		 ,[__x3] "+m" (x3)\
+		 ,[__x4] "+m" (x4)\
+		 ,[__x5] "+m" (x5)\
+		 ,[__x6] "+m" (x6)\
+		 ,[__x7] "+m" (x7)\
 		: [__q0] "m" (q0)	/* All inputs from memory addresses here */\
 		 ,[__q1] "m" (q1)	\
 		 ,[__q2] "m" (q2)	\
@@ -914,26 +933,10 @@ uint64 twopmodq64_q8(uint64 p, uint64 k0, uint64 k1, uint64 k2, uint64 k3, uint6
 		 ,[__q5] "m" (q5)	\
 		 ,[__q6] "m" (q6)	\
 		 ,[__q7] "m" (q7)	\
-		 ,[__qinv0] "m" (qinv0)	\
-		 ,[__qinv1] "m" (qinv1)	\
-		 ,[__qinv2] "m" (qinv2)	\
-		 ,[__qinv3] "m" (qinv3)	\
-		 ,[__qinv4] "m" (qinv4)	\
-		 ,[__qinv5] "m" (qinv5)	\
-		 ,[__qinv6] "m" (qinv6)	\
-		 ,[__qinv7] "m" (qinv7)	\
-		 ,[__x0] "m" (x0)	\
-		 ,[__x1] "m" (x1)	\
-		 ,[__x2] "m" (x2)	\
-		 ,[__x3] "m" (x3)	\
-		 ,[__x4] "m" (x4)	\
-		 ,[__x5] "m" (x5)	\
-		 ,[__x6] "m" (x6)	\
-		 ,[__x7] "m" (x7)	\
+		 ,[__qinv] "m" (qinv_ptr)	/* base of the qinv[8] array; see the note above */\
 		 ,[__pshift] "m" (pshift)	\
-		 ,[__j] "m" (j)	/* Only need this if debug and explicit loop enabled, but try with/sans for each version of the asm, pivk faster one. */\
 		 ,[__start_index] "m" (start_index)	\
-		: "cc","memory","rax","rbx","rcx","rdx","r8","r9","r10","r11","r12","r13","r14","r15"		/* Clobbered registers */\
+		: "cc","memory","rax","rbx","rcx","rdx","rdi","r8","r9","r10","r11","r12","r13","r14","r15"		/* Clobbered registers */\
 		);
 
 	/*...Double and return.	These are specialized for the case where 2^p == 1 mod q implies divisibility, in which case x = (q+1)/2.

--- a/src/twopmodq64_test.c
+++ b/src/twopmodq64_test.c
@@ -540,7 +540,10 @@ uint64 twopmodq64_q4(uint64 p, uint64 k0, uint64 k1, uint64 k2, uint64 k3)
 		"movq	%%r13,%[__x1]	\n\t"\
 		"movq	%%r14,%[__x2]	\n\t"\
 		"movq	%%r15,%[__x3]	\n\t"\
-		:	/* outputs: none */\
+		: [__x0] "+m" (x0)	/* outputs: the template stores into these */\
+		 ,[__x1] "+m" (x1)\
+		 ,[__x2] "+m" (x2)\
+		 ,[__x3] "+m" (x3)\
 		: [__q0] "m" (q0)	/* All inputs from memory addresses here */\
 		 ,[__q1] "m" (q1)	\
 		 ,[__q2] "m" (q2)	\
@@ -549,10 +552,6 @@ uint64 twopmodq64_q4(uint64 p, uint64 k0, uint64 k1, uint64 k2, uint64 k3)
 		 ,[__qinv1] "m" (qinv1)	\
 		 ,[__qinv2] "m" (qinv2)	\
 		 ,[__qinv3] "m" (qinv3)	\
-		 ,[__x0] "m" (x0)	\
-		 ,[__x1] "m" (x1)	\
-		 ,[__x2] "m" (x2)	\
-		 ,[__x3] "m" (x3)	\
 		 ,[__pshift] "m" (pshift)	\
 		 ,[__j] "m" (j)	/* Only need this if debug and explicit loop enabled, but try with/sans for each version of the asm, pivk faster one. */\
 		 ,[__start_index] "m" (start_index)	\

--- a/src/twopmodq80.c
+++ b/src/twopmodq80.c
@@ -5348,10 +5348,9 @@ if(~pshift != p+78) {
 				"addq	%%rdx,%%rcx		\n\t"\
 				"addq	%%rcx,%%rax		\n\t"\
 				"movq	%%rax,%[__result]	\n\t"\
-				:					/* outputs: none */\
+				: [__result] "=m" (r)	/* outputs: the template stores into these */\
 				: [__fq0] "m" (dptr)	/* All inputs from memory addresses here */\
 				 ,[__two26f] "m" (two26f)	\
-				 ,[__result] "m" (r)	\
 				: "cc","memory","cl","rax","rbx","rcx","rdx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
 			);
 
@@ -6146,10 +6145,9 @@ if(~pshift != p+78) {
 				"addq	%%rdx,%%rcx		\n\t"\
 				"addq	%%rcx,%%rax		\n\t"\
 				"movq	%%rax,%[__result]	\n\t"\
-				:					/* outputs: none */\
+				: [__result] "=m" (r)	/* outputs: the template stores into these */\
 				: [__fq0] "m" (dptr)	/* All inputs from memory addresses here */\
 				 ,[__two26f] "m" (two26f)	\
-				 ,[__result] "m" (r)	\
 				: "cc","memory","k0","k1","k2","k3","k4","k5","k6","k7","cl","rax","rbx","rcx","rdx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
 			);
 
@@ -6894,10 +6892,9 @@ if(~pshift != p+78) {
 				"addq	%%rdx,%%rcx		\n\t"\
 				"addq	%%rcx,%%rax		\n\t"\
 				"shlq	$32,%%rax	\n\t	addq	%%rax,%[__result]	\n\t"\
-				:					/* outputs: none */\
+				: [__result] "=m" (r)	/* outputs: the template stores into these */\
 				: [__fq0] "m" (dptr)	/* All inputs from memory addresses here */\
 				 ,[__two26f] "m" (two26f)	\
-				 ,[__result] "m" (r)	\
 				: "cc","memory","k0","k1","k2","k3","k4","k5","k6","k7","cl","rax","rbx","rcx","rdx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10", "xmm12","xmm13","xmm14", "xmm16","xmm17","xmm18", "xmm20","xmm21","xmm22", "xmm24","xmm25","xmm26", "xmm28","xmm29","xmm30"	/* Clobbered registers */\
 			);
 			return r;


### PR DESCRIPTION
105 operand declarations across 9 files say `"m"` — a read-only memory input, which is a promise the
asm does not modify it — for operands the template stores into. The compiler is entitled to treat
such an operand as unchanged: to consider the variable still uninitialized afterwards, to discard
the store, or to keep a cached copy and reuse it.

**Nothing is broken today**, and the reason is uniform: every one of these blocks also carries a
`"memory"` clobber, which forces the compiler to assume the asm wrote memory it was not told about,
so the operand's stack slot gets reloaded rather than assumed dead. That is measurable, not
inferred — #271 shows the same three `util.c` sites going silent-to-diagnosed the moment **only**
the `"memory"` clobber is removed, gcc reporting all three as `may be used uninitialized` at
`-O1`/`-O2`/`-O3`.

Which is the point. Narrowing those clobber lists is the work in #68, #71 and the asm-clobber lint —
an over-broad `"memory"` on every block is precisely what they are removing. Here it is load-bearing,
for reasons nothing in the source states, in the mi64 modpow chain and the SSE2/AVX carry macros,
where a lost store is a wrong residue rather than a crash.

Each operand is declared `"=m"` if the template only stores to it, `"+m"` if it reads it first. That
distinction is the whole risk in this change, and the criterion is the **first access in template
order**: if a pure write comes first the incoming value is dead and `"=m"` is right, otherwise `"+m"`
is required. (A destination like `addq %%rax,%[__result]` is a read too — but not if a plain `movq`
into it came earlier in the same template, which is the case in `twopmodq80.c`.) 76 of the 105 are
`"+m"`, mostly pointers the asm advances and hands back: `carry_gcc64.h`'s
`__wtA`/`__wtB`/`__wtC`/`__data`, `mi64.c`'s `__cy*` carry chains.

| file | sites | `=m` | `+m` |
| --- | --- | --- | --- |
| `src/mi64.c` | 42 | 29 | 13 |
| `src/carry_gcc64.h` | 24 | 1 | 23 |
| `src/carry_gcc32.h` | 14 | 0 | 14 |
| `src/twopmodq.c` | 4 | 0 | 4 |
| `src/twopmodq64_test.c` | 12 | 0 | 12 |
| `src/mi64.h` | 3 | 3 | 0 |
| `src/twopmodq80.c` | 3 | 3 | 0 |
| `src/imul_macro0.h` | 2 | 0 | 2 |
| `src/twopmodq100.c` | 1 | 1 | 0 |

That is 105 of the **108** such declarations in the tree; the other three are `util.c`'s, which
are #271. So after these two PRs there are none left.

## The second commit: `twopmodq64_q8` needed room made for it first

Eight of the 105 are in a block that a declaration change alone cannot fix, which is why it gets its
own commit. It has 27 operands, and `x0..x7` genuinely need `"+m"` — the template's first access to
each is a load of the incoming value at the top, and it stores them back at the bottom — so at two
slots apiece that is 35, and `more than 30 operands in 'asm'`.

The operand budget is the thing to fix, and two of the 27 are cheap to reclaim:

- **`__j` is declared but never referenced** anywhere in the template. Its own comment says *"Only
  need this if debug and explicit loop enabled"*. Dropped.
- **`qinv0..7` are eight read-only operands used exactly once each**, in eight consecutive
  `imulq %[__qinvN],%%rN` lines. They now travel as one array-pointer operand, loaded into `rdi`
  once before the loop and addressed as `0x00(%%rdi)`..`0x38(%%rdi)`. `rdi`, `rsi` and `rbp` are
  untouched by the rest of the block, so no register shuffling is needed, and the eight loads stay
  memory operands to the same `imulq`.

27 − 8 + 1 − 1 = 19 operands, so 19 + 8 = **27 slots**. The accounting is the whole argument, so I
measured it rather than trusting the manual: gcc accepts 30 plain `"m"` inputs and rejects 31,
accepts 15 `"+m"` and rejects 16, and accepts 8 `"+m"` alongside 14 `"m"` (30 slots) while rejecting
15 (31).

This is the live `twopmodq64_q8` — `twopmodq.c` defines one too, but `nm` shows the global
definition coming from `twopmodq64_test.o`, and `factor.c` dispatches it in the `TRYQ == 8` arm.

**Verifying it needed its own work**, because the Mfactor self-tests do not reach this routine as
normally built: `factor_test.h`'s q8 check sits under `#elif(TRYQ == 8)` and `makemake.sh` always
passes `TRYQ=4`.

| check | result |
| --- | --- |
| Mfactor built with `-DTRYQ=8`, which compiles `factor_test.h`'s q8 self-test *and* `factor.c`'s `TRYQ == 8` dispatch arm | self-tests pass in both trees, no `twopmodq64_q8 ... failed to find factor`, and `-m 2147483647 -bmax 50` gives the same 657696 trial divides |
| differential harness vs GMP, 12,500 octets over five exponents from M(127) to M(2147483647), with a genuine factor planted in a rotating lane so that **7501 of the 100000 candidates are real factors** | zero GMP mismatches in both trees; the checksum of every returned bitmask identical, `9908A028DE8B25E6` |
| that harness against an injected fault — one `imulq` pointed at the wrong array slot (`0x18`→`0x20`, lane 3 reading lane 4's qinv) | 939 mismatches and a different checksum, so the check is sensitive to exactly what this restructuring could get wrong |
| timing, 12,500 q8 calls, best of three | 194 ms before, 194 ms after |

Random `k` alone, without the planted factors, finds nothing at all across 160,000 candidates — that
harness would have passed against a routine that always answered "no factor", which is why the
planting matters.

## Verification

First, that the checks can see this class of fault at all. Injecting one — making `carry_gcc64.h`'s
`wtA` store land the wrong register, the same shape as a mis-declared operand — collapses the sse2
`-s tt` self-test from 26 residues to 4, with 34 error lines. (It still exits 0; the residue
comparison is what catches it, not the exit status.) Then, with the real change:

| check | result |
| --- | --- |
| generated `.text`, all 90 sources × gcc/clang × nosimd/sse2/avx/avx2/avx512, byte-compared vs main | 966 identical, 40 differ — the edited files plus `radix32_ditN_cy_dif1.c` under clang/sse2 and `radix36_ditN_cy_dif1.c` under clang/avx and clang/avx2. **gcc's output for every radix file is unchanged.** |
| diagnostics over that same matrix | not one warning or error added or removed |
| Mfactor self-test battery (`twopmodq64_q4`/`q8`, `twopmodq80/96/128/160/192/256`, `mi64_twopmodq`) | passes in nosimd, sse2, avx2; `-m 521 -bmax 20` gives the same 1320739 trial divides in all six builds |
| `Mlucas -s tt` / `-prp -s tt`, `-cpu 0:3`, per mode vs the same build of main | nosimd 41 and 43 identical `Res64`, sse2 26 and 26, avx2 23 and 23, all rc=0 |
| AVX-512 under Intel SDE (`-skx`), `-s tt` | 8 identical `Res64`, rc=0, binary confirmed as the AVX-512 build from its own banner |

**Sixteen of the 105 are the exception to all of that** — `carry_gcc32.h`'s 14 and
`imul_macro0.h`'s 2 — because they are in 32-bit x86 code that no supported configuration compiles.
A 32-bit SIMD build stops at `platform.h:1646`, *"SIMD-assembler code only supported for 64-bit
build!"*, and `radix16_ditN_cy_dif1_asm.h:2883`, *"32-bit OSes no longer supported for SIMD
builds!"*; `imul_macro0.h`'s block is in the `CPU_IS_X86` arm, and preprocessing `imul_macro.c` in
nosimd, sse2 and avx2 yields no occurrence of its operands at all, with the resulting object code
identical to main's. Those 16 are transformed by the same rule and pass the same structural checks,
but they are not compile-tested, because they cannot be. Happy to drop both files from the PR if
you'd rather leave dead code untouched.

## How the edit was made, and how to re-check it

I scripted it rather than hand-typing 97 of them. The finder is below - self-contained, needs only
python3, run it from the repo root. On this branch it reports just `util.c`'s three as remaining; on `main` it reports 108.

A companion script performed the move, and its method rather than its code is the reviewable part:
for each affected block it lifts the operand's declaration line out of the input list into the
output list, rewriting `"m"` to `"=m"` or `"+m"`, promotes the next surviving input to carry the
section's `:` when the moved line was the first one, then asserts the block still has three `:`
sections with no plain `"m"` left in the outputs and no `"=m"`/`"+m"` left in the inputs. It refuses
outright any block the conversion would push past 30 operands, which is how the `twopmodq64_q8`
block came to be flagged rather than silently broken — and is what sent me to make room for it in
the second commit.

**Delimiting these asm statements is the part worth stating**, because two plausible rules both
fail. Keying on `);` alone on a line misses single-line `asm(...)` statements and then runs on,
swallowing every block up to the next multi-line one - that is how I first missed `imul_macro0.h`
entirely. Counting parentheses trips over both the `(%%rbx)` in the templates *and* the unbalanced
parens in their trailing `/* ... */` comments - that is how I first undercounted `carry_gcc64.h` at
3 instead of 24. Stripping comments and string literals first, then counting parentheses,
terminates both shapes; and the site list it produces is exactly the **union** of what the two
flawed rules find, with each of them differing from it only by omission, never by inventing a site.
That is the cross-check that convinced me 108 is the whole set.

One caveat in the finder, and the reason the ARM asm is untouched here: on ARM, `%[__add0]` in
`ldr x5,%[__add0]` is the *source*, not the destination. A naive "last operand is the destination"
rule reports 72 false positives across the ARM headers, so the finder filters the ARM load
mnemonics.

If it would be useful I am happy to add this as a lint in a follow-up - standalone, or folded into
the asm-clobber lint job - so the pattern cannot come back. I have kept it out of this PR to hold
the diff to the declarations themselves.

<details>
<summary>The finder, if you want to reproduce the site list (click to expand)</summary>

```python
#!/usr/bin/env python3
"""Audit inline-asm operands declared as read-only "m" INPUTS that the template stores into.

Block delimiting is the whole difficulty. Two rules that look reasonable both fail here:
  - ");" alone on a line: single-line asm statements never match it, so the scan runs on
    and swallows every following block until the next multi-line one ends.
  - counting parentheses: the templates are full of "(%%rbx)" AND the trailing /* ... */
    comments contain unbalanced parens.
So: strip block comments (they span lines), line comments, and string/char literals, and
only then count parentheses. That terminates both shapes correctly.

Per operand, report whether the template also READS it - that decides "+m" over "=m".
"""
import re, sys, glob, json, collections

ARM_LOAD = re.compile(r'\b(ldr|ldp|ld1r?|ldur|ldrb|ldrh|ldrsw)\b')
SEC      = re.compile(r'^([ \t]*):')
ASM      = re.compile(r'(__asm__|(?<![\w.])asm)\s*(__volatile__|volatile)?\s*\(')

def strip_code(lines):
    """Return a parallel list with comments and literals blanked, preserving length."""
    out, in_cmt = [], False
    for ln in lines:
        s, i, res = ln, 0, []
        while i < len(s):
            if in_cmt:
                e = s.find('*/', i)
                if e < 0: res.append(' ' * (len(s) - i)); i = len(s)
                else: res.append(' ' * (e + 2 - i)); i = e + 2; in_cmt = False
            elif s.startswith('/*', i):
                in_cmt = True; res.append('  '); i += 2
            elif s.startswith('//', i):
                res.append(' ' * (len(s) - i)); i = len(s)
            elif s[i] in '"\'':
                q = s[i]; j = i + 1
                while j < len(s) and s[j] != q:
                    j += 2 if s[j] == '\\' else 1
                res.append(' ' * (min(j, len(s) - 1) + 1 - i)); i = j + 1
            else:
                res.append(s[i]); i += 1
        out.append(''.join(res))
    return out

results = []
for path in sorted(glob.glob('src/*.c') + glob.glob('src/*.h')):
    lines = open(path, encoding='utf-8', errors='replace').read().split('\n')
    bare  = strip_code(lines)
    i = 0
    while i < len(lines):
        m = ASM.search(bare[i])
        if not m: i += 1; continue
        depth, j, started = 0, i, False
        while j < len(lines):
            seg = bare[j][m.end()-1:] if j == i else bare[j]
            for ch in seg:
                if ch == '(': depth += 1; started = True
                elif ch == ')': depth -= 1
            if started and depth <= 0: break
            j += 1
            if j - i > 8000: break
        buf = lines[i:j+1]
        secs, cur, tmpl = [], None, []
        for off, ln in enumerate(buf):
            if SEC.match(ln):
                cur = []; secs.append(cur); cur.append((i+off+1, ln))
            elif cur is not None: cur.append((i+off+1, ln))
            else: tmpl.append((i+off+1, ln))
        if len(secs) >= 2:
            positional = bool(re.search(r'%[0-9]', '\n'.join(t for _, t in tmpl)))
            for lineno, text in secs[1]:
                for name in re.findall(r'\[\s*(_{1,2}\w+)\s*\]\s*"m"', text):
                    stores, reads = [], []
                    for ln_no, ln in tmpl:
                        if not re.search(r'%\[\s*'+re.escape(name)+r'\s*\]', ln): continue
                        if ARM_LOAD.search(ln): reads.append(ln_no); continue
                        nd = len(re.findall(r',[ \t]*%\[\s*'+re.escape(name)+r'\s*\][ \t]*(?=\\n|\\t|")', ln))
                        na = len(re.findall(r'%\[\s*'+re.escape(name)+r'\s*\]', ln))
                        if nd: stores.append(ln_no)
                        if na > nd: reads.append(ln_no)
                    if stores:
                        results.append(dict(file=path, decl_line=lineno, operand=name,
                                            constraint='+m' if reads else '=m',
                                            stores=stores, reads=reads,
                                            block=[i+1, j+1], positional=positional))
        i = j + 1

if len(sys.argv) > 1 and sys.argv[1] != '-': json.dump(results, open(sys.argv[1], 'w'), indent=1)
byf = collections.defaultdict(list)
for r in results: byf[r['file']].append(r)
eq = sum(1 for r in results if r['constraint'] == '=m')
print(f"{len(results)} operand declarations to move  (=m: {eq}, +m: {len(results)-eq})", file=sys.stderr)
for f, v in sorted(byf.items(), key=lambda kv: -len(kv[1])):
    e = sum(1 for r in v if r['constraint'] == '=m')
    print(f"  {f:26s} {len(v):3d} in {len({tuple(r['block']) for r in v}):3d} blocks   =m:{e:3d} +m:{len(v)-e:3d}"
          f"   positional:{sum(1 for r in v if r['positional'])}", file=sys.stderr)
```

</details>

Same class as #271.
