### PR TITLE
Let the carry step use any thread count, not just a power of two

### DIFF
--- a/src/dft_macro.c
+++ b/src/dft_macro.c
@@ -3403,7 +3403,10 @@ in the same order here as DIF, but the in-and-output-index offsets are BRed: j1 
 		#ifndef COMPILER_TYPE_GCC
 			ASSERT(NTHREADS == 1, "Multithreading currently only supported for GCC builds!");
 		#endif
-			if(sc_arr) { free((void *)sc_arr); }
+			// Must NULL the pointer as well as freeing it: ALLOC_VEC_DBL is a realloc, so leaving the
+			// freed value in place made the next line realloc an already-freed block (a double free).
+			// Only reachable when a later init-mode call asks for more threads than an earlier one.
+			if(sc_arr) { free((void *)sc_arr); sc_arr = 0x0; }
 			// 126 slots for DFT-63 data, 22 for DFT-7,9 consts and DFT-7 pads, 4 to allow for alignment = 152:
 			sc_arr = ALLOC_VEC_DBL(sc_arr, 152*max_threads);	if(!sc_arr){ sprintf(cbuf, "ERROR: unable to allocate sc_arr!.\n"); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf); }
 			sc_ptr = ALIGN_VEC_DBL(sc_arr);
@@ -3654,7 +3657,10 @@ in the same order here as DIF, but the in-and-output-index offsets are BRed: j1 
 		#ifndef COMPILER_TYPE_GCC
 			ASSERT(NTHREADS == 1, "Multithreading currently only supported for GCC builds!");
 		#endif
-			if(sc_arr) { free((void *)sc_arr); }
+			// Must NULL the pointer as well as freeing it: ALLOC_VEC_DBL is a realloc, so leaving the
+			// freed value in place made the next line realloc an already-freed block (a double free).
+			// Only reachable when a later init-mode call asks for more threads than an earlier one.
+			if(sc_arr) { free((void *)sc_arr); sc_arr = 0x0; }
 			// 126 slots for DFT-63 data, 22 for DFT-7,9 consts and DFT-7 pads, 4 to allow for alignment = 152:
 			sc_arr = ALLOC_VEC_DBL(sc_arr, 152*max_threads);	if(!sc_arr){ sprintf(cbuf, "ERROR: unable to allocate sc_arr!.\n"); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf); }
 			sc_ptr = ALIGN_VEC_DBL(sc_arr);
@@ -3886,7 +3892,10 @@ in the same order here as DIF, but the in-and-output-index offsets are BRed: j1 
 		#ifndef COMPILER_TYPE_GCC
 			ASSERT(NTHREADS == 1, "Multithreading currently only supported for GCC builds!");
 		#endif
-			if(sc_arr) { free((void *)sc_arr); }
+			// Must NULL the pointer as well as freeing it: ALLOC_VEC_DBL is a realloc, so leaving the
+			// freed value in place made the next line realloc an already-freed block (a double free).
+			// Only reachable when a later init-mode call asks for more threads than an earlier one.
+			if(sc_arr) { free((void *)sc_arr); sc_arr = 0x0; }
 			sc_arr = ALLOC_VEC_DBL(sc_arr, 0x32*max_threads);	if(!sc_arr){ sprintf(cbuf, "ERROR: unable to allocate sc_arr!.\n"); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf); }
 			sc_ptr = ALIGN_VEC_DBL(sc_arr);
 			ASSERT(((intptr_t)sc_ptr & 0x3f) == 0, "sc_ptr not 64-byte aligned!");
@@ -4291,7 +4300,10 @@ in the same order here as DIF, but the in-and-output-index offsets are BRed: j1 
 		#ifndef COMPILER_TYPE_GCC
 			ASSERT(NTHREADS == 1, "Multithreading currently only supported for GCC builds!");
 		#endif
-			if(sc_arr) { free((void *)sc_arr); }
+			// Must NULL the pointer as well as freeing it: ALLOC_VEC_DBL is a realloc, so leaving the
+			// freed value in place made the next line realloc an already-freed block (a double free).
+			// Only reachable when a later init-mode call asks for more threads than an earlier one.
+			if(sc_arr) { free((void *)sc_arr); sc_arr = 0x0; }
 			sc_arr = ALLOC_VEC_DBL(sc_arr, 0x32*max_threads);	if(!sc_arr){ sprintf(cbuf, "ERROR: unable to allocate sc_arr!.\n"); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf); }
 			sc_ptr = ALIGN_VEC_DBL(sc_arr);
 			ASSERT(((intptr_t)sc_ptr & 0x3f) == 0, "sc_ptr not 64-byte aligned!");

--- a/src/radix1008_ditN_cy_dif1.c
+++ b/src/radix1008_ditN_cy_dif1.c
@@ -565,7 +565,7 @@ int radix1008_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -575,7 +575,7 @@ int radix1008_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix1024_ditN_cy_dif1.c
+++ b/src/radix1024_ditN_cy_dif1.c
@@ -170,7 +170,7 @@ int radix1024_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 #if defined(USE_AVX2) && !defined(USE_IMCI512)
 	static double tan = 0.41421356237309504879;
 #endif
-	int NDIVR,i,j,j1,jt,full_pass,khi,l,ntmp,outer;
+	int NDIVR,i,j,j1,jt,full_pass,khi,kcum,l,ntmp,outer;
 #ifndef MULTITHREAD
   #ifdef USE_SSE2
 	int incr;
@@ -381,10 +381,10 @@ int radix1024_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 #endif
 
 /*...stuff for the multithreaded implementation is here:	*/
-	static uint32 CY_THREADS,pini;
+	static uint32 CY_THREADS;
 	int ithread,j_jhi;
 	uint32 ptr_prod;
-	static int *_i, *_jstart = 0x0, *_jhi = 0x0, *_col = 0x0, *_co2 = 0x0, *_co3 = 0x0;
+	static int *_i, *_jstart = 0x0, *_jhi = 0x0, *_khi = 0x0, *_col = 0x0, *_co2 = 0x0, *_co3 = 0x0;
 	static int *_bjmodnini = 0x0, *_bjmodn[RADIX];
 	static double *_cy_r[RADIX],*_cy_i[RADIX];
 	if(!_jhi) {
@@ -475,6 +475,17 @@ int radix1024_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 		/* #Chunks ||ized in carry step is ideally a power of 2, so use the largest
 		power of 2 that is <= the value of the global NTHREADS (but still <= MAX_THREADS):
 		*/
+		/* Mersenne-mod: the per-thread carry partition below allows unequal spans, so use every
+		thread the caller asked for. Rounding down to a power of two idled up to half the cores
+		for the whole carry phase (at 7 threads the carry ran on 4), measured as a 15-20% loss on
+		6- and 7-core machines. Fermat-mod keeps the equal-span scheme and the old rounding. */
+		if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE)
+		{	// Any count up to n_div_nwt works; above that there are too few outer-loop
+			// passes to give every thread one, so take as many as this radix can feed:
+			CY_THREADS = (NTHREADS <= n_div_nwt) ? NTHREADS : n_div_nwt;
+		}
+		else
+		{
 		if(isPow2(NTHREADS))
 			CY_THREADS = NTHREADS;
 		else
@@ -483,11 +494,18 @@ int radix1024_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 			CY_THREADS = (((uint32)NTHREADS << i) & 0x80000000) >> i;
 		}
 
+		}
 		if(CY_THREADS > MAX_THREADS)
 		{
 		//	CY_THREADS = MAX_THREADS;
 			fprintf(stderr,"WARN: CY_THREADS = %d exceeds number of cores = %d\n", CY_THREADS, MAX_THREADS);
 		}
+		if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE)
+		{	// Unequal spans need only that every thread can own one outer-loop pass:
+			if(CY_THREADS > n_div_nwt) { WARN(HERE, "CY_THREADS > n_div_nwt ... more threads than this leading radix can handle.", "", 1); return(ERR_ASSERT); }
+		}
+		else
+		{
 		if(!isPow2(CY_THREADS))		{ WARN(HERE, "CY_THREADS not a power of 2!", "", 1); return(ERR_ASSERT); }
 		if(CY_THREADS > 1)
 		{
@@ -495,6 +513,7 @@ int radix1024_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 			if(n_div_nwt%CY_THREADS != 0) { WARN(HERE, "n_div_nwt%CY_THREADS != 0 ... likely more threads than this leading radix can handle.", "", 1); return(ERR_ASSERT); }
 		}
 
+		}
 	  #ifdef USE_PTHREAD
 		if(tdat == 0x0) {
 			j = (uint32)sizeof(struct cy_thread_data_t);
@@ -507,7 +526,7 @@ int radix1024_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -517,7 +536,7 @@ int radix1024_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 
@@ -1082,7 +1101,6 @@ int radix1024_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 	#endif	// USE_SSE2
 
 		/*   constant index offsets for load/stores are here.	*/
-		pini = NDIVR/CY_THREADS;
 		p1 = NDIVR;
 		p2 = p1 + NDIVR;		p1 += ( (p1 >> DAT_BITS) << PAD_BITS );
 		p3 = p2 + NDIVR;		p2 += ( (p2 >> DAT_BITS) << PAD_BITS );
@@ -1285,6 +1303,7 @@ int radix1024_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 			}
 			free((void *)_jstart ); _jstart  = 0x0;
 			free((void *)_jhi    ); _jhi     = 0x0;
+			free((void *)_khi    ); _khi     = 0x0;
 			free((void *)_col   ); _col    = 0x0;
 			free((void *)_co2   ); _co2    = 0x0;
 			free((void *)_co3   ); _co3    = 0x0;
@@ -1299,6 +1318,7 @@ int radix1024_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 		}
 		_jstart  	= (int *)malloc(j);	ptr_prod += (uint32)(_jstart  == 0x0);
 		_jhi     	= (int *)malloc(j);	ptr_prod += (uint32)(_jhi     == 0x0);
+		_khi     	= (int *)malloc(j);	ptr_prod += (uint32)(_khi     == 0x0);
 		_col     	= (int *)malloc(j);	ptr_prod += (uint32)(_col     == 0x0);
 		_co2     	= (int *)malloc(j);	ptr_prod += (uint32)(_co2     == 0x0);
 		_co3     	= (int *)malloc(j);	ptr_prod += (uint32)(_co3     == 0x0);
@@ -1317,17 +1337,21 @@ int radix1024_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 			i.e. the one that n2/radix-separated FFT outputs need:
 			*/
 			_bjmodnini = (int *)malloc((CY_THREADS + 1)*sizeof(int));	if(!_bjmodnini){ sprintf(cbuf,"ERROR: unable to allocate array _bjmodnini.\n"); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf); }
+			/* Walk the DWT-index recurrence once and snapshot it at each thread's starting j, so
+			threads may own unequal spans. The old code derived one increment for an equal span and
+			added it repeatedly, which is what forced CY_THREADS to divide NDIVR. Same values when
+			it does divide, so power-of-two thread counts are unaffected. */
 			_bjmodnini[0] = 0;
-			_bjmodnini[1] = 0;
-			for(j=0; j < NDIVR/CY_THREADS; j++)
 			{
-				_bjmodnini[1] -= sw; _bjmodnini[1] = _bjmodnini[1] + ( (-(int)((uint32)_bjmodnini[1] >> 31)) & n);
-			}
-			if(CY_THREADS > 1)
-			{
-				for(ithread = 2; ithread <= CY_THREADS; ithread++)
+				int kbase_ini = n_div_nwt/CY_THREADS, krem_ini = n_div_nwt%CY_THREADS, jj, bj = 0;
+				for(ithread = 0; ithread < CY_THREADS; ithread++)
 				{
-					_bjmodnini[ithread] = _bjmodnini[ithread-1] + _bjmodnini[1] - n; _bjmodnini[ithread] = _bjmodnini[ithread] + ( (-(int)((uint32)_bjmodnini[ithread] >> 31)) & n);
+					int span = (kbase_ini + (ithread < krem_ini)) * nwt;
+					for(jj = 0; jj < span; jj++)
+					{
+						bj -= sw; bj = bj + ( (-(int)((uint32)bj >> 31)) & n);
+					}
+					_bjmodnini[ithread+1] = bj;
 				}
 			}
 			/* Check upper element against scalar value, as precomputed in single-thread mode: */
@@ -1440,18 +1464,25 @@ for(outer=0; outer <= 1; outer++)
 		*/
 		_i[0] = 1;		/* Pointer to the BASE and BASEINV arrays. lowest-order digit is always a bigword (_i[0] = 1).	*/
 
+		/* Per-thread spans, which need not be equal: the first (n_div_nwt % CY_THREADS) threads
+		take one extra outer-loop pass. jstart and col are running sums of the spans ahead of
+		each thread instead of multiples of one span, which is what lets CY_THREADS be any
+		value up to n_div_nwt. Reduces to the original when CY_THREADS divides n_div_nwt. */
 		khi = n_div_nwt/CY_THREADS;
+		kcum = 0;
 		for(ithread = 0; ithread < CY_THREADS; ithread++)
 		{
-			_jstart[ithread] = ithread*NDIVR/CY_THREADS;
+			_khi[ithread] = khi + (ithread < (n_div_nwt%CY_THREADS));
+			_jstart[ithread] = kcum*nwt;
 			if(!full_pass)
 				_jhi[ithread] = _jstart[ithread] + jhi_wrap_mers;	/* Cleanup loop assumes carryins propagate at most 4 words up. */
 			else
 				_jhi[ithread] = _jstart[ithread] + nwt-1;
 
-			_col[ithread] = ithread*(khi*RADIX);			/* col gets incremented by RADIX_VEC[0] on every pass through the k-loop */
+			_col[ithread] = kcum*RADIX;			/* col gets incremented by RADIX_VEC[0] on every pass through the k-loop */
 			_co2[ithread] = (n>>nwt_bits)-1+RADIX - _col[ithread];	/* co2 gets decremented by RADIX_VEC[0] on every pass through the k-loop */
 			_co3[ithread] = _co2[ithread]-RADIX;			/* At the start of each new j-loop, co3=co2-RADIX_VEC[0]	*/
+			kcum += _khi[ithread];
 		}
 	}
 	else
@@ -1460,6 +1491,7 @@ for(outer=0; outer <= 1; outer++)
 		for(ithread = 0; ithread < CY_THREADS; ithread++)
 		{
 			_jstart[ithread] = ithread*NDIVR/CY_THREADS;
+			_khi[ithread] = 1;	// Fermat-mod uses khi = 1 with a full-span jhi
 			/*
 			For right-angle transform need *complex* elements for wraparound, so jhi needs to be twice as large
 			*/
@@ -1507,8 +1539,8 @@ for(outer=0; outer <= 1; outer++)
 	if(!full_pass)
 	{
 		khi = 1;
+		for(ithread = 0; ithread < CY_THREADS; ithread++) { _khi[ithread] = 1; }
 	}
-
 #ifdef USE_PTHREAD
 	/* Populate the thread-specific data structs - use the invariant terms as memchecks: */
 	for(ithread = 0; ithread < CY_THREADS; ithread++)
@@ -1518,7 +1550,7 @@ for(outer=0; outer <= 1; outer++)
 		ASSERT(tdat[ithread].tid == ithread, "thread-local memcheck fail!");
 		ASSERT(tdat[ithread].ndivr == NDIVR, "thread-local memcheck fail!");
 
-		tdat[ithread].khi    = khi;
+		tdat[ithread].khi    = _khi[ithread];
 		tdat[ithread].i      = _i[ithread];	/* Pointer to the BASE and BASEINV arrays.	*/
 		tdat[ithread].jstart = _jstart[ithread];
 		tdat[ithread].jhi    = _jhi[ithread];
@@ -1893,7 +1925,7 @@ for(outer=0; outer <= 1; outer++)
 
 	for(ithread = 0; ithread < CY_THREADS; ithread++)
 	{
-		for(j = ithread*pini; j <= ithread*pini + j_jhi; j++)
+		for(j = _jstart[ithread]; j <= _jstart[ithread] + j_jhi; j++)
 		{
 			// Generate padded version of j, since prepadding pini is thread-count unsafe:
 			j1 = j + ( (j >> DAT_BITS) << PAD_BITS );

--- a/src/radix128_ditN_cy_dif1.c
+++ b/src/radix128_ditN_cy_dif1.c
@@ -186,7 +186,7 @@ int radix128_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 	const int jhi_wrap_mers =  7;
 	const int jhi_wrap_ferm = 15;	// For right-angle transform need *complex* elements for wraparound, so jhi needs to be twice as large
   #endif
-	int NDIVR,i,j,j1,jt,full_pass,khi,l,outer;
+	int NDIVR,i,j,j1,jt,full_pass,khi,kcum,l,outer;
   #if !defined(MULTITHREAD) && !defined(USE_SSE2)
 	int j2,jp,ntmp;
   #endif
@@ -374,10 +374,10 @@ int radix128_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 #endif
 
 /*...stuff for the multithreaded implementation is here:	*/
-	static uint32 CY_THREADS,pini;
+	static uint32 CY_THREADS;
 	int ithread,j_jhi;
 	uint32 ptr_prod;
-	static int *_i, *_jstart = 0x0, *_jhi = 0x0, *_col = 0x0, *_co2 = 0x0, *_co3 = 0x0;
+	static int *_i, *_jstart = 0x0, *_jhi = 0x0, *_khi = 0x0, *_col = 0x0, *_co2 = 0x0, *_co3 = 0x0;
 	static int *_bjmodnini = 0x0, *_bjmodn[RADIX];
 	static double *_cy_r[RADIX],*_cy_i[RADIX];
 	if(!_jhi) {
@@ -468,6 +468,17 @@ int radix128_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		/* #Chunks ||ized in carry step is ideally a power of 2, so use the largest
 		power of 2 that is <= the value of the global NTHREADS (but still <= MAX_THREADS):
 		*/
+		/* Mersenne-mod: the per-thread carry partition below allows unequal spans, so use every
+		thread the caller asked for. Rounding down to a power of two idled up to half the cores
+		for the whole carry phase (at 7 threads the carry ran on 4), measured as a 15-20% loss on
+		6- and 7-core machines. Fermat-mod keeps the equal-span scheme and the old rounding. */
+		if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE)
+		{	// Any count up to n_div_nwt works; above that there are too few outer-loop
+			// passes to give every thread one, so take as many as this radix can feed:
+			CY_THREADS = (NTHREADS <= n_div_nwt) ? NTHREADS : n_div_nwt;
+		}
+		else
+		{
 		if(isPow2(NTHREADS))
 			CY_THREADS = NTHREADS;
 		else
@@ -476,11 +487,18 @@ int radix128_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			CY_THREADS = (((uint32)NTHREADS << i) & 0x80000000) >> i;
 		}
 
+		}
 		if(CY_THREADS > MAX_THREADS)
 		{
 		//	CY_THREADS = MAX_THREADS;
 			fprintf(stderr,"WARN: CY_THREADS = %d exceeds number of cores = %d\n", CY_THREADS, MAX_THREADS);
 		}
+		if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE)
+		{	// Unequal spans need only that every thread can own one outer-loop pass:
+			if(CY_THREADS > n_div_nwt) { WARN(HERE, "CY_THREADS > n_div_nwt ... more threads than this leading radix can handle.", "", 1); return(ERR_ASSERT); }
+		}
+		else
+		{
 		if(!isPow2(CY_THREADS))		{ WARN(HERE, "CY_THREADS not a power of 2!", "", 1); return(ERR_ASSERT); }
 		if(CY_THREADS > 1)
 		{
@@ -488,6 +506,7 @@ int radix128_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			if(n_div_nwt%CY_THREADS != 0) { WARN(HERE, "n_div_nwt%CY_THREADS != 0 ... likely more threads than this leading radix can handle.", "", 1); return(ERR_ASSERT); }
 		}
 
+		}
 	  #ifdef USE_PTHREAD
 		if(tdat == 0x0) {
 			j = (uint32)sizeof(struct cy_thread_data_t);
@@ -500,7 +519,7 @@ int radix128_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -510,7 +529,7 @@ int radix128_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 
@@ -1148,7 +1167,6 @@ int radix128_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 	#endif	// USE_SSE2
 
 		/*   constant index offsets for load/stores are here.	*/
-		pini = NDIVR/CY_THREADS;
 		p01 = NDIVR;
 		p02 = p01 + p01;
 		p03 = p02 + p01;
@@ -1244,6 +1262,7 @@ int radix128_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			}
 			free((void *)_jstart ); _jstart  = 0x0;
 			free((void *)_jhi    ); _jhi     = 0x0;
+			free((void *)_khi    ); _khi     = 0x0;
 			free((void *)_col   ); _col    = 0x0;
 			free((void *)_co2   ); _co2    = 0x0;
 			free((void *)_co3   ); _co3    = 0x0;
@@ -1258,6 +1277,7 @@ int radix128_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		}
 		_jstart  	= (int *)malloc(j);	ptr_prod += (uint32)(_jstart  == 0x0);
 		_jhi     	= (int *)malloc(j);	ptr_prod += (uint32)(_jhi     == 0x0);
+		_khi     	= (int *)malloc(j);	ptr_prod += (uint32)(_khi     == 0x0);
 		_col     	= (int *)malloc(j);	ptr_prod += (uint32)(_col     == 0x0);
 		_co2     	= (int *)malloc(j);	ptr_prod += (uint32)(_co2     == 0x0);
 		_co3     	= (int *)malloc(j);	ptr_prod += (uint32)(_co3     == 0x0);
@@ -1276,17 +1296,21 @@ int radix128_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			i.e. the one that n2/radix-separated FFT outputs need:
 			*/
 			_bjmodnini = (int *)malloc((CY_THREADS + 1)*sizeof(int));	if(!_bjmodnini){ sprintf(cbuf,"ERROR: unable to allocate array _bjmodnini.\n"); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf); }
+			/* Walk the DWT-index recurrence once and snapshot it at each thread's starting j, so
+			threads may own unequal spans. The old code derived one increment for an equal span and
+			added it repeatedly, which is what forced CY_THREADS to divide NDIVR. Same values when
+			it does divide, so power-of-two thread counts are unaffected. */
 			_bjmodnini[0] = 0;
-			_bjmodnini[1] = 0;
-			for(j=0; j < NDIVR/CY_THREADS; j++)
 			{
-				_bjmodnini[1] -= sw; _bjmodnini[1] = _bjmodnini[1] + ( (-(int)((uint32)_bjmodnini[1] >> 31)) & n);
-			}
-			if(CY_THREADS > 1)
-			{
-				for(ithread = 2; ithread <= CY_THREADS; ithread++)
+				int kbase_ini = n_div_nwt/CY_THREADS, krem_ini = n_div_nwt%CY_THREADS, jj, bj = 0;
+				for(ithread = 0; ithread < CY_THREADS; ithread++)
 				{
-					_bjmodnini[ithread] = _bjmodnini[ithread-1] + _bjmodnini[1] - n; _bjmodnini[ithread] = _bjmodnini[ithread] + ( (-(int)((uint32)_bjmodnini[ithread] >> 31)) & n);
+					int span = (kbase_ini + (ithread < krem_ini)) * nwt;
+					for(jj = 0; jj < span; jj++)
+					{
+						bj -= sw; bj = bj + ( (-(int)((uint32)bj >> 31)) & n);
+					}
+					_bjmodnini[ithread+1] = bj;
 				}
 			}
 			/* Check upper element against scalar value, as precomputed in single-thread mode: */
@@ -1399,18 +1423,25 @@ for(outer=0; outer <= 1; outer++)
 		*/
 		_i[0] = 1;		/* Pointer to the BASE and BASEINV arrays. lowest-order digit is always a bigword (_i[0] = 1).	*/
 
+		/* Per-thread spans, which need not be equal: the first (n_div_nwt % CY_THREADS) threads
+		take one extra outer-loop pass. jstart and col are running sums of the spans ahead of
+		each thread instead of multiples of one span, which is what lets CY_THREADS be any
+		value up to n_div_nwt. Reduces to the original when CY_THREADS divides n_div_nwt. */
 		khi = n_div_nwt/CY_THREADS;
+		kcum = 0;
 		for(ithread = 0; ithread < CY_THREADS; ithread++)
 		{
-			_jstart[ithread] = ithread*NDIVR/CY_THREADS;
+			_khi[ithread] = khi + (ithread < (n_div_nwt%CY_THREADS));
+			_jstart[ithread] = kcum*nwt;
 			if(!full_pass)
 				_jhi[ithread] = _jstart[ithread] + jhi_wrap_mers;	/* Cleanup loop assumes carryins propagate at most 4 words up. */
 			else
 				_jhi[ithread] = _jstart[ithread] + nwt-1;
 
-			_col[ithread] = ithread*(khi*RADIX);			/* col gets incremented by RADIX_VEC[0] on every pass through the k-loop */
+			_col[ithread] = kcum*RADIX;			/* col gets incremented by RADIX_VEC[0] on every pass through the k-loop */
 			_co2[ithread] = (n>>nwt_bits)-1+RADIX - _col[ithread];	/* co2 gets decremented by RADIX_VEC[0] on every pass through the k-loop */
 			_co3[ithread] = _co2[ithread]-RADIX;			/* At the start of each new j-loop, co3=co2-RADIX_VEC[0]	*/
+			kcum += _khi[ithread];
 		}
 	}
 	else
@@ -1419,6 +1450,7 @@ for(outer=0; outer <= 1; outer++)
 		for(ithread = 0; ithread < CY_THREADS; ithread++)
 		{
 			_jstart[ithread] = ithread*NDIVR/CY_THREADS;
+			_khi[ithread] = 1;	// Fermat-mod uses khi = 1 with a full-span jhi
 			/*
 			For right-angle transform need *complex* elements for wraparound, so jhi needs to be twice as large
 			*/
@@ -1466,8 +1498,8 @@ for(outer=0; outer <= 1; outer++)
 	if(!full_pass)
 	{
 		khi = 1;
+		for(ithread = 0; ithread < CY_THREADS; ithread++) { _khi[ithread] = 1; }
 	}
-
 #ifdef USE_PTHREAD
 	/* Populate the thread-specific data structs - use the invariant terms as memchecks: */
 	for(ithread = 0; ithread < CY_THREADS; ithread++)
@@ -1477,7 +1509,7 @@ for(outer=0; outer <= 1; outer++)
 		ASSERT(tdat[ithread].tid == ithread, "thread-local memcheck fail!");
 		ASSERT(tdat[ithread].ndivr == NDIVR, "thread-local memcheck fail!");
 
-		tdat[ithread].khi    = khi;
+		tdat[ithread].khi    = _khi[ithread];
 		tdat[ithread].i      = _i[ithread];	/* Pointer to the BASE and BASEINV arrays.	*/
 		tdat[ithread].jstart = _jstart[ithread];
 		tdat[ithread].jhi    = _jhi[ithread];
@@ -1851,7 +1883,7 @@ for(outer=0; outer <= 1; outer++)
 
 	for(ithread = 0; ithread < CY_THREADS; ithread++)
 	{
-		for(j = ithread*pini; j <= ithread*pini + j_jhi; j++)
+		for(j = _jstart[ithread]; j <= _jstart[ithread] + j_jhi; j++)
 		{
 			// Generate padded version of j, since prepadding pini is thread-count unsafe:
 			j1 = j + ( (j >> DAT_BITS) << PAD_BITS );

--- a/src/radix12_ditN_cy_dif1.c
+++ b/src/radix12_ditN_cy_dif1.c
@@ -395,7 +395,7 @@ int radix12_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -405,7 +405,7 @@ int radix12_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix144_ditN_cy_dif1.c
+++ b/src/radix144_ditN_cy_dif1.c
@@ -498,7 +498,7 @@ int radix144_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -508,7 +508,7 @@ int radix144_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix160_ditN_cy_dif1.c
+++ b/src/radix160_ditN_cy_dif1.c
@@ -474,7 +474,7 @@ int radix160_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -484,7 +484,7 @@ int radix160_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix16_ditN_cy_dif1.c
+++ b/src/radix16_ditN_cy_dif1.c
@@ -532,7 +532,7 @@ int radix16_ditN_cy_dif1		(double a[],             int n, int nwt, int nwt_bits,
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -543,7 +543,7 @@ int radix16_ditN_cy_dif1		(double a[],             int n, int nwt, int nwt_bits,
 
 				//main_work_units = 0;
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix176_ditN_cy_dif1.c
+++ b/src/radix176_ditN_cy_dif1.c
@@ -535,7 +535,7 @@ ATTR_NO_ASAN int radix176_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits,
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -545,7 +545,7 @@ ATTR_NO_ASAN int radix176_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits,
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix192_ditN_cy_dif1.c
+++ b/src/radix192_ditN_cy_dif1.c
@@ -471,7 +471,7 @@ int radix192_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -481,7 +481,7 @@ int radix192_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix208_ditN_cy_dif1.c
+++ b/src/radix208_ditN_cy_dif1.c
@@ -502,7 +502,7 @@ const double cc1=  0.88545602565320989590,	/* Real part of exp(i*2*pi/13), the r
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -512,7 +512,7 @@ const double cc1=  0.88545602565320989590,	/* Real part of exp(i*2*pi/13), the r
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix20_ditN_cy_dif1.c
+++ b/src/radix20_ditN_cy_dif1.c
@@ -432,7 +432,7 @@ int radix20_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -442,7 +442,7 @@ int radix20_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix224_ditN_cy_dif1.c
+++ b/src/radix224_ditN_cy_dif1.c
@@ -633,7 +633,7 @@ int radix224_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -643,7 +643,7 @@ int radix224_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix240_ditN_cy_dif1.c
+++ b/src/radix240_ditN_cy_dif1.c
@@ -621,7 +621,7 @@ int radix240_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -631,7 +631,7 @@ int radix240_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix24_ditN_cy_dif1.c
+++ b/src/radix24_ditN_cy_dif1.c
@@ -463,7 +463,7 @@ int radix24_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -473,7 +473,7 @@ int radix24_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix256_ditN_cy_dif1.c
+++ b/src/radix256_ditN_cy_dif1.c
@@ -225,7 +225,7 @@ int radix256_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 	const int jhi_wrap_mers =  7;
 	const int jhi_wrap_ferm = 15;	// For right-angle transform need *complex* elements for wraparound, so jhi needs to be twice as large
   #endif
-	int NDIVR,i,j,j1,jt,full_pass,khi,l,ntmp,outer;
+	int NDIVR,i,j,j1,jt,full_pass,khi,kcum,l,ntmp,outer;
   #if !defined(MULTITHREAD) && !defined(USE_SSE2)
 	int j2,jp;
   #endif
@@ -411,10 +411,10 @@ int radix256_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 #endif
 
 /*...stuff for the multithreaded implementation is here:	*/
-	static uint32 CY_THREADS,pini;
+	static uint32 CY_THREADS;
 	int ithread,j_jhi;
 	uint32 ptr_prod;
-	static int *_i, *_jstart = 0x0, *_jhi = 0x0, *_col = 0x0, *_co2 = 0x0, *_co3 = 0x0;
+	static int *_i, *_jstart = 0x0, *_jhi = 0x0, *_khi = 0x0, *_col = 0x0, *_co2 = 0x0, *_co3 = 0x0;
 	static int *_bjmodnini = 0x0, *_bjmodn[RADIX];
 	static double *_cy_r[RADIX],*_cy_i[RADIX];
 	if(!_jhi) {
@@ -600,6 +600,17 @@ int radix256_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		/* #Chunks ||ized in carry step is ideally a power of 2, so use the largest
 		power of 2 that is <= the value of the global NTHREADS (but still <= MAX_THREADS):
 		*/
+		/* Mersenne-mod: the per-thread carry partition below allows unequal spans, so use every
+		thread the caller asked for. Rounding down to a power of two idled up to half the cores
+		for the whole carry phase (at 7 threads the carry ran on 4), measured as a 15-20% loss on
+		6- and 7-core machines. Fermat-mod keeps the equal-span scheme and the old rounding. */
+		if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE)
+		{	// Any count up to n_div_nwt works; above that there are too few outer-loop
+			// passes to give every thread one, so take as many as this radix can feed:
+			CY_THREADS = (NTHREADS <= n_div_nwt) ? NTHREADS : n_div_nwt;
+		}
+		else
+		{
 		if(isPow2(NTHREADS))
 			CY_THREADS = NTHREADS;
 		else
@@ -608,11 +619,18 @@ int radix256_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			CY_THREADS = (((uint32)NTHREADS << i) & 0x80000000) >> i;
 		}
 
+		}
 		if(CY_THREADS > MAX_THREADS)
 		{
 		//	CY_THREADS = MAX_THREADS;
 			fprintf(stderr,"WARN: CY_THREADS = %d exceeds number of cores = %d\n", CY_THREADS, MAX_THREADS);
 		}
+		if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE)
+		{	// Unequal spans need only that every thread can own one outer-loop pass:
+			if(CY_THREADS > n_div_nwt) { WARN(HERE, "CY_THREADS > n_div_nwt ... more threads than this leading radix can handle.", "", 1); return(ERR_ASSERT); }
+		}
+		else
+		{
 		if(!isPow2(CY_THREADS))		{ WARN(HERE, "CY_THREADS not a power of 2!", "", 1); return(ERR_ASSERT); }
 		if(CY_THREADS > 1)
 		{
@@ -620,6 +638,7 @@ int radix256_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			if(n_div_nwt%CY_THREADS != 0) { WARN(HERE, "n_div_nwt%CY_THREADS != 0 ... likely more threads than this leading radix can handle.", "", 1); return(ERR_ASSERT); }
 		}
 
+		}
 	  #ifdef USE_PTHREAD
 		if(tdat == 0x0) {
 			j = (uint32)sizeof(struct cy_thread_data_t);
@@ -632,7 +651,7 @@ int radix256_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -642,7 +661,7 @@ int radix256_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 
@@ -1221,7 +1240,6 @@ int radix256_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 	#endif	// USE_SSE2
 
 		/*   constant index offsets for load/stores are here.	*/
-		pini = NDIVR/CY_THREADS;
 		p01 = NDIVR;
 		p02 = p01 + p01;
 		p03 = p02 + p01;
@@ -1348,6 +1366,7 @@ int radix256_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			}
 			free((void *)_jstart ); _jstart  = 0x0;
 			free((void *)_jhi    ); _jhi     = 0x0;
+			free((void *)_khi    ); _khi     = 0x0;
 			free((void *)_col   ); _col    = 0x0;
 			free((void *)_co2   ); _co2    = 0x0;
 			free((void *)_co3   ); _co3    = 0x0;
@@ -1362,6 +1381,7 @@ int radix256_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		}
 		_jstart  	= (int *)malloc(j);	ptr_prod += (uint32)(_jstart  == 0x0);
 		_jhi     	= (int *)malloc(j);	ptr_prod += (uint32)(_jhi     == 0x0);
+		_khi     	= (int *)malloc(j);	ptr_prod += (uint32)(_khi     == 0x0);
 		_col     	= (int *)malloc(j);	ptr_prod += (uint32)(_col     == 0x0);
 		_co2     	= (int *)malloc(j);	ptr_prod += (uint32)(_co2     == 0x0);
 		_co3     	= (int *)malloc(j);	ptr_prod += (uint32)(_co3     == 0x0);
@@ -1380,17 +1400,21 @@ int radix256_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			i.e. the one that n2/radix-separated FFT outputs need:
 			*/
 			_bjmodnini = (int *)malloc((CY_THREADS + 1)*sizeof(int));	if(!_bjmodnini){ sprintf(cbuf,"ERROR: unable to allocate array _bjmodnini.\n"); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf); }
+			/* Walk the DWT-index recurrence once and snapshot it at each thread's starting j, so
+			threads may own unequal spans. The old code derived one increment for an equal span and
+			added it repeatedly, which is what forced CY_THREADS to divide NDIVR. Same values when
+			it does divide, so power-of-two thread counts are unaffected. */
 			_bjmodnini[0] = 0;
-			_bjmodnini[1] = 0;
-			for(j=0; j < NDIVR/CY_THREADS; j++)
 			{
-				_bjmodnini[1] -= sw; _bjmodnini[1] = _bjmodnini[1] + ( (-(int)((uint32)_bjmodnini[1] >> 31)) & n);
-			}
-			if(CY_THREADS > 1)
-			{
-				for(ithread = 2; ithread <= CY_THREADS; ithread++)
+				int kbase_ini = n_div_nwt/CY_THREADS, krem_ini = n_div_nwt%CY_THREADS, jj, bj = 0;
+				for(ithread = 0; ithread < CY_THREADS; ithread++)
 				{
-					_bjmodnini[ithread] = _bjmodnini[ithread-1] + _bjmodnini[1] - n; _bjmodnini[ithread] = _bjmodnini[ithread] + ( (-(int)((uint32)_bjmodnini[ithread] >> 31)) & n);
+					int span = (kbase_ini + (ithread < krem_ini)) * nwt;
+					for(jj = 0; jj < span; jj++)
+					{
+						bj -= sw; bj = bj + ( (-(int)((uint32)bj >> 31)) & n);
+					}
+					_bjmodnini[ithread+1] = bj;
 				}
 			}
 			/* Check upper element against scalar value, as precomputed in single-thread mode: */
@@ -1503,18 +1527,25 @@ for(outer=0; outer <= 1; outer++)
 		*/
 		_i[0] = 1;		/* Pointer to the BASE and BASEINV arrays. lowest-order digit is always a bigword (_i[0] = 1).	*/
 
+		/* Per-thread spans, which need not be equal: the first (n_div_nwt % CY_THREADS) threads
+		take one extra outer-loop pass. jstart and col are running sums of the spans ahead of
+		each thread instead of multiples of one span, which is what lets CY_THREADS be any
+		value up to n_div_nwt. Reduces to the original when CY_THREADS divides n_div_nwt. */
 		khi = n_div_nwt/CY_THREADS;
+		kcum = 0;
 		for(ithread = 0; ithread < CY_THREADS; ithread++)
 		{
-			_jstart[ithread] = ithread*NDIVR/CY_THREADS;
+			_khi[ithread] = khi + (ithread < (n_div_nwt%CY_THREADS));
+			_jstart[ithread] = kcum*nwt;
 			if(!full_pass)
 				_jhi[ithread] = _jstart[ithread] + jhi_wrap_mers;	/* Cleanup loop assumes carryins propagate at most 4 words up. */
 			else
 				_jhi[ithread] = _jstart[ithread] + nwt-1;
 
-			_col[ithread] = ithread*(khi*RADIX);			/* col gets incremented by RADIX_VEC[0] on every pass through the k-loop */
+			_col[ithread] = kcum*RADIX;			/* col gets incremented by RADIX_VEC[0] on every pass through the k-loop */
 			_co2[ithread] = (n>>nwt_bits)-1+RADIX - _col[ithread];	/* co2 gets decremented by RADIX_VEC[0] on every pass through the k-loop */
 			_co3[ithread] = _co2[ithread]-RADIX;			/* At the start of each new j-loop, co3=co2-RADIX_VEC[0]	*/
+			kcum += _khi[ithread];
 		}
 	}
 	else
@@ -1523,6 +1554,7 @@ for(outer=0; outer <= 1; outer++)
 		for(ithread = 0; ithread < CY_THREADS; ithread++)
 		{
 			_jstart[ithread] = ithread*NDIVR/CY_THREADS;
+			_khi[ithread] = 1;	// Fermat-mod uses khi = 1 with a full-span jhi
 			/*
 			For right-angle transform need *complex* elements for wraparound, so jhi needs to be twice as large
 			*/
@@ -1570,8 +1602,8 @@ for(outer=0; outer <= 1; outer++)
 	if(!full_pass)
 	{
 		khi = 1;
+		for(ithread = 0; ithread < CY_THREADS; ithread++) { _khi[ithread] = 1; }
 	}
-
 #ifdef USE_PTHREAD
 	/* Populate the thread-specific data structs - use the invariant terms as memchecks: */
 	for(ithread = 0; ithread < CY_THREADS; ithread++)
@@ -1581,7 +1613,7 @@ for(outer=0; outer <= 1; outer++)
 		ASSERT(tdat[ithread].tid == ithread, "thread-local memcheck fail!");
 		ASSERT(tdat[ithread].ndivr == NDIVR, "thread-local memcheck fail!");
 
-		tdat[ithread].khi    = khi;
+		tdat[ithread].khi    = _khi[ithread];
 		tdat[ithread].i      = _i[ithread];	/* Pointer to the BASE and BASEINV arrays.	*/
 		tdat[ithread].jstart = _jstart[ithread];
 		tdat[ithread].jhi    = _jhi[ithread];
@@ -1957,7 +1989,7 @@ for(outer=0; outer <= 1; outer++)
 
 	for(ithread = 0; ithread < CY_THREADS; ithread++)
 	{
-		for(j = ithread*pini; j <= ithread*pini + j_jhi; j++)
+		for(j = _jstart[ithread]; j <= _jstart[ithread] + j_jhi; j++)
 		{
 			// Generate padded version of j, since prepadding pini is thread-count unsafe:
 			j1 = j + ( (j >> DAT_BITS) << PAD_BITS );

--- a/src/radix288_ditN_cy_dif1.c
+++ b/src/radix288_ditN_cy_dif1.c
@@ -460,7 +460,7 @@ int radix288_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -470,7 +470,7 @@ int radix288_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix28_ditN_cy_dif1.c
+++ b/src/radix28_ditN_cy_dif1.c
@@ -666,7 +666,7 @@ int radix28_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -676,7 +676,7 @@ int radix28_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix320_ditN_cy_dif1.c
+++ b/src/radix320_ditN_cy_dif1.c
@@ -495,7 +495,7 @@ int radix320_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -505,7 +505,7 @@ int radix320_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix32_ditN_cy_dif1.c
+++ b/src/radix32_ditN_cy_dif1.c
@@ -145,7 +145,7 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 	const int jhi_wrap_mers =  7;
 	const int jhi_wrap_ferm = 15;	// For right-angle transform need *complex* elements for wraparound, so jhi needs to be twice as large
   #endif
-	int NDIVR,i,j,j1,j2,jt,jp,full_pass,khi,l,outer;
+	int NDIVR,i,j,j1,j2,jt,jp,full_pass,khi,kcum,l,outer;
   #ifdef USE_SSE2
 	int nbytes;
   #endif
@@ -303,10 +303,10 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 #endif
 
 /*...stuff for the multithreaded implementation is here:	*/
-	static uint32 CY_THREADS,pini;
+	static uint32 CY_THREADS;
 	int ithread,j_jhi;
 	uint32 ptr_prod;
-	static int *_i, *_jstart = 0x0, *_jhi = 0x0, *_col = 0x0, *_co2 = 0x0, *_co3 = 0x0;
+	static int *_i, *_jstart = 0x0, *_jhi = 0x0, *_khi = 0x0, *_col = 0x0, *_co2 = 0x0, *_co3 = 0x0;
 	static int *_bjmodnini = 0x0, *_bjmodn[RADIX];
 	static double *_cy_r[RADIX],*_cy_i[RADIX];
 	if(!_jhi) {
@@ -399,6 +399,17 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		/* #Chunks ||ized in carry step is ideally a power of 2, so use the largest
 		power of 2 that is <= the value of the global NTHREADS (but still <= MAX_THREADS):
 		*/
+		/* Mersenne-mod: the per-thread carry partition below allows unequal spans, so use every
+		thread the caller asked for. Rounding down to a power of two idled up to half the cores
+		for the whole carry phase (at 7 threads the carry ran on 4), measured as a 15-20% loss on
+		6- and 7-core machines. Fermat-mod keeps the equal-span scheme and the old rounding. */
+		if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE)
+		{	// Any count up to n_div_nwt works; above that there are too few outer-loop
+			// passes to give every thread one, so take as many as this radix can feed:
+			CY_THREADS = (NTHREADS <= n_div_nwt) ? NTHREADS : n_div_nwt;
+		}
+		else
+		{
 		if(isPow2(NTHREADS))
 			CY_THREADS = NTHREADS;
 		else
@@ -407,11 +418,18 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			CY_THREADS = (((uint32)NTHREADS << i) & 0x80000000) >> i;
 		}
 
+		}
 		if(CY_THREADS > MAX_THREADS)
 		{
 		//	CY_THREADS = MAX_THREADS;
 			fprintf(stderr,"WARN: CY_THREADS = %d exceeds number of cores = %d\n", CY_THREADS, MAX_THREADS);
 		}
+		if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE)
+		{	// Unequal spans need only that every thread can own one outer-loop pass:
+			if(CY_THREADS > n_div_nwt) { WARN(HERE, "CY_THREADS > n_div_nwt ... more threads than this leading radix can handle.", "", 1); return(ERR_ASSERT); }
+		}
+		else
+		{
 		if(!isPow2(CY_THREADS))		{ WARN(HERE, "CY_THREADS not a power of 2!", "", 1); return(ERR_ASSERT); }
 		if(CY_THREADS > 1)
 		{
@@ -419,6 +437,7 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			if(n_div_nwt%CY_THREADS != 0) { WARN(HERE, "n_div_nwt%CY_THREADS != 0 ... likely more threads than this leading radix can handle.", "", 1); return(ERR_ASSERT); }
 		}
 
+		}
 	  #ifdef USE_PTHREAD
 		if(tdat == 0x0) {
 			j = (uint32)sizeof(struct cy_thread_data_t);
@@ -431,7 +450,7 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -442,7 +461,7 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 
 				//main_work_units = 0;
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 		}
@@ -1005,7 +1024,6 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 	#endif	// USE_SSE2
 
 		/*   constant index offsets for load/stores are here.	*/
-		pini = NDIVR/CY_THREADS;
 		p01 = NDIVR;
 		p02 = p01 +p01;
 		p03 = p02 +p01;
@@ -1060,6 +1078,7 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			}
 			free((void *)_jstart ); _jstart  = 0x0;
 			free((void *)_jhi    ); _jhi     = 0x0;
+			free((void *)_khi    ); _khi     = 0x0;
 			free((void *)_col   ); _col    = 0x0;
 			free((void *)_co2   ); _co2    = 0x0;
 			free((void *)_co3   ); _co3    = 0x0;
@@ -1074,6 +1093,7 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		}
 		_jstart  	= (int *)malloc(j);	ptr_prod += (uint32)(_jstart  == 0x0);
 		_jhi     	= (int *)malloc(j);	ptr_prod += (uint32)(_jhi     == 0x0);
+		_khi     	= (int *)malloc(j);	ptr_prod += (uint32)(_khi     == 0x0);
 		_col     	= (int *)malloc(j);	ptr_prod += (uint32)(_col     == 0x0);
 		_co2     	= (int *)malloc(j);	ptr_prod += (uint32)(_co2     == 0x0);
 		_co3     	= (int *)malloc(j);	ptr_prod += (uint32)(_co3     == 0x0);
@@ -1092,17 +1112,21 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			i.e. the one that n2/radix-separated FFT outputs need:
 			*/
 			_bjmodnini = (int *)malloc((CY_THREADS + 1)*sizeof(int));	if(!_bjmodnini){ sprintf(cbuf,"ERROR: unable to allocate array _bjmodnini.\n"); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf); }
+			/* Walk the DWT-index recurrence once and snapshot it at each thread's starting j, so
+			threads may own unequal spans. The old code derived one increment for an equal span and
+			added it repeatedly, which is what forced CY_THREADS to divide NDIVR. Same values when
+			it does divide, so power-of-two thread counts are unaffected. */
 			_bjmodnini[0] = 0;
-			_bjmodnini[1] = 0;
-			for(j=0; j < NDIVR/CY_THREADS; j++)
 			{
-				_bjmodnini[1] -= sw; _bjmodnini[1] = _bjmodnini[1] + ( (-(int)((uint32)_bjmodnini[1] >> 31)) & n);
-			}
-			if(CY_THREADS > 1)
-			{
-				for(ithread = 2; ithread <= CY_THREADS; ithread++)
+				int kbase_ini = n_div_nwt/CY_THREADS, krem_ini = n_div_nwt%CY_THREADS, jj, bj = 0;
+				for(ithread = 0; ithread < CY_THREADS; ithread++)
 				{
-					_bjmodnini[ithread] = _bjmodnini[ithread-1] + _bjmodnini[1] - n; _bjmodnini[ithread] = _bjmodnini[ithread] + ( (-(int)((uint32)_bjmodnini[ithread] >> 31)) & n);
+					int span = (kbase_ini + (ithread < krem_ini)) * nwt;
+					for(jj = 0; jj < span; jj++)
+					{
+						bj -= sw; bj = bj + ( (-(int)((uint32)bj >> 31)) & n);
+					}
+					_bjmodnini[ithread+1] = bj;
 				}
 			}
 			/* Check upper element against scalar value, as precomputed in single-thread mode: */
@@ -1215,18 +1239,25 @@ for(outer=0; outer <= 1; outer++)
 		*/
 		_i[0] = 1;		/* Pointer to the BASE and BASEINV arrays. lowest-order digit is always a bigword (_i[0] = 1).	*/
 
+		/* Per-thread spans, which need not be equal: the first (n_div_nwt % CY_THREADS) threads
+		take one extra outer-loop pass. jstart and col are running sums of the spans ahead of
+		each thread instead of multiples of one span, which is what lets CY_THREADS be any
+		value up to n_div_nwt. Reduces to the original when CY_THREADS divides n_div_nwt. */
 		khi = n_div_nwt/CY_THREADS;
+		kcum = 0;
 		for(ithread = 0; ithread < CY_THREADS; ithread++)
 		{
-			_jstart[ithread] = ithread*NDIVR/CY_THREADS;
+			_khi[ithread] = khi + (ithread < (n_div_nwt%CY_THREADS));
+			_jstart[ithread] = kcum*nwt;
 			if(!full_pass)
 				_jhi[ithread] = _jstart[ithread] + jhi_wrap_mers;	/* Cleanup loop assumes carryins propagate at most 4 words up. */
 			else
 				_jhi[ithread] = _jstart[ithread] + nwt-1;
 
-			_col[ithread] = ithread*(khi*RADIX);			/* col gets incremented by RADIX_VEC[0] on every pass through the k-loop */
+			_col[ithread] = kcum*RADIX;			/* col gets incremented by RADIX_VEC[0] on every pass through the k-loop */
 			_co2[ithread] = (n>>nwt_bits)-1+RADIX - _col[ithread];	/* co2 gets decremented by RADIX_VEC[0] on every pass through the k-loop */
 			_co3[ithread] = _co2[ithread]-RADIX;			/* At the start of each new j-loop, co3=co2-RADIX_VEC[0]	*/
+			kcum += _khi[ithread];
 		}
 	}
 	else
@@ -1235,6 +1266,7 @@ for(outer=0; outer <= 1; outer++)
 		for(ithread = 0; ithread < CY_THREADS; ithread++)
 		{
 			_jstart[ithread] = ithread*NDIVR/CY_THREADS;
+			_khi[ithread] = 1;	// Fermat-mod uses khi = 1 with a full-span jhi
 			/*
 			For right-angle transform need *complex* elements for wraparound, so jhi needs to be twice as large
 			*/
@@ -1282,8 +1314,8 @@ for(outer=0; outer <= 1; outer++)
 	if(!full_pass)
 	{
 		khi = 1;
+		for(ithread = 0; ithread < CY_THREADS; ithread++) { _khi[ithread] = 1; }
 	}
-
 #ifdef USE_PTHREAD
 	/* Populate the thread-specific data structs - use the invariant terms as memchecks: */
 	for(ithread = 0; ithread < CY_THREADS; ithread++)
@@ -1293,7 +1325,7 @@ for(outer=0; outer <= 1; outer++)
 		ASSERT(tdat[ithread].tid == ithread, "thread-local memcheck fail!");
 		ASSERT(tdat[ithread].ndivr == NDIVR, "thread-local memcheck fail!");
 
-		tdat[ithread].khi    = khi;
+		tdat[ithread].khi    = _khi[ithread];
 		tdat[ithread].i      = _i[ithread];	/* Pointer to the BASE and BASEINV arrays.	*/
 		tdat[ithread].jstart = _jstart[ithread];
 		tdat[ithread].jhi    = _jhi[ithread];
@@ -1713,7 +1745,7 @@ for(outer=0; outer <= 1; outer++)
 
 	for(ithread = 0; ithread < CY_THREADS; ithread++)
 	{
-		for(j = ithread*pini; j <= ithread*pini + j_jhi; j++)
+		for(j = _jstart[ithread]; j <= _jstart[ithread] + j_jhi; j++)
 		{
 			// Generate padded version of j, since prepadding pini is thread-count unsafe:
 			j1 = j + ( (j >> DAT_BITS) << PAD_BITS );

--- a/src/radix352_ditN_cy_dif1.c
+++ b/src/radix352_ditN_cy_dif1.c
@@ -494,7 +494,7 @@ ATTR_NO_ASAN int radix352_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits,
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -504,7 +504,7 @@ ATTR_NO_ASAN int radix352_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits,
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix36_ditN_cy_dif1.c
+++ b/src/radix36_ditN_cy_dif1.c
@@ -453,7 +453,7 @@ int radix36_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -463,7 +463,7 @@ int radix36_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix384_ditN_cy_dif1.c
+++ b/src/radix384_ditN_cy_dif1.c
@@ -460,7 +460,7 @@ int radix384_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -470,7 +470,7 @@ int radix384_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix4032_ditN_cy_dif1.c
+++ b/src/radix4032_ditN_cy_dif1.c
@@ -523,7 +523,7 @@ int radix4032_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -533,7 +533,7 @@ int radix4032_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix40_ditN_cy_dif1.c
+++ b/src/radix40_ditN_cy_dif1.c
@@ -446,7 +446,7 @@ int radix40_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -456,7 +456,7 @@ int radix40_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix44_ditN_cy_dif1.c
+++ b/src/radix44_ditN_cy_dif1.c
@@ -479,7 +479,7 @@ ATTR_NO_ASAN int radix44_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, 
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -489,7 +489,7 @@ ATTR_NO_ASAN int radix44_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, 
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix48_ditN_cy_dif1.c
+++ b/src/radix48_ditN_cy_dif1.c
@@ -463,7 +463,7 @@ int radix48_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -473,7 +473,7 @@ int radix48_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix52_ditN_cy_dif1.c
+++ b/src/radix52_ditN_cy_dif1.c
@@ -458,7 +458,7 @@ const double cc1=  0.88545602565320989590,	/* Real part of exp(i*2*pi/13), the r
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -468,7 +468,7 @@ const double cc1=  0.88545602565320989590,	/* Real part of exp(i*2*pi/13), the r
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix56_ditN_cy_dif1.c
+++ b/src/radix56_ditN_cy_dif1.c
@@ -585,7 +585,7 @@ int radix56_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -595,7 +595,7 @@ int radix56_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix60_ditN_cy_dif1.c
+++ b/src/radix60_ditN_cy_dif1.c
@@ -605,7 +605,7 @@ int radix60_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -615,7 +615,7 @@ int radix60_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix63_ditN_cy_dif1.c
+++ b/src/radix63_ditN_cy_dif1.c
@@ -261,7 +261,7 @@ int radix63_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -271,7 +271,7 @@ int radix63_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix64_ditN_cy_dif1.c
+++ b/src/radix64_ditN_cy_dif1.c
@@ -189,7 +189,7 @@ int radix64_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 	const int jhi_wrap_mers =  7;
 	const int jhi_wrap_ferm = 15;	// For right-angle transform need *complex* elements for wraparound, so jhi needs to be twice as large
   #endif
-	int NDIVR,i,j,j1,jt,full_pass,khi,l,outer;
+	int NDIVR,i,j,j1,jt,full_pass,khi,kcum,l,outer;
   #if !defined(MULTITHREAD) && !defined(USE_SSE2)
 	int j2,jp;
   #endif
@@ -396,10 +396,10 @@ int radix64_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 #endif
 
 /*...stuff for the multithreaded implementation is here:	*/
-	static uint32 CY_THREADS,pini;
+	static uint32 CY_THREADS;
 	int ithread,j_jhi;
 	uint32 ptr_prod;
-	static int *_i, *_jstart = 0x0, *_jhi = 0x0, *_col = 0x0, *_co2 = 0x0, *_co3 = 0x0;
+	static int *_i, *_jstart = 0x0, *_jhi = 0x0, *_khi = 0x0, *_col = 0x0, *_co2 = 0x0, *_co3 = 0x0;
 	static int *_bjmodnini = 0x0, *_bjmodn[RADIX];
 	static double *_cy_r[RADIX],*_cy_i[RADIX];
 	if(!_jhi) {
@@ -490,6 +490,17 @@ int radix64_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		/* #Chunks ||ized in carry step is ideally a power of 2, so use the largest
 		power of 2 that is <= the value of the global NTHREADS (but still <= MAX_THREADS):
 		*/
+		/* Mersenne-mod: the per-thread carry partition below allows unequal spans, so use every
+		thread the caller asked for. Rounding down to a power of two idled up to half the cores
+		for the whole carry phase (at 7 threads the carry ran on 4), measured as a 15-20% loss on
+		6- and 7-core machines. Fermat-mod keeps the equal-span scheme and the old rounding. */
+		if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE)
+		{	// Any count up to n_div_nwt works; above that there are too few outer-loop
+			// passes to give every thread one, so take as many as this radix can feed:
+			CY_THREADS = (NTHREADS <= n_div_nwt) ? NTHREADS : n_div_nwt;
+		}
+		else
+		{
 		if(isPow2(NTHREADS))
 			CY_THREADS = NTHREADS;
 		else
@@ -498,11 +509,18 @@ int radix64_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			CY_THREADS = (((uint32)NTHREADS << i) & 0x80000000) >> i;
 		}
 
+		}
 		if(CY_THREADS > MAX_THREADS)
 		{
 		//	CY_THREADS = MAX_THREADS;
 			fprintf(stderr,"WARN: CY_THREADS = %d exceeds number of cores = %d\n", CY_THREADS, MAX_THREADS);
 		}
+		if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE)
+		{	// Unequal spans need only that every thread can own one outer-loop pass:
+			if(CY_THREADS > n_div_nwt) { WARN(HERE, "CY_THREADS > n_div_nwt ... more threads than this leading radix can handle.", "", 1); return(ERR_ASSERT); }
+		}
+		else
+		{
 		if(!isPow2(CY_THREADS))		{ WARN(HERE, "CY_THREADS not a power of 2!", "", 1); return(ERR_ASSERT); }
 		if(CY_THREADS > 1)
 		{
@@ -510,6 +528,7 @@ int radix64_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			if(n_div_nwt%CY_THREADS != 0) { WARN(HERE, "n_div_nwt%CY_THREADS != 0 ... likely more threads than this leading radix can handle.", "", 1); return(ERR_ASSERT); }
 		}
 
+		}
 	  #ifdef USE_PTHREAD
 		if(tdat == 0x0) {
 			j = (uint32)sizeof(struct cy_thread_data_t);
@@ -522,7 +541,7 @@ int radix64_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -532,7 +551,7 @@ int radix64_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 
@@ -1261,7 +1280,6 @@ int radix64_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 	#endif	// USE_SSE2
 
 		/*   constant index offsets for load/stores are here.	*/
-		pini = NDIVR/CY_THREADS;
 		p01 = NDIVR;
 		p02 = p01 +p01;
 		p03 = p02 +p01;
@@ -1342,6 +1360,7 @@ int radix64_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			}
 			free((void *)_jstart ); _jstart  = 0x0;
 			free((void *)_jhi    ); _jhi     = 0x0;
+			free((void *)_khi    ); _khi     = 0x0;
 			free((void *)_col   ); _col    = 0x0;
 			free((void *)_co2   ); _co2    = 0x0;
 			free((void *)_co3   ); _co3    = 0x0;
@@ -1356,6 +1375,7 @@ int radix64_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		}
 		_jstart  	= (int *)malloc(j);	ptr_prod += (uint32)(_jstart  == 0x0);
 		_jhi     	= (int *)malloc(j);	ptr_prod += (uint32)(_jhi     == 0x0);
+		_khi     	= (int *)malloc(j);	ptr_prod += (uint32)(_khi     == 0x0);
 		_col     	= (int *)malloc(j);	ptr_prod += (uint32)(_col     == 0x0);
 		_co2     	= (int *)malloc(j);	ptr_prod += (uint32)(_co2     == 0x0);
 		_co3     	= (int *)malloc(j);	ptr_prod += (uint32)(_co3     == 0x0);
@@ -1374,17 +1394,21 @@ int radix64_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			i.e. the one that n2/radix-separated FFT outputs need:
 			*/
 			_bjmodnini = (int *)malloc((CY_THREADS + 1)*sizeof(int));	if(!_bjmodnini){ sprintf(cbuf,"ERROR: unable to allocate array _bjmodnini.\n"); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf); }
+			/* Walk the DWT-index recurrence once and snapshot it at each thread's starting j, so
+			threads may own unequal spans. The old code derived one increment for an equal span and
+			added it repeatedly, which is what forced CY_THREADS to divide NDIVR. Same values when
+			it does divide, so power-of-two thread counts are unaffected. */
 			_bjmodnini[0] = 0;
-			_bjmodnini[1] = 0;
-			for(j=0; j < NDIVR/CY_THREADS; j++)
 			{
-				_bjmodnini[1] -= sw; _bjmodnini[1] = _bjmodnini[1] + ( (-(int)((uint32)_bjmodnini[1] >> 31)) & n);
-			}
-			if(CY_THREADS > 1)
-			{
-				for(ithread = 2; ithread <= CY_THREADS; ithread++)
+				int kbase_ini = n_div_nwt/CY_THREADS, krem_ini = n_div_nwt%CY_THREADS, jj, bj = 0;
+				for(ithread = 0; ithread < CY_THREADS; ithread++)
 				{
-					_bjmodnini[ithread] = _bjmodnini[ithread-1] + _bjmodnini[1] - n; _bjmodnini[ithread] = _bjmodnini[ithread] + ( (-(int)((uint32)_bjmodnini[ithread] >> 31)) & n);
+					int span = (kbase_ini + (ithread < krem_ini)) * nwt;
+					for(jj = 0; jj < span; jj++)
+					{
+						bj -= sw; bj = bj + ( (-(int)((uint32)bj >> 31)) & n);
+					}
+					_bjmodnini[ithread+1] = bj;
 				}
 			}
 			/* Check upper element against scalar value, as precomputed in single-thread mode: */
@@ -1497,18 +1521,25 @@ for(outer=0; outer <= 1; outer++)
 		*/
 		_i[0] = 1;		/* Pointer to the BASE and BASEINV arrays. lowest-order digit is always a bigword (_i[0] = 1).	*/
 
+		/* Per-thread spans, which need not be equal: the first (n_div_nwt % CY_THREADS) threads
+		take one extra outer-loop pass. jstart and col are running sums of the spans ahead of
+		each thread instead of multiples of one span, which is what lets CY_THREADS be any
+		value up to n_div_nwt. Reduces to the original when CY_THREADS divides n_div_nwt. */
 		khi = n_div_nwt/CY_THREADS;
+		kcum = 0;
 		for(ithread = 0; ithread < CY_THREADS; ithread++)
 		{
-			_jstart[ithread] = ithread*NDIVR/CY_THREADS;
+			_khi[ithread] = khi + (ithread < (n_div_nwt%CY_THREADS));
+			_jstart[ithread] = kcum*nwt;
 			if(!full_pass)
 				_jhi[ithread] = _jstart[ithread] + jhi_wrap_mers;	/* Cleanup loop assumes carryins propagate at most 4 words up. */
 			else
 				_jhi[ithread] = _jstart[ithread] + nwt-1;
 
-			_col[ithread] = ithread*(khi*RADIX);			/* col gets incremented by RADIX_VEC[0] on every pass through the k-loop */
+			_col[ithread] = kcum*RADIX;			/* col gets incremented by RADIX_VEC[0] on every pass through the k-loop */
 			_co2[ithread] = (n>>nwt_bits)-1+RADIX - _col[ithread];	/* co2 gets decremented by RADIX_VEC[0] on every pass through the k-loop */
 			_co3[ithread] = _co2[ithread]-RADIX;			/* At the start of each new j-loop, co3=co2-RADIX_VEC[0]	*/
+			kcum += _khi[ithread];
 		}
 	}
 	else
@@ -1517,6 +1548,7 @@ for(outer=0; outer <= 1; outer++)
 		for(ithread = 0; ithread < CY_THREADS; ithread++)
 		{
 			_jstart[ithread] = ithread*NDIVR/CY_THREADS;
+			_khi[ithread] = 1;	// Fermat-mod uses khi = 1 with a full-span jhi
 			/*
 			For right-angle transform need *complex* elements for wraparound, so jhi needs to be twice as large
 			*/
@@ -1564,8 +1596,8 @@ for(outer=0; outer <= 1; outer++)
 	if(!full_pass)
 	{
 		khi = 1;
+		for(ithread = 0; ithread < CY_THREADS; ithread++) { _khi[ithread] = 1; }
 	}
-
 #ifdef USE_PTHREAD
 	/* Populate the thread-specific data structs - use the invariant terms as memchecks: */
 	for(ithread = 0; ithread < CY_THREADS; ithread++)
@@ -1575,7 +1607,7 @@ for(outer=0; outer <= 1; outer++)
 		ASSERT(tdat[ithread].tid == ithread, "thread-local memcheck fail!");
 		ASSERT(tdat[ithread].ndivr == NDIVR, "thread-local memcheck fail!");
 
-		tdat[ithread].khi    = khi;
+		tdat[ithread].khi    = _khi[ithread];
 		tdat[ithread].i      = _i[ithread];	/* Pointer to the BASE and BASEINV arrays.	*/
 		tdat[ithread].jstart = _jstart[ithread];
 		tdat[ithread].jhi    = _jhi[ithread];
@@ -1948,7 +1980,7 @@ for(outer=0; outer <= 1; outer++)
 
 	for(ithread = 0; ithread < CY_THREADS; ithread++)
 	{
-		for(j = ithread*pini; j <= ithread*pini + j_jhi; j++)
+		for(j = _jstart[ithread]; j <= _jstart[ithread] + j_jhi; j++)
 		{
 			// Generate padded version of j, since prepadding pini is thread-count unsafe:
 			j1 = j + ( (j >> DAT_BITS) << PAD_BITS );

--- a/src/radix768_ditN_cy_dif1.c
+++ b/src/radix768_ditN_cy_dif1.c
@@ -453,7 +453,7 @@ int radix768_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -463,7 +463,7 @@ int radix768_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix960_ditN_cy_dif1.c
+++ b/src/radix960_ditN_cy_dif1.c
@@ -626,7 +626,7 @@ int radix960_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -636,7 +636,7 @@ int radix960_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/radix992_ditN_cy_dif1.c
+++ b/src/radix992_ditN_cy_dif1.c
@@ -409,7 +409,7 @@ int radix992_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 				if(CY_THREADS > 1) {
 					main_work_units = CY_THREADS/2;
 					pool_work_units = CY_THREADS - main_work_units;
-					ASSERT(0x0 != (tpool = carry_threadpool_get(pool_work_units, MAX_THREADS)), "carry_threadpool_get failed!");
+					ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 					printf("radix%d_ditN_cy_dif1: Init threadpool of %d threads\n", RADIX, pool_work_units);
 				} else {
 					main_work_units = 1;
@@ -419,7 +419,7 @@ int radix992_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			#else
 
 				pool_work_units = CY_THREADS;
-				ASSERT(0x0 != (tpool = carry_threadpool_get(CY_THREADS, MAX_THREADS)), "carry_threadpool_get failed!");
+				ASSERT(0x0 != (tpool = carry_threadpool_get(NTHREADS, MAX_THREADS)), "carry_threadpool_get failed!");
 
 			#endif
 

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -885,6 +885,11 @@ me at: heber.tomer@gmail.com
 	}
 
 
+/* Callers must pass the run's thread count (NTHREADS), not the number of carry tasks they intend
+to dispatch. Each radix*_ditN_cy_dif1 routine caches the returned pointer for the life of the
+process, so replacing the pool because one radix wanted a different worker count would leave every
+other routine holding a freed pointer. The task count is independent of the pool size: more workers
+than tasks simply leaves some idle, and fewer makes the blocking enqueue wait. */
 struct threadpool* carry_threadpool_get(int num_threads, int num_cores)
 {
 	static struct threadpool *pool = 0x0;

--- a/src/threadpool.h
+++ b/src/threadpool.h
@@ -196,8 +196,9 @@ int threadpool_drain(struct threadpool *pool,
 /* The one process-wide pool used by every radix*_ditN_cy_dif1 carry step. All of those routines
 want the same pool shape (CY_THREADS workers, CY_THREADS queue slots, no per-thread init/shutdown
 hooks), and only one of them is ever active at a time, so they share a single pool instead of each
-holding a private one for the life of the process. Created on first call; re-created (after
-freeing the old one, which is quiescent between carry calls) only if num_threads changes. */
+holding a private one for the life of the process. Pass the run's thread count (NTHREADS): callers
+cache the returned pointer for the life of the process, so the pool must not be replaced because
+one leading radix dispatches a different number of carry tasks than another. */
 struct threadpool* carry_threadpool_get(int num_threads, int num_cores);
 
 #ifdef __cplusplus


### PR DESCRIPTION
## The problem

`CY_THREADS`, the carry step's thread count, is rounded to a power of two in every
`radix*_ditN_cy_dif1.c`. On seven cores the carry phase runs on four; on six, four; on three, two.
The carry phase is 30-60% of an iteration, so a third to a half of the machine sits idle for a
large part of every iteration.

Measured on a Ryzen 7 7800X3D at 4096K with per-phase timing, the carry phase is *flat* from four
to seven cores (1.33, 1.27, 1.26 ms) and halves only when the eighth core makes the count a power
of two again (0.75 ms).

The requirement is not inherent to carry propagation. Carries are handed to the next thread by the
existing `_cy_r` rotate and resolved in the cleanup pass, so threads need no intra-iteration
coordination. The power-of-two constraint falls out of the *partition* being written as an equal
split: one shared trip count `khi = n_div_nwt/CY_THREADS`, offsets computed by multiplication
(`ithread*NDIVR/CY_THREADS`), and every thread's DWT index seed derived by repeatedly adding a
single increment.

## The change

Make the spans unequal, and keep the static partition. Per converted file:

- **`CY_THREADS = NTHREADS`** for Mersenne-mod, clamped to `n_div_nwt` (above that there are not
  enough outer-loop passes to give every thread one). Fermat-mod keeps the equal-span scheme and
  the old rounding.
- **A new per-thread `_khi[]` trip count**: the first `n_div_nwt % CY_THREADS` threads take one
  extra outer-loop pass. The thread-data struct already had a per-thread `khi` field and the worker
  already read its own, so no worker changes were needed.
- **`_jstart[]` and `_col[]` become running sums** of the spans ahead of each thread rather than
  multiples of one span. The identity `NDIVR/CY_THREADS == khi*nwt` is what makes this exact, so
  the spans still tile `[0, NDIVR)` with no divisibility requirement left.
- **`_bjmodnini[]` is built by walking the DWT-index recurrence once and snapshotting it at each
  thread's starting j**, instead of deriving one increment and adding it repeatedly. The routine
  already walked that recurrence once for a verification check, so this costs nothing new.
- **`pini`**, an equal-span stride used by the final cleanup loop, is replaced by the per-thread
  `_jstart`.

Every expression reduces to the original when `CY_THREADS` divides `n_div_nwt`, so power-of-two
thread counts are unchanged.

Converted in this PR: the power-of-two leading radices, `radix32`, `radix64`, `radix128`,
`radix256` and `radix1024`, which are the ones the GIMPS wavefront FFT lengths use. The other 30
files keep the old rounding and are unaffected; the transformation script
(`plan-notes/scaling-tools/apply_cy_spans2.py`) reports which anchors did not match in each, and
they differ only in brace and blank-line style, so extending it is mechanical follow-up work.

## Results

7800X3D, 4096K, AVX-512, box idle, radices `64 32 32 32`, median of three runs of 1000 iterations:

| cores | carry threads before | before ms | carry threads after | after ms | gain |
| --- | --- | --- | --- | --- | --- |
| 1 | 1 | 13.533 | 1 | 13.461 | - |
| 2 | 2 | 6.911 | 2 | 6.939 | - |
| 3 | 2 | 5.624 | 3 | 4.725 | **16.0%** |
| 4 | 4 | 3.583 | 4 | 3.553 | - |
| 5 | 4 | 3.344 | 5 | 3.058 | **8.6%** |
| 6 | 4 | 3.032 | 6 | 2.664 | **12.1%** |
| 7 | 4 | 2.753 | 7 | 2.298 | **16.5%** |
| 8 | 8 | 1.958 | 8 | 1.960 | - |

Powers of two are unchanged, as intended. Against mprime 31.7 measured on the same machine at the
same FFT length, the parallel speedup now tracks it at every core count:

| cores | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| mprime | 1.00 | 1.95 | 2.79 | 3.62 | 4.37 | 5.19 | 5.94 | 6.70 |
| Mlucas after | 1.00 | 1.94 | 2.85 | 3.79 | 4.40 | 5.05 | 5.86 | 6.87 |

Before this change Mlucas was 14-23% behind mprime's speedup at 3, 5, 6 and 7 cores while being
level or ahead at 2, 4 and 8. The remaining flat ~1.65x difference in absolute time is per-core
kernel speed, which this PR does not address.

## Two things found on the way, both included

**A pre-existing double free (first commit).** Four init-mode blocks in `dft_macro.c` do
`free(sc_arr)` and then `sc_arr = ALLOC_VEC_DBL(sc_arr, ...)`, which is a realloc of the pointer
just freed. It is unreachable while every caller passes the same thread count for the life of the
process, and fires immediately once two callers disagree, which this PR makes them do. Found with
AddressSanitizer. It stands on its own merits and is kept as a separate commit.

**The shared carry pool must be sized by the run, not by a radix.** Each radix routine caches the
pointer from `carry_threadpool_get()` once, inside `if(tdat == 0x0)`, and never re-fetches it. The
getter re-creates the pool when the requested worker count changes, which was harmless while that
count was uniform. Now that it is per-radix, the first differing request would free the pool out
from under every cached pointer. All callers therefore pass `NTHREADS`; the task count stays
`CY_THREADS`.

## Correctness

The residue must not depend on the thread count. Checked against an unmodified build of the same
commit, AVX2 on an i9-10885H and AVX-512 on the 7800X3D
(`plan-notes/scaling-tools/test_cy_spans.sh`):

- **4096K radix sets 0, 1, 4, 7, 9** (leading radix 1024, 256, 128, 64, 32: all five converted
  files) at every core count from 1 to 8: identical `Res64` in all 40 runs, and the carry-thread
  count now equals the core count.
- **2048K radix sets 0, 1, 2, 4, 6** at 1 to 8 cores: identical.
- 2048K radix set 0 is a bonus fix. Its `n_div_nwt` is 4, so the old code refused to run at eight
  threads at all (`n_div_nwt % CY_THREADS != 0`); the clamp now runs it on four carry threads and
  produces the right residue.
- A `-s s` self-test tier at three threads: **all 127 residues identical** to the reference,
  covering converted and unconverted leading radices together.
- AddressSanitizer clean on that self-test after the `dft_macro` fix.

Not covered: the Fermat-mod path is deliberately unchanged, and a `-DUSE_THREADS`-less build is
unaffected (the serial dispatch loop reads the same per-thread value).

Resolves part of #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
