### PR TITLE
Record the thread count in mlucas.cfg entries and only use entries that match the run

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -107,6 +107,14 @@ Supported command-line arguments:
 	only be written to the resulting mlucas.cfg file if the timing-test results match each other.
 	This is important for tuning code parameters to your particular platform.
 
+	Each mlucas.cfg entry records the thread count it was timed with ('nthreads = N'). The radix
+	set that is fastest at one thread is frequently not the fastest at 4 or 16, so at run time
+	only entries whose thread count matches the current -cpu/-nthread setting are used; an entry
+	for the same FFT length timed with a different count is ignored, and a quick timing test at the
+	current count is run and appended instead. One cfg file may therefore hold an entry per FFT
+	length and thread count. Entries written by older versions have no thread-count field and are
+	accepted for any count. Run the self-test with the same -cpu setting you will use for real work.
+
 Options - again note the user can override the default iteration count based on #threads via
 '-iters {+int}', though only 100|1000|10000-iteration cases have precomputed reference residues.
 The (very rough) time estimates are for 1000 iterations done using 4 or more cores.

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -4897,6 +4897,13 @@ TIMING_TEST_LOOP:
 			*/
 			for(i = 0; i < 10; i++){ fprintf(fp,"%3u",RADIX_VEC[i]); };
 
+			/* Record the thread count the timing was taken with. The fastest radix set at one thread
+			is often not the fastest at 4 or 16 - the FFT-phase working set grows with thread count -
+			so get_preferred_fft_radix() only trusts entries whose thread count matches the current run,
+			and a cfg file may hold one entry per (FFT length, thread count). Fixed width like the rest
+			of the line; entries written by older versions lack the field and are accepted for any count: */
+			fprintf(fp, "  nthreads = %4u", NTHREADS);
+
 			/* If it's a new self-test residue being computed, add the SH residues to the .cfg file line */
 			if(new_data)
 				fprintf(fp, "\tp = %s: %d-iter Res mod 2^64, 2^35-1, 2^36-1 = %016" PRIX64 ", %11.0f, %11.0f",ESTRING,iters,new_res.sh0,(double)new_res.sh1,(double)new_res.sh2);

--- a/src/get_preferred_fft_radix.c
+++ b/src/get_preferred_fft_radix.c
@@ -91,7 +91,8 @@ uint32	get_preferred_fft_radix(uint32 kblocks)
 {
 	uint32 i, j, k, kprod, found, retval = 0;
 	double tbest = 0, tcurr;
-	char *char_addr;
+	char *char_addr, *nt_addr;
+	uint32 nt, nt_skipped = 0, nt_seen = 0;	// #entries for the target length skipped for a thread-count mismatch, and the last such count
 
 	/* FFT-radix configuration file is named mlucas.cfg or fermat.cfg,
 	depending on whether Mersenne or Fermat number test is being done:
@@ -118,6 +119,17 @@ uint32	get_preferred_fft_radix(uint32 kblocks)
 				within range in favor of an out-of-range one that later trips the caller's ASSERT:
 				*/
 				if((i >= kblocks) && (i <= (kblocks<<1)) && (char_addr = strstr(g_in_line, "msec/iter =")) != 0) {
+					/* Entries carry the thread count they were timed with ('nthreads = N', written by the
+					self-test since v21.1). A radix set that is fastest at 1 thread is often not fastest at
+					4 or 16, because the FFT-phase working set grows with the thread count, so a timing taken
+					with a different count is not evidence for this run: skip such lines. Lines without the
+					field (older cfg files) are accepted as before. Doing this before the duplicate-entry
+					check below is what lets one cfg file hold an entry per (FFT length, thread count):
+					*/
+					if((nt_addr = strstr(g_in_line, "nthreads =")) != 0x0 && sscanf(nt_addr + 10, "%u", &nt) == 1 && nt != (uint32)NTHREADS) {
+						if(i == kblocks) { nt_skipped++; nt_seen = nt; }	// Reported below, only if no matching entry turns up
+						continue;
+					}
 					/* Stores whether we found an entry for the requested FFT length
 					(whether that proves to have the best timing for lengths >= kblocks or not): */
 					if(i == kblocks) {
@@ -218,6 +230,10 @@ uint32	get_preferred_fft_radix(uint32 kblocks)
 	Otherwise clear RADIX_VEC and return 0:
 	*/
 	if(!found) {
+		if(nt_skipped) {
+			fprintf(stderr, "INFO: %s has %u entr%s for FFT length %uK, but timed with a different thread count (%u) than this run's %d; ignoring %s. A timing test for this length at %d threads will be run and its result appended.\n",
+				CONFIGFILE, nt_skipped, nt_skipped == 1 ? "y" : "ies", kblocks, nt_seen, NTHREADS, nt_skipped == 1 ? "it" : "them", NTHREADS);
+		}
 		retval = 0;
 		for(j=0; j<10; j++) { RADIX_VEC[j] = 0; }
 		NRADICES = 0;


### PR DESCRIPTION
## Summary

The radix set that is fastest at one thread is frequently not the fastest at 4 or 16. The
working set each FFT-phase thread sweeps is `16*n/radix0` bytes, so more threads favour a
larger leading radix; at 16384K and 16 threads the leading radix alone spans 41.6 to 119.4
ms/iter across the sets the self-test tries. But `mlucas.cfg` entries do not record the thread
count they were timed with, and `get_preferred_fft_radix()` reads only `msec/iter` and
`radices`. A cfg produced by a 1-thread self-test therefore silently drives radix selection for
a 4- or 16-thread production run, and vice versa.

## Change

- Each cfg line written by the self-test now ends its fixed-width part with `nthreads = N`
  (before the optional `p = ...` residue data).
- `get_preferred_fft_radix()` skips any line whose `nthreads` differs from the current
  `NTHREADS`. The skip happens before the duplicate-entry check, so one cfg file can hold one
  entry per (FFT length, thread count) and the existing "multiple entries" assertion is not
  triggered by entries for other thread counts.
- If the only entries for the requested length were skipped for this reason, an INFO line says
  so and the normal not-found path runs the quick timing test for that length and appends the
  result, now tagged with the current thread count. Subsequent runs at that count find it.
- Lines without the field (cfg files from earlier versions) are accepted for any thread count,
  exactly as before.
- help.txt documents the field and the recommendation to run the self-test with the same
  `-cpu` setting as production.

Parsers that locate named fields (`msec/iter =`, `radices =`, `p =`) are unaffected; the radix
list is still the ten integers after `radices =`.

## Verification

AVX2 build; functional test at 13K-16K (`plan-notes/scaling-tools/test_b1.sh`), production mode
driven through worktodo.txt:

| check | result |
| --- | --- |
| `-s tt -cpu 0` then `-cpu 0:1`: every entry tagged, both sets coexist | pass |
| production run at 2 threads finds the 2-thread 16K entry: no INFO, no timing test | pass |
| production run at 3 threads: INFO printed, quick test appends `nthreads = 3` for 16K, run completes, no duplicate-entry assertion | pass |
| second 3-thread run: silent | pass |
| cfg with the field stripped (old format), 4 threads: accepted, no timing test | pass |

## Follow-ups (separate PRs)

Startup report of the physical cores and cache sizes behind a `-cpu` set, and ordering the
self-test's radix candidates by working set when NTHREADS > 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
