### PR TITLE
test_fft_radix: restore t2/t3, which are live at the default RADIX

### DIFF
--- a/src/test_fft_radix.c
+++ b/src/test_fft_radix.c
@@ -321,6 +321,12 @@ void test_fft_radix(void)
 	struct complex *ac, *bc;
 	struct complex **mat = 0x0, **ctmpp = 0x0, *ctmp = 0x0;
 	double t0,t1;
+#if RADIX == 1024 || (TTYPE == 2 && defined(USE_SSE2))
+	// t2/t3 are live in two places only: the RADIX == 1024 reference-input block below (RADIX
+	// defaults to 1024, so this is the configuration a bare compile of this file gets), and the
+	// TTYPE == 2 bit-reversal block under USE_SSE2:
+	double t2,t3;
+#endif
 	double theta, twopi = 6.2831853071795864769;
   #ifdef USE_FGT61
 	#if defined(USE_SSE2) || (RADIX != 16)


### PR DESCRIPTION
Fixes a regression I introduced in #287, which has been breaking the **GCC-analyzer** and **Clang-Tidy** jobs on `main` since it merged. Both were green at `b1b1262` and have failed at every run from `4641e28` onward.

## What went wrong

#287 reduced `double t0,t1,t2,t3;` to `double t0,t1;` on the grounds that `t2` and `t3` were unused in all four `TTYPE` modes. That was wrong - they are live in two places:

- the `#if RADIX == 1024` reference-input block (`t2 = t3 = 0.;` at line 398), and
- the `#if TTYPE == 2` bit-reversal block under `#ifdef USE_SSE2`.

The first is the one that bit, and the reason is specific: **`RADIX` defaults to 1024 in this file**

```c
#ifndef RADIX
	#define RADIX	1024
#endif
```

and both affected jobs compile `src/*.c` with no `-DRADIX` at all:

```
gcc -c -fdiagnostics-color -std=gnu99 -g -O3 -march=native -DUSE_THREADS -fanalyzer src/*.c
```

So the default is precisely the configuration CI exercises. My verification for #287 used six *explicit* radices - 8, 16, 31, 63, 128, 1008 - and never compiled the default. Every configuration I tested skipped the only block that mattered.

## The fix

`t2`/`t3` come back under a guard matching their two uses, rather than unconditionally, so the warning #287 removed does not return for the configurations where they really are dead. `matp` and `print_pass` have no remaining references anywhere in the file and stay removed - those two removals were correct.

## Verification

Reproduced first, then fixed - the probe fails against `main`:

| | errors from the analyzer's own invocation on this file |
| --- | --- |
| `main` (`eca0f17`) | **2** |
| with this change | **0** |

Then the matrix I should have run the first time - **64 combinations**, all clean under `-Wall -Wextra`, zero warnings and zero errors:

- `{gcc, clang}` x `{default (no -DRADIX), 8, 16, 31, 63, 128, 1008, 1024}` x `TTYPE {0,1,2,3}`

plus `-DTTYPE=2 -DUSE_SSE2`, the second live site, also clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
