### PR TITLE
CI: do not let the diagnostic macro probe fail the windows-11-arm job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -751,12 +751,18 @@ jobs:
         # The windows-11-arm runner ships no native aarch64 toolchain (no MSYS2/CLANGARM64), so its
         # "gcc" is really an x86_64-w64-mingw32 compiler running under emulation. Both $HOSTTYPE
         # (x86_64) and the matrix OS label (arm) mislead here, so key the arch off what the compiler
-        # itself targets:
-        if [[ "$($CC -dM -E - </dev/null)" == *__aarch64__* ]]; then
-            $CC -dM -E -mcpu=native - </dev/null
-        else
-            $CC -dM -E -march=native - </dev/null
-        fi
+        # itself targets.
+        #
+        # This whole block only dumps predefined macros for the log, so it must not be able to fail
+        # the job. On windows-11-arm the emulated compiler dies on the probe with 0x80000004 and takes
+        # the step with it, before anything has been built - which is how that cell has been failing.
+        {
+            if [[ "$($CC -dM -E - </dev/null)" == *__aarch64__* ]]; then
+                $CC -dM -E -mcpu=native - </dev/null
+            else
+                $CC -dM -E -march=native - </dev/null
+            fi
+        } || echo "::warning::predefined-macro probe failed; it is diagnostic only, continuing."
     - name: Script
       shell: bash
       run: |


### PR DESCRIPTION
The `Windows (windows-11-arm, gcc)` job has been failing on every run, and it is the one remaining `main` CI failure in #224 that no other open PR covers.

It is not a code defect. The `Before script` step exists only to dump the compiler's predefined macros into the log, and on that runner it takes the whole job down before anything is built:

```
gcc.exe (x86_64-posix-seh-rev2, Built by MinGW-Builds project) 14.2.0
Copyright (C) 2024 Free Software Foundation, Inc.
##[error]Process completed with exit code -2147483644.
```

That is `0x80000004`, immediately after `$CC --version` succeeds - so the failure is the `$CC -dM -E -` probe itself.

## Why the toolchain is wrong there

`windows-11-arm` ships no native aarch64 toolchain (no MSYS2 `CLANGARM64`), so although the matrix sets `PACKAGE_PREFIX: mingw-w64-clang-aarch64-`, `$CC` resolves to an **x86_64**-w64-mingw32 gcc running under emulation - as its own version string says. The emulated compiler dies on the probe.

The step already carries a comment explaining this and keys its arch detection off what the compiler targets rather than the OS label, which is correct. The problem is simply that a diagnostic is allowed to be fatal.

## The change

Group the block and swallow a failure with a `::warning::`. The arch detection is otherwise untouched.

The `Script` step performs the same detection independently, so if the probe fails there too, `$(...)` yields empty, the `__aarch64__` test is false, and it selects the x86_64 mode list - which is the correct list for an x86_64 compiler. So this does not merely relocate the failure.

## Verification

I cannot run `windows-11-arm` directly, so I extracted the step from the workflow and ran it under `bash -e` exactly as CI does, against a stub compiler that succeeds on `--version` and fails on the probe:

| | step exit |
| --- | --- |
| `main` | **132** (fails, as CI does) |
| this PR | **0**, after printing the warning |

And with a stub reporting `__aarch64__`, the `-mcpu=native` path is still taken, so the detection logic is unchanged for a runner that ever does get a native toolchain.

CI on this PR is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
