### PR TITLE
Add opt-in per-phase timing and print the core clock on the self-test Clocks line

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -2402,7 +2402,13 @@ READ_RESTART_FILE:
 				*sh2 = Res36m1;
 		}
 		/*...print runtime in hh:mm:ss format.	*/
-		fprintf(stderr, "Clocks =%s\n",get_time_str(tdiff) );
+		{
+			double mhz = cpuset_mean_mhz();	// sampled once, now, at the end of the run
+			if(mhz > 0)
+				fprintf(stderr, "Clocks =%s  [core clock at end of run: %.0f MHz]\n",get_time_str(tdiff), mhz);
+			else
+				fprintf(stderr, "Clocks =%s\n",get_time_str(tdiff) );
+		}
 		/*exit(EXIT_SUCCESS);*/
  		return(resFlag);
 	}	/* endif(INTERACT) */

--- a/src/fermat_mod_square.c
+++ b/src/fermat_mod_square.c
@@ -1346,8 +1346,18 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 	fprintf(stderr,"%s: NTHREADS = %3d\n",func,NTHREADS);
   #endif
 
+#ifdef PHASE_TIMING
+	// Wall time of the two phases of an iteration, accumulated over this ilo..ihi block: the FFT phase
+	// (passes 2..S, dyadic square, inverse passes, i.e. the threadpool dispatch + drain) and the carry
+	// phase (radix0 DIT + carry + radix0 DIF, the radixN_ditN_cy_dif1 call). Whatever is left of the
+	// per-iteration time is bookkeeping. Developer instrumentation: build with -DPHASE_TIMING.
+	double pt_fft = 0.0, pt_cy = 0.0, pt0 = 0.0;
+#endif
 for(iter=ilo+1; iter <= ihi && MLUCAS_KEEP_RUNNING; iter++)
 {
+#ifdef PHASE_TIMING
+	pt0 = getRealTime();
+#endif
 
 /*...perform the FFT-based squaring:
 	Do last S-1 of S forward decimation-in-frequency transform passes.	*/
@@ -1413,6 +1423,9 @@ for(iter=ilo+1; iter <= ihi && MLUCAS_KEEP_RUNNING; iter++)
 	}
 /*...Do the final inverse FFT pass, carry propagation and initial forward FFT pass in one fell swoop, er, swell loop...	*/
 
+#ifdef PHASE_TIMING
+	pt_fft += getRealTime() - pt0;	pt0 = getRealTime();
+#endif
 	fracmax = 0.0;
 //printf("Exit(0) from %s\n",func); exit(0);
 	switch(radix0)
@@ -1495,6 +1508,9 @@ for(iter=ilo+1; iter <= ihi && MLUCAS_KEEP_RUNNING; iter++)
 			sprintf(cbuf,"ERROR: radix %d not available for ditN_cy_dif1. Halting...\n",radix0); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf);
 	}
 
+#ifdef PHASE_TIMING
+	pt_cy += getRealTime() - pt0;
+#endif
 	// v19: Nonzero exit carries used to be fatal, added retry-from-last-savefile handling for these
 	if(ierr)
 		return(ierr);
@@ -1598,6 +1614,11 @@ if(iter < ihi) {
 //	*tdiff += difftime(clock2 , clock1);
 	clock2 = getRealTime();
 	*tdiff += clock2 - clock1;
+#ifdef PHASE_TIMING
+	if(ihi > ilo)
+		fprintf(stderr,"%s: PHASE_TIMING iters %u-%u: fft-phase %.4f ms/iter, carry-phase %.4f ms/iter, total %.4f ms/iter\n",
+			func, ilo+1, ihi, 1000*pt_fft/(ihi-ilo), 1000*pt_cy/(ihi-ilo), 1000*(clock2-clock1)/(ihi-ilo));
+#endif
 #endif
 
 #if DBG_THREADS

--- a/src/mers_mod_square.c
+++ b/src/mers_mod_square.c
@@ -1778,8 +1778,18 @@ for(i=0; i < NRT; i++) {
 	fprintf(stderr,"%s: NTHREADS = %3d\n",func,NTHREADS);
   #endif
 
+#ifdef PHASE_TIMING
+	// Wall time of the two phases of an iteration, accumulated over this ilo..ihi block: the FFT phase
+	// (passes 2..S, dyadic square, inverse passes, i.e. the threadpool dispatch + drain) and the carry
+	// phase (radix0 DIT + carry + radix0 DIF, the radixN_ditN_cy_dif1 call). Whatever is left of the
+	// per-iteration time is bookkeeping. Developer instrumentation: build with -DPHASE_TIMING.
+	double pt_fft = 0.0, pt_cy = 0.0, pt0 = 0.0;
+#endif
 for(iter=ilo+1; iter <= ihi && MLUCAS_KEEP_RUNNING; iter++)
 {
+#ifdef PHASE_TIMING
+	pt0 = getRealTime();
+#endif
 /*...perform the FFT-based squaring:
 	 Do last S-1 of S forward decimation-in-frequency transform passes.	*/
 
@@ -1829,6 +1839,9 @@ for(iter=ilo+1; iter <= ihi && MLUCAS_KEEP_RUNNING; iter++)
 
 /*...Do the final inverse FFT pass, carry propagation and initial forward FFT pass in one fell swoop, er, swell loop...	*/
 
+#ifdef PHASE_TIMING
+	pt_fft += getRealTime() - pt0;	pt0 = getRealTime();
+#endif
 	fracmax = 0.0;
 
 	switch(radix0)
@@ -1939,6 +1952,9 @@ for(iter=ilo+1; iter <= ihi && MLUCAS_KEEP_RUNNING; iter++)
 			sprintf(cbuf,"ERROR: radix %d not available for ditN_cy_dif1. Halting...\n",radix0); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf);
 	}
 
+#ifdef PHASE_TIMING
+	pt_cy += getRealTime() - pt0;
+#endif
 	// v19: Nonzero exit carries used to be fatal, added retry-from-last-savefile handling for these
 	if(ierr)
 		return(ierr);
@@ -2046,6 +2062,11 @@ if(iter < ihi) {
 //	*tdiff += difftime(clock2 , clock1);
 	clock2 = getRealTime();
 	*tdiff += clock2 - clock1;
+#ifdef PHASE_TIMING
+	if(ihi > ilo)
+		fprintf(stderr,"%s: PHASE_TIMING iters %u-%u: fft-phase %.4f ms/iter, carry-phase %.4f ms/iter, total %.4f ms/iter\n",
+			func, ilo+1, ihi, 1000*pt_fft/(ihi-ilo), 1000*pt_cy/(ihi-ilo), 1000*(clock2-clock1)/(ihi-ilo));
+#endif
 #endif
 
 #if DBG_THREADS

--- a/src/util.c
+++ b/src/util.c
@@ -9317,6 +9317,33 @@ double get_time(double tdiff)
 #endif
 }
 
+/* Mean current core clock, in MHz, of the logical CPUs the run is pinned to (CORE_SET), read from
+Linux sysfs. A single sample: call it at the end of a timing run, when the clocks have settled under
+load. Turbo and power limits make the 1-thread and N-thread clocks differ on most CPUs, so a timing
+comparison across thread counts is not interpretable without this. Returns 0 where unavailable. */
+double cpuset_mean_mhz(void)
+{
+#if defined(OS_TYPE_LINUX) && !defined(__MINGW32__)
+	double sum = 0; uint32 n = 0, i, ncpu = 1;
+	char path[96]; FILE *f; unsigned long khz;
+  #ifdef MULTITHREAD
+	ncpu = MAX_CORES;
+  #endif
+	for(i = 0; i < ncpu; i++) {
+	  #ifdef MULTITHREAD
+		if(!(CORE_SET[i>>6] & (1ull << (i&63)))) continue;
+	  #endif
+		snprintf(path, sizeof(path), "/sys/devices/system/cpu/cpu%u/cpufreq/scaling_cur_freq", i);
+		if(!(f = fopen(path, "r"))) continue;
+		if(fscanf(f, "%lu", &khz) == 1) { sum += khz/1000.0; n++; }
+		fclose(f);
+	}
+	return n ? sum/n : 0.0;
+#else
+	return 0.0;
+#endif
+}
+
 char*get_time_str(double tdiff)
 {
 	static char cbuf[STR_MAX_LEN*2];

--- a/src/util.h
+++ b/src/util.h
@@ -168,6 +168,7 @@ int		mlucas_nanosleep(const struct timespec *req);
 void	host_init(void);	/* This one is a wrapper for calls to the next few: */
 double	get_time    (double tdiff);
 char*	get_time_str(double tdiff);
+double	cpuset_mean_mhz(void);	// Linux: mean current clock (MHz) of the CPUs in CORE_SET (or CPU 0 if unthreaded); 0 if unavailable
 void	set_stacklimit_restart(char *argv[]);
 uint32	get_system_ram(void);
 void	print_host_info(void);


### PR DESCRIPTION
## Summary

Two small pieces of instrumentation I need for the multithread-scaling investigation:

1. **`-DPHASE_TIMING`** (off by default). `mers_mod_square` and `fermat_mod_square` accumulate the
   wall time of the two phases of every iteration - the FFT phase (passes 2..S, dyadic square,
   inverse passes: the threadpool dispatch and drain) and the carry phase (radix0 DIT + carry +
   radix0 DIF: the `radixN_ditN_cy_dif1` call) - and print both as ms/iter next to the total at the
   end of each `ilo..ihi` block:

       mers_mod_square: PHASE_TIMING iters 1-100: fft-phase 4.4082 ms/iter, carry-phase 3.3231 ms/iter, total 7.8209 ms/iter

   The phase whose share grows with the thread count is the one that does not scale, which is the
   question to answer before choosing a remedy. A normal build is unchanged.

2. **Core clock on the `Clocks =` line.** The self-test's per-run `Clocks =` line now appends the
   mean current clock of the CPUs the run is pinned to, read once from Linux sysfs at the end of
   the run:

       Clocks = 00:00:00.782  [core clock at end of run: 4367 MHz]

   Turbo and power limits make the 1-thread and N-thread clocks differ on most CPUs, so 1-vs-N
   timings are not interpretable without it. On other platforms the line is unchanged.

## Verification

AVX2 builds with and without `-DPHASE_TIMING`, 1024K, 2 threads, all radix sets: identical Res64
(`95AFD7A5269F14F6`) from both binaries; the per-phase line appears only in the `PHASE_TIMING`
build; the Clocks line carries the MHz figure in both. (The MHz values in that run ranged 2400 to
4367 because the box was under other load; that variability is the reason the figure is worth
printing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
