### PR TITLE
makemake.sh: probe for librt instead of inferring it from $OSTYPE (fixes the MinGW cross-build link)

### DIFF
--- a/makemake.sh
+++ b/makemake.sh
@@ -154,14 +154,16 @@ try_lto() {
 
 if [[ ! $OSTYPE == darwin* ]]; then
 	LD_ARGS+=(-lm -lpthread)
-	# librt does not exist on Windows targets. Probe the compiler for it rather than testing $OSTYPE:
-	# $OSTYPE describes the *build host*, so it only skips -lrt for a native msys/cygwin build, and a
-	# MinGW cross-build from Linux (CC=x86_64-w64-mingw32-gcc) still got -lrt and died at the link step
-	# with "cannot find -lrt". Probing also drops the flag on any other target that has folded the librt
-	# entry points into libc, which is where glibc has been heading since 2.34:
-	if try_flag -lrt; then
-		LD_ARGS+=(-lrt)
-	fi
+fi
+# librt is not a "which host am I on" question, so it is asked of the toolchain rather than of
+# $OSTYPE - which describes the *build host*, not the target. The old test only skipped -lrt for a
+# native msys/cygwin build, so a MinGW cross-build from Linux (CC=x86_64-w64-mingw32-gcc) still got
+# the flag and died at the link step with "cannot find -lrt". The probe covers every target that
+# lacks librt with one rule: Windows, macOS (whose realtime entry points live in libSystem), and any
+# system that has folded them into libc, which is where glibc has been heading since 2.34. That is
+# why this sits outside the darwin block above rather than inside it:
+if try_flag -lrt; then
+	LD_ARGS+=(-lrt)
 fi
 # GNU Make's -O (synchronize parallel-job output) flag needs Make >= 4.0 - probe for the flag itself
 # rather than assuming by version number (which drifts, and varies by distro/backport):

--- a/makemake.sh
+++ b/makemake.sh
@@ -154,7 +154,12 @@ try_lto() {
 
 if [[ ! $OSTYPE == darwin* ]]; then
 	LD_ARGS+=(-lm -lpthread)
-	if [[ $OSTYPE != msys && $OSTYPE != cygwin ]]; then
+	# librt does not exist on Windows targets. Probe the compiler for it rather than testing $OSTYPE:
+	# $OSTYPE describes the *build host*, so it only skips -lrt for a native msys/cygwin build, and a
+	# MinGW cross-build from Linux (CC=x86_64-w64-mingw32-gcc) still got -lrt and died at the link step
+	# with "cannot find -lrt". Probing also drops the flag on any other target that has folded the librt
+	# entry points into libc, which is where glibc has been heading since 2.34:
+	if try_flag -lrt; then
 		LD_ARGS+=(-lrt)
 	fi
 fi


### PR DESCRIPTION
`makemake.sh` decides whether to link `-lrt` from `$OSTYPE`:

```bash
if [[ ! $OSTYPE == darwin* ]]; then
	LD_ARGS+=(-lm -lpthread)
	if [[ $OSTYPE != msys && $OSTYPE != cygwin ]]; then
		LD_ARGS+=(-lrt)
	fi
fi
```

`$OSTYPE` is the machine the script is *running on*, not the one being built *for*. So the exclusion fires only for a native msys/cygwin build, and a MinGW cross-build from Linux still gets `-lrt`:

```
$ CC=x86_64-w64-mingw32-gcc ./makemake.sh avx2 no_gmp
...
x86_64-w64-mingw32-gcc ... -o Mlucas [~90 .o files] -lm -lpthread -lrt
/usr/x86_64-w64-mingw32/bin/ld: cannot find -lrt: No such file or directory
collect2: error: ld returned 1 exit status
```

Every translation unit compiles; only the final link fails, so you get the failure at the very end of a full build.

## Fix

Probe the toolchain instead, with the `try_flag` helper already in this file — the same approach it uses for `-march=native`, `-fdiagnostics-color` and Make's `-O`, and consistent with the comment there about probing rather than "assuming by version number (which drifts, and varies by distro/backport)". The probe discriminates cleanly:

```
gcc:                     -lrt OK
x86_64-w64-mingw32-gcc:  -lrt UNAVAILABLE
```

As a side benefit it also drops the flag on any target that has folded the librt entry points into libc, which is where glibc has been heading since 2.34.

## Verification

| build | result |
| --- | --- |
| native Linux (`./makemake.sh nosimd`) | `-lrt` still on the link line, builds clean |
| MinGW cross (`CC=x86_64-w64-mingw32-gcc ./makemake.sh avx2 no_gmp`) | links; no `-lrt` anywhere in `build.log` |

And the cross-built binary is not merely link-clean — it runs. Under Wine 11.16, with the MinGW runtime DLLs alongside it:

```
CPU Family = x86_64, OS = Windows, 64-bit Version, compiled with Gnu C [or other compatible], Version 16.2.0.
Res64: 5F1F741C1FBDA658. AvgMaxErr = 0.010018485. MaxErr = 0.015625000. Program: E21.0.2
```

`M189997 -fft 10 -iters 100`, matching the residue the same case gives built for Linux.

I hit this while testing the Windows side of #108, where I had to hand-link around it.
