### PR TITLE
Report the physical cores and cache sizes behind the selected CPU set at startup

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -455,10 +455,20 @@ numbering conventions used by the leading x86-CPU manufacturers Intel and AMD.
 	setting syntax in which each of the comma-separated 'triplet' subfields is in the above
 	form and, analogously to the one-triplet-only version, no whitespace is permitted within
 	the colon-and-comma-separated numeric field. Thus '-cpu 0:3,8:11' and '-cpu 0:3:1,8:11:1'
+	(see also the note on logical-CPU numbering after this list)
 	both specify an 8-threaded run with affinity set to logical core quartets 0-3 and 8-11,
 	whereas '-cpu 0:3:2,8:11:2' means run 4-threaded on cores 0,2,8,10. As described for the
 	-nthread option, it is an error for any core index to exceed the available number of logical
 	processor cores.
+
+	NOTE on logical-CPU numbering: the -cpu indices are the operating system's logical-processor
+	numbers, and which of those are hyperthread (SMT) siblings of one physical core differs by OS
+	and vendor. Linux on Intel usually numbers siblings as i and i+(number of cores), so '-cpu 0:3'
+	is four physical cores; Windows, FreeBSD and most AMD systems number siblings adjacently, so the
+	same '-cpu 0:3' is two physical cores with both hyperthreads each. At startup Mlucas prints how
+	many physical cores the selected set spans and warns when siblings share a core; use '-core
+	lo:hi:1' (hwloc builds) or list one logical CPU per core (e.g. '-cpu 0:6:2') for one thread per
+	core. The detected L2 (per core) and L3 cache sizes are printed on the same occasion.
 
 ======================
 

--- a/help.txt
+++ b/help.txt
@@ -462,13 +462,15 @@ numbering conventions used by the leading x86-CPU manufacturers Intel and AMD.
 	processor cores.
 
 	NOTE on logical-CPU numbering: the -cpu indices are the operating system's logical-processor
-	numbers, and which of those are hyperthread (SMT) siblings of one physical core differs by OS
-	and vendor. Linux on Intel usually numbers siblings as i and i+(number of cores), so '-cpu 0:3'
-	is four physical cores; Windows, FreeBSD and most AMD systems number siblings adjacently, so the
-	same '-cpu 0:3' is two physical cores with both hyperthreads each. At startup Mlucas prints how
-	many physical cores the selected set spans and warns when siblings share a core; use '-core
-	lo:hi:1' (hwloc builds) or list one logical CPU per core (e.g. '-cpu 0:6:2') for one thread per
-	core. The detected L2 (per core) and L3 cache sizes are printed on the same occasion.
+	numbers, and which of those are hyperthread (SMT) siblings of one physical core is decided by
+	firmware, so it varies from system to system and is not a property of the CPU vendor. Two
+	layouts are common: siblings numbered adjacently, so that CPUs 0 and 1 share a core, and
+	siblings numbered i and i+(number of cores), so that CPUs 0 and 8 share a core on an 8-core
+	part. Under the first, '-cpu 0:3' is two physical cores with both hyperthreads each; under the
+	second it is four separate cores. At startup Mlucas prints how many physical cores the selected
+	set spans and warns when siblings share a core; use '-core lo:hi:1' (hwloc builds) or list one
+	logical CPU per core (e.g. '-cpu 0:6:2') for one thread per core. The detected L2 (per core) and
+	L3 cache sizes are printed on the same occasion.
 
 ======================
 

--- a/src/Mdata.h
+++ b/src/Mdata.h
@@ -357,6 +357,7 @@ extern uint32 TRANSFORM_TYPE;
 extern const char OFILE[], WORKFILE[];
 extern const char MLUCAS_INI_FILE[];
 extern char CONFIGFILE[];
+extern uint64 L2_CACHE_BYTES, L3_CACHE_BYTES;	// Detected per-core L2 and (shared) L3 sizes, 0 = unknown; set by report_cpu_topology()
 extern char STATFILE[];
 extern char RESTARTFILE[];
 extern uint64 KNOWN_FACTORS[40];	// Known prime-factors input to p-1 runs ... for now limit to 10 factors, each < 2^256

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -198,6 +198,7 @@ const char WORKFILE [] = "worktodo.txt";	/* File containing exponents to be test
 
 const char MLUCAS_INI_FILE[] = "mlucas.ini";	/* File containing user-customizable configuration settings [currently unused] */
 
+uint64 L2_CACHE_BYTES = 0, L3_CACHE_BYTES = 0;	// Detected per-core L2 and (shared) L3 sizes, 0 = unknown
 char CONFIGFILE[15];						/* Configuration File: contains allowed FFT lengths
 											and allows user to control (at runtime, and in
 											a modifiable way) which of a predefined set
@@ -4392,6 +4393,14 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 			print_help();
 		}
 	}	/* end of command-line-argument processing while() loop */
+
+#ifdef MULTITHREAD
+	// Say what the selected logical CPUs are in physical terms (cores, threads per core) and what the
+	// cache sizes are, and warn if SMT siblings were selected without -core asking for that: what
+	// '-cpu 0:3' means depends on the OS's and vendor's logical-CPU numbering, and scaling reports
+	// are not comparable without this.
+	if(cpu || nthread || core) report_cpu_topology(core);
+#endif
 
 	// Nov 2020: Sanity-check any p-1 bounds:
 	if(testType == TEST_TYPE_PM1) {

--- a/src/util.c
+++ b/src/util.c
@@ -9304,6 +9304,130 @@ exit(0);
 		}
 	}
 
+	/* Return the physical-core key of logical CPU `cpu`, or -1 if unknown. Keys are only compared
+	   for equality, so any stable encoding works: (package << 16 | core_id) on Linux, hwloc CORE
+	   logical index, Windows core ordinal. */
+	static int cpu_core_key(uint32 cpu)
+	{
+	#if INCLUDE_HWLOC
+		/* Consistent with threadpool.c, which binds worker i to HWLOC_OBJ_PU with *logical* index i: */
+		hwloc_obj_t pu = hwloc_get_obj_by_type(hw_topology, HWLOC_OBJ_PU, cpu);
+		if(pu) {
+			hwloc_obj_t core = hwloc_get_ancestor_obj_by_type(hw_topology, HWLOC_OBJ_CORE, pu);
+			if(core) return (int)core->logical_index;
+		}
+		return -1;
+	#elif defined(OS_TYPE_LINUX) && !defined(__MINGW32__)
+		char path[128]; FILE *f; int core = -1, pkg = 0;
+		snprintf(path, sizeof(path), "/sys/devices/system/cpu/cpu%u/topology/core_id", cpu);
+		if((f = fopen(path, "r"))) { if(fscanf(f, "%d", &core) != 1) core = -1; fclose(f); }
+		snprintf(path, sizeof(path), "/sys/devices/system/cpu/cpu%u/topology/physical_package_id", cpu);
+		if((f = fopen(path, "r"))) { if(fscanf(f, "%d", &pkg) != 1) pkg = 0; fclose(f); }
+		return (core < 0) ? -1 : ((pkg & 0x7fff) << 16) | (core & 0xffff);
+	#elif defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
+		/* Enumerate RelationProcessorCore records; the k-th record is core k; a CPU belongs to it if
+		   its (group, bit) is in the record's GroupMask array. */
+		DWORD len = 0; int key = -1, k = 0;
+		GetLogicalProcessorInformationEx(RelationProcessorCore, NULL, &len);
+		if(len == 0) return -1;
+		char *buf = malloc(len); if(!buf) return -1;
+		if(GetLogicalProcessorInformationEx(RelationProcessorCore, (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)buf, &len)) {
+			char *p = buf;
+			while(p < buf + len) {
+				SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *rec = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)p;
+				for(WORD g = 0; g < rec->Processor.GroupCount; g++) {
+					GROUP_AFFINITY *ga = &rec->Processor.GroupMask[g];
+					if(ga->Group == (WORD)(cpu >> 6) && (ga->Mask & ((KAFFINITY)1 << (cpu & 63)))) { key = k; break; }
+				}
+				if(key >= 0) break;
+				p += rec->Size; k++;
+			}
+		}
+		free(buf);
+		return key;
+	#else
+		(void)cpu; return -1;
+	#endif
+	}
+	
+	/* Fill L2_CACHE_BYTES (per-core L2) and L3_CACHE_BYTES; leave 0 where unknown. */
+	static void detect_cache_sizes(void)
+	{
+	#if INCLUDE_HWLOC
+		hwloc_obj_t o;
+		if((o = hwloc_get_obj_by_type(hw_topology, HWLOC_OBJ_L2CACHE, 0)) && o->attr) L2_CACHE_BYTES = o->attr->cache.size;
+		if((o = hwloc_get_obj_by_type(hw_topology, HWLOC_OBJ_L3CACHE, 0)) && o->attr) L3_CACHE_BYTES = o->attr->cache.size;
+	#elif defined(OS_TYPE_LINUX) && !defined(__MINGW32__)
+		/* /sys/devices/system/cpu/cpu0/cache/indexN/{level,type,size}; size is like "256K" or "16384K" */
+		for(int i = 0; i < 8; i++) {
+			char path[128], type[32] = ""; int level = 0; unsigned long sz = 0; char unit = 0; FILE *f;
+			snprintf(path, sizeof(path), "/sys/devices/system/cpu/cpu0/cache/index%d/level", i);
+			if(!(f = fopen(path, "r"))) break;
+			if(fscanf(f, "%d", &level) != 1) level = 0;
+			fclose(f);
+			snprintf(path, sizeof(path), "/sys/devices/system/cpu/cpu0/cache/index%d/type", i);
+			if((f = fopen(path, "r"))) { if(fscanf(f, "%31s", type) != 1) type[0] = 0; fclose(f); }
+			snprintf(path, sizeof(path), "/sys/devices/system/cpu/cpu0/cache/index%d/size", i);
+			if((f = fopen(path, "r"))) { if(fscanf(f, "%lu%c", &sz, &unit) < 1) sz = 0; fclose(f); }
+			if(unit == 'K') sz <<= 10; else if(unit == 'M') sz <<= 20;
+			if(strcmp(type, "Instruction") == 0) continue;
+			if(level == 2) L2_CACHE_BYTES = sz; else if(level == 3) L3_CACHE_BYTES = sz;
+		}
+	#elif defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
+		DWORD len = 0;
+		GetLogicalProcessorInformationEx(RelationCache, NULL, &len);
+		if(len) {
+			char *buf = malloc(len);
+			if(buf && GetLogicalProcessorInformationEx(RelationCache, (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)buf, &len)) {
+				for(char *p = buf; p < buf + len; ) {
+					SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *rec = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)p;
+					if(rec->Cache.Type != CacheInstruction) {
+						if(rec->Cache.Level == 2 && !L2_CACHE_BYTES) L2_CACHE_BYTES = rec->Cache.CacheSize;
+						if(rec->Cache.Level == 3 && !L3_CACHE_BYTES) L3_CACHE_BYTES = rec->Cache.CacheSize;
+					}
+					p += rec->Size;
+				}
+			}
+			free(buf);
+		}
+	#endif
+	}
+	
+	/* Call once after CORE_SET/NTHREADS are final. `user_chose_smt` = TRUE when the set came from
+	   '-core lo:hi:tpc' with tpc > 1, i.e. sharing cores was requested. */
+	void report_cpu_topology(int user_chose_smt)
+	{
+		uint32 i, word, bit, nsel = 0, nunknown = 0, ncores = 0, maxper = 0;
+		int keys[MAX_CORES]; uint32 cnt[MAX_CORES];
+		detect_cache_sizes();
+		for(i = 0; i < MAX_CORES; i++) {
+			word = i >> 6; bit = i & 63;
+			if(!(CORE_SET[word] & (1ull << bit))) continue;
+			nsel++;
+			int k = cpu_core_key(i), j;
+			if(k < 0) { nunknown++; continue; }
+			for(j = 0; j < (int)ncores; j++) if(keys[j] == k) break;
+			if(j == (int)ncores) { keys[ncores] = k; cnt[ncores] = 0; ncores++; }
+			cnt[j]++; if(cnt[j] > maxper) maxper = cnt[j];
+		}
+		if(nunknown == nsel) {
+			fprintf(stderr, "INFO: %u logical CPUs selected; physical-core topology not available on this platform.\n", nsel);
+		} else {
+			fprintf(stderr, "INFO: %u logical CPUs selected on %u physical core%s (up to %u thread%s per core).\n",
+				nsel, ncores, ncores == 1 ? "" : "s", maxper, maxper == 1 ? "" : "s");
+			if(maxper > 1 && !user_chose_smt) {
+				fprintf(stderr, "WARN: some selected logical CPUs are SMT siblings on the same physical core. Logical-CPU numbering\n"
+				                "      differs by OS and vendor (Windows, FreeBSD and most AMD systems number siblings adjacently, Intel/Linux\n"
+				                "      typically as i and i+ncores), so '-cpu 0:3' is not always 4 cores. To run one thread per core use\n"
+				                "      '-core lo:hi:1' (hwloc builds) or list one logical CPU per core explicitly, e.g. '-cpu 0:6:2'.\n");
+			}
+		}
+		if(L2_CACHE_BYTES || L3_CACHE_BYTES)
+			fprintf(stderr, "INFO: cache: L2 = %llu KB per core, L3 = %llu KB.\n",
+				(unsigned long long)(L2_CACHE_BYTES >> 10), (unsigned long long)(L3_CACHE_BYTES >> 10));
+	}
+	
+
 #endif	// MULTITHREAD ?
 
 /***********************/

--- a/src/util.c
+++ b/src/util.c
@@ -9416,10 +9416,12 @@ exit(0);
 			fprintf(stderr, "INFO: %u logical CPUs selected on %u physical core%s (up to %u thread%s per core).\n",
 				nsel, ncores, ncores == 1 ? "" : "s", maxper, maxper == 1 ? "" : "s");
 			if(maxper > 1 && !user_chose_smt) {
-				fprintf(stderr, "WARN: some selected logical CPUs are SMT siblings on the same physical core. Logical-CPU numbering\n"
-				                "      differs by OS and vendor (Windows, FreeBSD and most AMD systems number siblings adjacently, Intel/Linux\n"
-				                "      typically as i and i+ncores), so '-cpu 0:3' is not always 4 cores. To run one thread per core use\n"
-				                "      '-core lo:hi:1' (hwloc builds) or list one logical CPU per core explicitly, e.g. '-cpu 0:6:2'.\n");
+				fprintf(stderr, "WARN: some selected logical CPUs are SMT siblings on the same physical core. Which logical\n"
+				                "      CPUs share a core is decided by firmware and varies from system to system; it is not a\n"
+				                "      property of the CPU vendor. Siblings may be numbered adjacently (0,1) on one machine and\n"
+				                "      as i, i+ncores (0,8) on another, so '-cpu 0:3' is not always 4 distinct cores. To run one\n"
+				                "      thread per core use '-core lo:hi:1' (hwloc builds) or list one logical CPU per core\n"
+				                "      explicitly, e.g. '-cpu 0:6:2'.\n");
 			}
 		}
 		if(L2_CACHE_BYTES || L3_CACHE_BYTES)

--- a/src/util.h
+++ b/src/util.h
@@ -215,6 +215,7 @@ double	mlucas_getOptVal(const char*fname, char*optname);
   #endif
 	uint32	parseAffinityTriplet(char*istr, int hwloc_topo);
 	void	parseAffinityString(char*istr);
+	void	report_cpu_topology(int user_chose_smt);
 
 #endif	// MULTITHREAD ?
 


### PR DESCRIPTION
## Why

`-cpu` indices are the operating system's logical-processor numbers, and which of them are SMT
siblings of one physical core differs by OS and vendor. Linux on Intel usually numbers siblings
as i and i+ncores, so `-cpu 0:3` is four physical cores; Windows, FreeBSD and most AMD systems
number siblings adjacently, so the same `-cpu 0:3` is two physical cores with both hyperthreads
each. Mlucas passes the numbers straight through on every backend (`sched_setaffinity`,
`cpuset_setaffinity`, `SetThreadGroupAffinity`, macOS affinity tags), so a user, or a scaling
report, cannot tell from the command line what was actually run. Only the hwloc `-core lo:hi:tpc`
form is topology-aware, and hwloc is off by default in makemake.sh.

## What it does

After command-line parsing, when `-cpu`, `-nthread` or `-core` was given, print:

    INFO: 4 logical CPUs selected on 4 physical cores (up to 1 thread per core).
    INFO: cache: L2 = 256 KB per core, L3 = 16384 KB.

and, when selected CPUs share a core and the set did not come from `-core` (where sharing is an
explicit choice):

    WARN: some selected logical CPUs are SMT siblings on the same physical core. ...

Sources: hwloc when built in (consistent with the PU indexing threadpool.c binds to), Linux sysfs
(`topology/core_id`, `physical_package_id`, `cache/indexN`), Windows
`GetLogicalProcessorInformationEx` (RelationProcessorCore / RelationCache). Anything else says
the topology is not available and never fails. The detected sizes are kept in two new globals,
`L2_CACHE_BYTES` and `L3_CACHE_BYTES` (0 = unknown), for later use by radix selection.

help.txt gains a note on logical-CPU numbering under the `-cpu` description.

## Verification

AVX2 build on Linux (i9-10885H, siblings are i and i+8):

| command | output |
| --- | --- |
| `-cpu 0:3` | 4 logical CPUs on 4 physical cores, 1 thread per core; no warning; L2 = 256 KB, L3 = 16384 KB |
| `-cpu 0,8` | 2 logical CPUs on 1 physical core, 2 threads per core; warning printed |
| `-cpu 0` | 1 logical CPU on 1 physical core |
| `-nthread 2` | reports as for `-cpu 0:1` |
| no flag | nothing printed (single thread on CPU 0, nothing to report) |

The Windows branch was cross-compiled with x86_64-w64-mingw32-gcc; it has not been run on
Windows. FreeBSD and macOS report "topology not available".

## Relation to other work

Independent of #176 (default core set from an external affinity mask), which changes what goes
into the set; this reports on whatever ends up in it. Follows #277 (thread count in cfg entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
