### PR TITLE
Add opt-in sub-block ordering of FFT passes 2..S-1 (-DSUBBLOCK_ORDER)

### DIFF
--- a/src/fermat_mod_square.c
+++ b/src/fermat_mod_square.c
@@ -1179,6 +1179,14 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 		if(tpool) { threadpool_free(tpool); tpool = 0x0; }
 		ASSERT(0x0 != (tpool = threadpool_init(NTHREADS, MAX_THREADS, pool_work_units, &thread_control)), "threadpool_init failed!");
 		printf("%s: Init threadpool of %d threads\n",func,NTHREADS);
+	  #ifdef SUBBLOCK_ORDER
+		{
+			int incr2 = (n/radix0)/RADIX_VEC[1];
+			printf("%s: SUBBLOCK_ORDER %s for this radix set: sub-block = %d doubles = %d KB, block = %d KB\n", func,
+				((NRADICES >= 4) && ((incr2 & ((1 << DAT_BITS) - 1)) == 0)) ? "active" : "inactive (whole-block order)",
+				incr2, incr2>>7, (n/radix0)>>7);
+		}
+	  #endif
 
 	#endif	// MULTITHREAD?
 	}
@@ -1789,6 +1797,15 @@ void fermat_process_chunk(
 	int radix0 = RADIX_VEC[0];
 	int i,incr,istart,jstart,k,koffset,l,mm;
 	int init_sse2 = FALSE;	// Init-calls to various radix-pass routines presumed done prior to entry into this routine
+#ifdef SUBBLOCK_ORDER
+	/* Sub-block ordering of the FFT phase, as in mers_process_chunk(): after pass 1 (radix R1 = RADIX_VEC[1])
+	the block is R1 independent sub-FFTs of incr2 = (n/radix0)/R1 doubles; run passes 2..S-1 to completion on
+	one sub-block before the next so their working set is block/R1. Bit-identical results. Needs the sub-block
+	start to be a multiple of 2^DAT_BITS for the pass routines' block-relative padding; otherwise whole-block. */
+	const int nsub = RADIX_VEC[1], incr2 = (n/radix0)/nsub;
+	const int subblock = (NRADICES >= 4) && ((incr2 & ((1 << DAT_BITS) - 1)) == 0);
+	int sb, kk, mmk, inck, ii2, sbstart, sbpad;
+#endif
 	uint64 bptr = 0x0;	// Pointer to B-array, if one is supplied in guise of the uint64 fwd_fft arg
 	double*cptr = 0x0;
 
@@ -1815,6 +1832,28 @@ void fermat_process_chunk(
   }	else {
 	for(i=1; i <= NRADICES-2; i++)
 	{
+	  #ifdef SUBBLOCK_ORDER
+		if(i == 2 && subblock) {	/* (k,mm,incr) is the pass-2 state: mm = R1 groups of incr = incr2 doubles */
+			for(sb = 0; sb < nsub; sb++) {
+				kk = k;	mmk = mm;	inck = incr;
+				sbstart = istart + sb*incr2;
+				sbpad = sbstart + ((sbstart >> DAT_BITS) << PAD_BITS);
+				for(ii2 = 2; ii2 <= NRADICES-2; ii2++) {
+					koffset = l*mmk + sb*(mmk/nsub);
+					switch(RADIX_VEC[ii2]) {
+					case  8:  radix8_dif_pass(&a[sbpad],n,rt0,rt1,&index[kk+koffset],mmk/nsub,inck,init_sse2,thr_id); break;
+					case 16: radix16_dif_pass(&a[sbpad],n,rt0,rt1,&index[kk+koffset],mmk/nsub,inck,init_sse2,thr_id); break;
+					case 32: radix32_dif_pass(&a[sbpad],n,rt0,rt1,&index[kk+koffset],mmk/nsub,inck,init_sse2,thr_id); break;
+					default: sprintf(cbuf,"ERROR: radix %d not available for dif_pass. Halting...\n",RADIX_VEC[ii2]); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf);
+					}
+					kk += mmk*radix0;	mmk *= RADIX_VEC[ii2];	inck /= RADIX_VEC[ii2];
+				}
+			}
+			/* Leave (k,mm,incr) at their post-loop values: fermat_process_chunk passes incr on to the dyadic-square routine. */
+			for(ii2 = 2; ii2 <= NRADICES-2; ii2++) { k += mm*radix0;	mm *= RADIX_VEC[ii2];	incr /= RADIX_VEC[ii2]; }
+			break;	/* passes 2..S-1 are done */
+		}
+	  #endif
 		/* Offset from base address of index array = L*NLOOPS = L*MM: */
 		koffset = l*mm;
 		switch(RADIX_VEC[i])
@@ -1887,6 +1926,28 @@ void fermat_process_chunk(
 		incr *= RADIX_VEC[i];
 		mm   /= RADIX_VEC[i];
 		k    -= mm*radix0;
+	  #ifdef SUBBLOCK_ORDER
+		if(i == NRADICES-2 && subblock) {	/* (k,mm,incr) is the pass-(S-1) state */
+			for(sb = 0; sb < nsub; sb++) {
+				kk = k;	mmk = mm;	inck = incr;
+				sbstart = istart + sb*incr2;
+				sbpad = sbstart + ((sbstart >> DAT_BITS) << PAD_BITS);
+				for(ii2 = NRADICES-2; ii2 >= 2; ii2--) {
+					koffset = l*mmk + sb*(mmk/nsub);
+					switch(RADIX_VEC[ii2]) {
+					case  8:  radix8_dit_pass(&a[sbpad],n,rt0,rt1,&index[kk+koffset],mmk/nsub,inck,init_sse2,thr_id); break;
+					case 16: radix16_dit_pass(&a[sbpad],n,rt0,rt1,&index[kk+koffset],mmk/nsub,inck,init_sse2,thr_id); break;
+					case 32: radix32_dit_pass(&a[sbpad],n,rt0,rt1,&index[kk+koffset],mmk/nsub,inck,init_sse2,thr_id); break;
+					default: sprintf(cbuf,"ERROR: radix %d not available for dit_pass. Halting...\n",RADIX_VEC[ii2]); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf);
+					}
+					if(ii2 > 2) { inck *= RADIX_VEC[ii2-1];	mmk /= RADIX_VEC[ii2-1];	kk -= mmk*radix0; }
+				}
+			}
+			/* Move the block-level state from pass S-1 to pass 1 and let the code below run pass 1 on the whole block: */
+			for(ii2 = NRADICES-2; ii2 >= 2; ii2--) { incr *= RADIX_VEC[ii2-1];	mm /= RADIX_VEC[ii2-1];	k -= mm*radix0; }
+			i = 1;
+		}
+	  #endif
 		koffset = l*mm;
 		switch(RADIX_VEC[i])
 		{

--- a/src/mers_mod_square.c
+++ b/src/mers_mod_square.c
@@ -2259,6 +2259,8 @@ void mers_process_chunk(
 						kk += mmk*radix0;	mmk *= RADIX_VEC[ii2];	inck /= RADIX_VEC[ii2];
 					}
 				}
+				/* Leave (k,mm,incr) at their post-loop values, as the whole-block loop would have: */
+				for(ii2 = 2; ii2 <= NRADICES-2; ii2++) { k += mm*radix0;	mm *= RADIX_VEC[ii2];	incr /= RADIX_VEC[ii2]; }
 				break;	/* passes 2..S-1 are done for this block */
 			}
 		  #endif

--- a/src/mers_mod_square.c
+++ b/src/mers_mod_square.c
@@ -1370,6 +1370,14 @@ for(i=0; i < NRT; i++) {
 		if(tpool) { threadpool_free(tpool); tpool = 0x0; }
 		ASSERT(0x0 != (tpool = threadpool_init(NTHREADS, MAX_THREADS, pool_work_units, &thread_control)), "threadpool_init failed!");
 		printf("%s: Init threadpool of %d threads\n",func,NTHREADS);
+	  #ifdef SUBBLOCK_ORDER
+		{
+			int incr2 = (n/radix0)/RADIX_VEC[1];
+			printf("%s: SUBBLOCK_ORDER %s for this radix set: sub-block = %d doubles = %d KB, block = %d KB\n", func,
+				((NRADICES >= 4) && ((incr2 & ((1 << DAT_BITS) - 1)) == 0)) ? "active" : "inactive (whole-block order)",
+				incr2, incr2>>7, (n/radix0)>>7);
+		}
+	  #endif
 
 	#endif	// MULTITHREAD?
 	}
@@ -2189,6 +2197,19 @@ void mers_process_chunk(
 	int radix0 = RADIX_VEC[0];
 	int i,incr,istart,j,jhi,jstart,k,koffset,l,mm;
 	int init_sse2 = FALSE;	// Init-calls to various radix-pass routines presumed done prior to entry into this routine
+#ifdef SUBBLOCK_ORDER
+	/* Sub-block ordering of the FFT phase. After pass 1 (radix R1 = RADIX_VEC[1]) a block of n/radix0 doubles
+	is R1 independent sub-FFTs of incr2 = (n/radix0)/R1 doubles each. Instead of sweeping the whole block once
+	per pass, run passes 2..S-1 to completion on one sub-block before touching the next, so the working set of
+	those passes is block/R1 rather than block; the wrapper_square still sees the whole block pair. Results are
+	bit-identical to the whole-block order: every butterfly sees the same inputs in the same order, only the
+	sequence of independent groups changes. The pass routines compute array padding from the block-relative
+	index, so the sub-block start must be a multiple of 2^DAT_BITS; when it is not (sub-blocks under 8 KB,
+	which fit L2 anyway) keep the whole-block order. */
+	const int nsub = RADIX_VEC[1], incr2 = (n/radix0)/nsub;
+	const int subblock = (NRADICES >= 4) && ((incr2 & ((1 << DAT_BITS) - 1)) == 0);
+	int sb, kk, mmk, inck, ii2, sbstart, sbpad;
+#endif
 	/*** Unlike fermat_mod_square, no need for separate cptr = c + [offset] here, since c-array offsets computed inside radix*_wrapper_square routines ***/
 
 	/* If radix0 odd and i = 0, process just one block of data, otherwise do two: */
@@ -2221,6 +2242,26 @@ void mers_process_chunk(
 
 		for(i=1; i <= NRADICES-2; i++)
 		{
+		  #ifdef SUBBLOCK_ORDER
+			if(i == 2 && subblock) {	/* (k,mm,incr) is the pass-2 state: mm = R1 groups of incr = incr2 doubles */
+				for(sb = 0; sb < nsub; sb++) {
+					kk = k;	mmk = mm;	inck = incr;
+					sbstart = istart + sb*incr2;
+					sbpad = sbstart + ((sbstart >> DAT_BITS) << PAD_BITS);
+					for(ii2 = 2; ii2 <= NRADICES-2; ii2++) {
+						koffset = l*mmk + sb*(mmk/nsub);	/* this sub-block's slice of block l's mmk twiddle groups */
+						switch(RADIX_VEC[ii2]) {
+						case  8 :  radix8_dif_pass(&a[sbpad],n,rt0,rt1,&index[kk+koffset],mmk/nsub,inck,init_sse2,thr_id); break;
+						case 16 : radix16_dif_pass(&a[sbpad],n,rt0,rt1,&index[kk+koffset],mmk/nsub,inck,init_sse2,thr_id); break;
+						case 32 : radix32_dif_pass(&a[sbpad],n,rt0,rt1,&index[kk+koffset],mmk/nsub,inck,init_sse2,thr_id); break;
+						default : sprintf(cbuf,"ERROR: radix %d not available for dif_pass. Halting...\n",RADIX_VEC[ii2]); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf);
+						}
+						kk += mmk*radix0;	mmk *= RADIX_VEC[ii2];	inck /= RADIX_VEC[ii2];
+					}
+				}
+				break;	/* passes 2..S-1 are done for this block */
+			}
+		  #endif
 			/* Offset from base address of index array = L*NLOOPS = L*MM : */
 			koffset = l*mm;
 
@@ -2324,6 +2365,28 @@ void mers_process_chunk(
 			mm   /= RADIX_VEC[i];
 			k    -= mm*radix0;
 
+		  #ifdef SUBBLOCK_ORDER
+			if(i == NRADICES-2 && subblock) {	/* (k,mm,incr) is the pass-(S-1) state */
+				for(sb = 0; sb < nsub; sb++) {
+					kk = k;	mmk = mm;	inck = incr;
+					sbstart = istart + sb*incr2;
+					sbpad = sbstart + ((sbstart >> DAT_BITS) << PAD_BITS);
+					for(ii2 = NRADICES-2; ii2 >= 2; ii2--) {
+						koffset = l*mmk + sb*(mmk/nsub);
+						switch(RADIX_VEC[ii2]) {
+						case  8 :  radix8_dit_pass(&a[sbpad],n,rt0,rt1,&index[kk+koffset],mmk/nsub,inck,init_sse2,thr_id); break;
+						case 16 : radix16_dit_pass(&a[sbpad],n,rt0,rt1,&index[kk+koffset],mmk/nsub,inck,init_sse2,thr_id); break;
+						case 32 : radix32_dit_pass(&a[sbpad],n,rt0,rt1,&index[kk+koffset],mmk/nsub,inck,init_sse2,thr_id); break;
+						default : sprintf(cbuf,"ERROR: radix %d not available for dit_pass. Halting...\n",RADIX_VEC[ii2]); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf);
+						}
+						if(ii2 > 2) { inck *= RADIX_VEC[ii2-1];	mmk /= RADIX_VEC[ii2-1];	kk -= mmk*radix0; }
+					}
+				}
+				/* Move the block-level state from pass S-1 to pass 1 and let the code below run pass 1 on the whole block: */
+				for(ii2 = NRADICES-2; ii2 >= 2; ii2--) { incr *= RADIX_VEC[ii2-1];	mm /= RADIX_VEC[ii2-1];	k -= mm*radix0; }
+				i = 1;
+			}
+		  #endif
 			koffset = l*mm;
 
 			switch(RADIX_VEC[i])


### PR DESCRIPTION
## Why

Each FFT-phase task sweeps its block pair of `2n/radix0` doubles about `2*(NRADICES-2)+1` times
per iteration: once per forward pass, the wrapper_square, once per inverse pass, all with strided
radix-8/16/32 butterflies. That working set is fixed by the radix set, not by the cache, and
multithreading multiplies it: T threads sweep T block pairs against one shared L3. On this box
at 16384K and 16 threads, the leading radix alone (which sets the block size) spans 41.6 to 119.4
ms/iter across the radix sets the self-test tries, in the order of the block size.

## What it does

After pass 1 (radix `R1 = RADIX_VEC[1]`) a block is `R1` independent sub-FFTs of `block/R1`
doubles. With `-DSUBBLOCK_ORDER`, `mers_process_chunk` and `fermat_process_chunk` run passes 2..S-1 to completion on one
sub-block before touching the next, forward and inverse; pass 1 and the wrapper_square are
unchanged. So for a radix set like `32 16 16 16 16` at 4096K, four of the seven sweeps per block
drop from a 1 MB working set to 64 KB.

No kernel changes. The pass routines already take a base pointer, a twiddle-group slice and a
group count (`&a[jstart]`, `&index[k + l*mm]`, `mm`), because that is how the existing
multithread decomposition slices at block granularity. A sub-block is the same slice one level
down: `&a[pad(istart + sb*incr2)]`, `&index[k + l*mm + sb*mm/R1]`, `mm/R1`.

The pass routines compute array padding from the block-relative index, so a sub-block start must
be a multiple of `2^DAT_BITS` (1024 doubles). When it is not, i.e. sub-blocks under 8 KB, which
fit L2 anyway, the whole-block order is kept. A line at threadpool init reports which applies for
the radix set in use.

## Correctness

Results must be bit-identical to the whole-block order: every butterfly sees the same inputs in
the same floating-point order, only the sequence of independent groups changes. Checked against
an unmodified main binary (AVX2, same command lines), comparing Res64:

| case | sub-blocking | result |
| --- | --- | --- |
| 4096K radsets 4, 7, 9 (sub-blocks 2K, 2K, 8K doubles), 4 threads | active | identical |
| 4096K radset 9, 1 thread | active | identical |
| 4096K radset 0 (`1024 8 16 16`, 512-double sub-blocks) | inactive, fallback | identical |
| 2048K radset 2 (`128 16 16 32`, exactly 1024-double sub-blocks) | active | identical |
| 4608K, all 7 radix sets (odd leading radix 144 among them), 2 threads | active | identical |
| `-s tt` (13K-15K, all radix sets), 2 threads | inactive | identical |
| Fermat F22 at 256K, all 7 radix sets (2 active), 2 threads | mixed | identical |
| Fermat F24 at 1024K, all 12 radix sets (7 active), 4 threads | mixed | identical |
| Fermat F25 at 2048K, all 10 radix sets (7 active), 2 threads | mixed | identical |

The Fermat path exposed one thing the Mersenne path did not: `fermat_process_chunk` passes the
post-loop `incr` on to the dyadic-square routine (which asserts `incr == 2*R_last`), so the early
break out of the pass loop must leave `k/mm/incr` at their post-loop values. Fixed in both files;
the first attempt aborted on exactly that assertion, which is why the Fermat cases are in the table.

## Timing (i9-10885H, 8c/16t, AVX2, DDR4-2933; pinned `-m 76821337 -fft 4096 -iters 1000`, box idle)

Reference vs `-DSUBBLOCK_ORDER`, ms/iter:

| radset (chunk = 16n/radix0) | 4 cores | 8 cores | 16 threads |
| --- | --- | --- | --- |
| 1: `256 16 16 32` (256 KB) | 7.68 / 7.49 | 6.81 / 6.78 | 8.52 / 7.80 |
| 4: `128 16 32 32` (512 KB) | 8.04 / 8.10 | 6.90 / 6.95 | 8.37 / 8.49 |
| 7: `64 32 32 32` (1 MB) | 8.50 / 8.50 | 8.25 / 8.70 | 10.52 / 10.35 |
| 9: `32 16 16 16 16` (2 MB) | 8.83 / 8.77 | 9.75 / **8.83** | 15.69 / **13.33** |
| 10: `16 16 16 16 32` (4 MB) | 10.01 / 9.97 | 14.45 / **12.65** | 14.50 / **12.69** |
| 16384K, 4: `128 16 16 16 16` (2 MB) | - | 62.5 / **57.2** | 85.8 / **67.1** |

Run-to-run noise is ~3% at 4 cores and ~5-8% at 8-16 threads. Within that, the change is neutral
wherever the chunk already fits L2 (the 256 KB-1 MB rows) and at 4 cores, where this machine is at
its DRAM bandwidth ceiling (~17.5 GB/s from any number of cores) whatever the cache behaviour. It
gains 9-22% for the 2-4 MB-chunk sets at 8 cores and 16 threads, most at 16384K with 16 threads.

It does not make a large-chunk set beat the best small-chunk set (radset 9 at 8 cores improves to
8.83, radset 1 sits at 6.8), so on that box it is insurance against a poor radix choice at high
thread counts rather than a speedup of the best configuration.

**Second machine, and a negative result.** I expected a larger gain on a part with more L2. On a
Ryzen 7 7800X3D (8 cores, 1 MB L2 per core, 96 MB L3, DDR5), it does nothing at all. Medians of
five runs at 4096K on 4 cores, AVX-512:

| radices | reference | SUBBLOCK_ORDER | ratio |
| --- | --- | --- | --- |
| 64 32 32 32 | 3.626 | 3.600 | 0.99 |
| 32 16 16 16 16 | 4.069 | 4.132 | 1.02 |

A single-run sweep over all radix sets there, in both instruction sets and at 4096K, 8192K and
16384K, scatters symmetrically about 1.0 with no trend. (Three apparently large single-run wins,
including one of 19%, did not survive repetition; that box had a competing process and needs
repeated measures for anything under about 10%.)

That is consistent with the mechanism rather than against it: blocking the FFT phase into L2 pays
only when something is contending for the level above it, and on a 96 MB L3 the whole array fits.
So the honest summary is that this helps a bandwidth-starved machine that is also using a
large-chunk radix set, and does nothing otherwise. It stays opt-in and I am leaving it in draft;
the cheaper fix for that case is choosing a better radix set.

## Not in this PR

- Making the ordering default, or having the self-test choose it. First the numbers from a
  second machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
